### PR TITLE
Extract WMS config/longpress modules and improve toolbar UX

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -69,22 +69,74 @@ html, body {
     top: 0;
     display: flex;
     justify-content: space-around;
-    align-items: center;
+    align-items: stretch;
     color: var(--dark-medium-emphasis-text-color);
-    flex-flow: row wrap;
+    flex-flow: row nowrap;
     touch-action: none;
-  }
-
-  .navbar > div {
-    flex-grow: 1;
-    text-align: center;
-    font-size: 0.75em;
+    gap: 4px;
   }
 
   .navbar > button {
-    flex-grow: 1;
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     text-align: center;
     font-size: 0.75em;
+    font-family: 'Roboto', sans-serif;
+    color: var(--dark-medium-emphasis-text-color);
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 6px;
+    padding: 6px 4px;
+    min-height: 48px;
+    cursor: pointer;
+    box-sizing: border-box;
+    transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+    outline: none;
+  }
+
+  .navbar > button:hover {
+    background-color: var(--dark-theme-surface-hovered);
+  }
+
+  .navbar > button:active,
+  .navbar > button.pressing {
+    background-color: var(--dark-theme-surface-focused);
+    transform: scale(0.93);
+  }
+
+  .navbar > button:focus-visible {
+    outline: 2px solid var(--dark-primary-color);
+    outline-offset: -2px;
+  }
+
+  .btn-label {
+    font-size: inherit;
+    line-height: 1.3;
+  }
+
+  .menu-indicator {
+    font-size: 7px;
+    color: var(--dark-primary-color);
+    opacity: 0.7;
+    line-height: 1;
+  }
+
+  .menu-indicator .material-icons {
+    font-size: 10px;
+  }
+
+  .menu-spacer {
+    font-size: 7px;
+    line-height: 1;
+    visibility: hidden;
+  }
+
+  .menu-spacer .material-icons {
+    font-size: 10px;
   }
 
 
@@ -273,8 +325,13 @@ html, body {
 }
 
 .selectedButton {
-    /**color: #5BD5FD; */
     color: var(--dark-theme-on-surface);
+}
+
+.navbar > button.selectedButton {
+    color: var(--dark-theme-on-surface);
+    background-color: var(--dark-primary-color-bg);
+    border-bottom-color: var(--dark-primary-color);
 }
 
 .flexColumn {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,138 @@
+const wmsServerConfiguration = {
+	'fmi-radar': {
+		url: 'https://openwms.fmi.fi/geoserver/Radar/wms',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'FMI (CC-BY-4.0)',
+		disabled: false
+	},
+	'meteo-radar': {
+		url: 'https://wms.meteo.fi/geoserver/wms',
+		namespace: 'radar',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'FMI (CC-BY-4.0)',
+		disabled: false
+	},
+	'meteo-obs-new': {
+		url: 'https://wms-obs.app.meteo.fi/geoserver/wms',
+		namespace: 'observation',
+		refresh: 300000,
+		category: 'observationLayer',
+		attribution: 'FMI (CC-BY-4.0)'
+	},
+	'meteo-obs': {
+		url: 'https://geoserver.app.meteo.fi/geoserver/wms',
+		namespace: 'observation',
+		refresh: 300000,
+		category: 'observationLayer',
+		attribution: 'FMI (CC-BY-4.0)',
+		disabled: true
+	},
+	'eumetsat': {
+		url: 'https://eumetview.eumetsat.int/geoserv/wms',
+		namespace: 'meteosat',
+		refresh: 300000,
+		category: "satelliteLayer",
+		attribution: 'EUMETSAT',
+		disabled: true
+	},
+	'eumetsat1': {
+		url: 'https://view.eumetsat.int/geoserver/msg_fes/rgb_eview/wms',
+		refresh: 300000,
+		category: "satelliteLayer",
+		title: 'Meteosat pilvialueet yö/päivä',
+		abstract: 'Päivällä alapilvet näkyvät keltaisen sävyissä ja korkeat pilvet sinertävinä. Yöllä sinertävässä infrapunakuvassa kylmät pilvet näkyvät kirkaina.',
+		attribution: 'EUMETSAT',
+		disabled: false
+	},
+	'eumetsat2': {
+		url: 'https://view.eumetsat.int/geoserver/msg_fes/rgb_convection/wms',
+		refresh: 300000,
+		category: "satelliteLayer",
+		title: 'Meteosat konvektiopilvet',
+		abstract: 'Vaaraa aiheuttavat konvektiiviset rajuilmat näkyvät kuvassa kirkkaan keltaisena. Ukkospilven alasimen läpäisevät huiput näkyvät kuvassa kirkkaan vaalean punaisena.',
+		attribution: 'EUMETSAT',
+		disabled: false
+	},
+	'eumetsat3': {
+		url: 'https://view.eumetsat.int/geoserver/msg_fes/rgb_naturalenhncd/wms',
+		refresh: 300000,
+		category: "satelliteLayer",
+		title: 'Meteosat pilvialueet',
+		abstract: 'Vesipilvet näkyvät kuvassa vaaleina, jäiset valkoisina, kasvillisuus vihreänä, maa ruskeana ja meri mustana.',
+		attribution: 'EUMETSAT',
+		disabled: false
+	},
+	'eumetsat4': {
+		url: 'https://eumetview.eumetsat.int/geoserv/meteosat/msg_airmass/wms',
+		refresh: 300000,
+		category: "satelliteLayer",
+		title: 'Meteosat ilmamassat',
+		abstract: 'Kylmä polaarinen ilma näkyy kuvassa violettina, lämmin trooppinen ilma vihreänä, kuiva ilma punaisena sekä paksut korkeat pilvet valkoisena.',
+		attribution: 'EUMETSAT',
+		disabled: true
+	},
+	ca: {
+		url: 'https://geo.weather.gc.ca/geomet/',
+		layer: 'RADAR_1KM_RRAI',
+		refresh: 300000,
+		category: 'radarLayer',
+		disabled: false
+	},
+	de: {
+		url: 'https://maps.dwd.de/geoserver/dwd/RX-Produkt/wms',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'Deutscher Wetterdienst',
+		disabled: true
+	},
+	nl: {
+		url: 'https://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'KNMI',
+		disabled: true
+	},
+	no: {
+		url: 'https://meteocore.app.meteo.fi/wms',
+		layer: 'met-radar-composite-dbz',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'MET Norway',
+		disabled: false
+	},
+	se: {
+		url: 'https://meteocore.app.meteo.fi/wms',
+		layer: 'smhi-radar-composite-dbz',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'SMHI',
+		disabled: false
+	},
+	dk: {
+		url: 'https://meteocore.app.meteo.fi/wms',
+		layer: 'dmi-radar-composite-dbz',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'DMI',
+		disabled: false
+	},
+	vn: {
+		url: 'https://vietnam.smartmet.fi/wms',
+		namespace: 'vnmha:radar',
+		refresh: 60000,
+		category: "radarLayer",
+		attribution: 'VNMHA',
+		disabled: true
+	},
+	noaa: {
+		url: 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi',
+		refresh: 60000,
+		category: "radarLayer",
+		attribution: 'NOAA',
+		disabled: true
+	}
+};
+
+export default wmsServerConfiguration;

--- a/src/index.html
+++ b/src/index.html
@@ -64,15 +64,15 @@
 </head>
 
 <body>
-  <div class="toolbar navbar noselect">
-    <div id="locationLayerButton"><i id="gpsStatus" class="material-icons">gps_not_fixed</i></div>
-    <div id="mapLayerButton"><i class="material-icons">brightness_2</i></div>
-    <div id="satelliteLayerButton"><i class="material-icons">satellite</i><br>Satelliitti</div>
-    <div id="radarLayerButton" class="selectedButton"><i class="material-icons">filter_tilt_shift</i><br>Säätutka</div>
-    <div id="lightningLayerButton"><i class="material-icons">flash_on</i><br>Salamat</div>
-    <div id="observationLayerButton"><i class="material-icons">place</i><br>Havainto</div>
-    <div id="layersButton"><i class="material-icons">more_vert</i></div>
-  </div>
+  <nav class="toolbar navbar noselect">
+    <button id="locationLayerButton" aria-label="Paikannus" aria-pressed="false"><i id="gpsStatus" class="material-icons">gps_not_fixed</i><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
+    <button id="mapLayerButton" aria-label="Karttapohja" aria-pressed="false"><i class="material-icons">brightness_2</i><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
+    <button id="satelliteLayerButton" aria-pressed="false" aria-haspopup="menu"><i class="material-icons">satellite</i><span class="btn-label">Satelliitti</span><span class="menu-indicator"><i class="material-icons">expand_more</i></span></button>
+    <button id="radarLayerButton" class="selectedButton" aria-pressed="true" aria-haspopup="menu"><i class="material-icons">filter_tilt_shift</i><span class="btn-label">Säätutka</span><span class="menu-indicator"><i class="material-icons">expand_more</i></span></button>
+    <button id="lightningLayerButton" aria-pressed="false"><i class="material-icons">flash_on</i><span class="btn-label">Salamat</span><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
+    <button id="observationLayerButton" aria-pressed="false" aria-haspopup="menu"><i class="material-icons">place</i><span class="btn-label">Havainto</span><span class="menu-indicator"><i class="material-icons">expand_more</i></span></button>
+    <button id="layersButton" aria-label="Lisää tasoja"><i class="material-icons">more_vert</i><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
+  </nav>
   
   <div id="map"></div>
  

--- a/src/longpress.js
+++ b/src/longpress.js
@@ -1,0 +1,92 @@
+/**
+ * Creates a long-press handler for a button that shows a context menu.
+ * Short tap (< 500ms) calls onTap. Long press (>= 500ms) shows the menu.
+ *
+ * @param {string} buttonId - DOM id of the trigger button
+ * @param {string} menuId - DOM id of the context menu
+ * @param {Function} onTap - called on short tap
+ * @param {Function} onSelect - called with the selected menu item's data-layer value
+ * @param {Function} getActiveLayer - returns the current active WMS layer name for highlighting
+ * @param {Function} isLayerVisible - returns whether the layer is currently visible
+ * @returns {{ show: Function, hide: Function }}
+ */
+function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLayer, isLayerVisible) {
+	let timer = null;
+	let triggered = false;
+	let startTime = 0;
+	const button = document.getElementById(buttonId);
+
+	function showMenu() {
+		const menu = document.getElementById(menuId);
+		const menuItems = menu.querySelectorAll('.menu-item');
+		const currentLayer = getActiveLayer();
+		const visible = isLayerVisible();
+		menuItems.forEach(function(item) {
+			item.classList.toggle('selected', visible && item.getAttribute('data-layer') === currentLayer);
+		});
+
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		const br = button.getBoundingClientRect();
+		menu.style.display = 'block';
+		menu.style.visibility = 'hidden';
+		const mr = menu.getBoundingClientRect();
+		const left = Math.max(10, Math.min(br.left, vw - mr.width - 10));
+		let top = br.bottom + 5;
+		if (top + mr.height > vh - 10) {
+			top = Math.max(10, br.top - mr.height - 5);
+		}
+		menu.style.left = left + 'px';
+		menu.style.top = top + 'px';
+		menu.style.visibility = 'visible';
+	}
+
+	function hideMenu() {
+		document.getElementById(menuId).style.display = 'none';
+	}
+
+	function start(e) {
+		triggered = false;
+		startTime = Date.now();
+		timer = setTimeout(function() {
+			triggered = true;
+			showMenu();
+		}, 500);
+	}
+
+	function end() {
+		clearTimeout(timer);
+		if (!triggered && Date.now() - startTime < 500) {
+			onTap();
+		}
+	}
+
+	function cancel() {
+		clearTimeout(timer);
+		triggered = false;
+	}
+
+	button.addEventListener('mousedown', start);
+	button.addEventListener('mouseup', end);
+	button.addEventListener('mouseleave', cancel);
+	button.addEventListener('touchstart', function(e) { e.preventDefault(); start(e); });
+	button.addEventListener('touchend', function(e) { e.preventDefault(); end(e); });
+	button.addEventListener('touchmove', function(e) { e.preventDefault(); cancel(); });
+	button.addEventListener('touchcancel', function(e) { e.preventDefault(); cancel(); });
+
+	// Menu item click/touch handlers
+	document.querySelectorAll('#' + menuId + ' .menu-item').forEach(function(item) {
+		item.addEventListener('click', function() {
+			onSelect(this.getAttribute('data-layer'));
+		});
+		item.addEventListener('touchend', function(e) {
+			e.preventDefault();
+			e.stopPropagation();
+			onSelect(this.getAttribute('data-layer'));
+		});
+	});
+
+	return { show: showMenu, hide: hideMenu };
+}
+
+export default createLongPressHandler;

--- a/src/radar.js
+++ b/src/radar.js
@@ -22,6 +22,8 @@ import LatLon from 'geodesy/latlon-spherical'
 import WMSCapabilities from 'ol/format/WMSCapabilities.js';
 import { transformExtent } from 'ol/proj';
 import Timeline from './timeline';
+import wmsServerConfiguration from './config';
+import createLongPressHandler from './longpress';
 import dayjs from 'dayjs';
 import 'dayjs/locale/fi';
 import utcPlugin from 'dayjs/plugin/utc';
@@ -43,142 +45,7 @@ const options = {
 	frameRate: 2, // fps
 	defaultFrameRate: 2, // fps
 	imageRatio: 1.5,
-	wmsServerConfiguration: {
-		'fmi-radar': {
-			url: 'https://openwms.fmi.fi/geoserver/Radar/wms',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'FMI (CC-BY-4.0)',
-			disabled: false
-		},
-		'meteo-radar': {
-			url: 'https://wms.meteo.fi/geoserver/wms',
-			namespace: 'radar',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'FMI (CC-BY-4.0)',
-			disabled: false
-		},
-		'meteo-obs-new': {
-			url: 'https://wms-obs.app.meteo.fi/geoserver/wms',
-			namespace: 'observation',
-			refresh: 300000,
-			category: 'observationLayer',
-			attribution: 'FMI (CC-BY-4.0)'
-		},
-		'meteo-obs': {
-			url: 'https://geoserver.app.meteo.fi/geoserver/wms',
-			namespace: 'observation',
-			refresh: 300000,
-			category: 'observationLayer',
-			attribution: 'FMI (CC-BY-4.0)',
-			disabled: true
-		},
-		'eumetsat': {
-			url: 'https://eumetview.eumetsat.int/geoserv/wms',
-			namespace: 'meteosat',
-			refresh: 300000,
-			category: "satelliteLayer",
-			attribution: 'EUMETSAT',
-			disabled: true
-		},
-		'eumetsat1': {
-			url: 'https://view.eumetsat.int/geoserver/msg_fes/rgb_eview/wms',
-			refresh: 300000,
-			category: "satelliteLayer",
-			title: 'Meteosat pilvialueet yö/päivä',
-			abstract: 'Päivällä alapilvet näkyvät keltaisen sävyissä ja korkeat pilvet sinertävinä. Yöllä sinertävässä infrapunakuvassa kylmät pilvet näkyvät kirkaina.',
-			attribution: 'EUMETSAT',
-			disabled: false
-		},
-		'eumetsat2': {
-			url: 'https://view.eumetsat.int/geoserver/msg_fes/rgb_convection/wms',
-			refresh: 300000,
-			category: "satelliteLayer",
-			title: 'Meteosat konvektiopilvet',
-			abstract: 'Vaaraa aiheuttavat konvektiiviset rajuilmat näkyvät kuvassa kirkkaan keltaisena. Ukkospilven alasimen läpäisevät huiput näkyvät kuvassa kirkkaan vaalean punaisena.',
-			attribution: 'EUMETSAT',
-			disabled: false
-		},
-		'eumetsat3': {
-			url: 'https://view.eumetsat.int/geoserver/msg_fes/rgb_naturalenhncd/wms',
-			refresh: 300000,
-			category: "satelliteLayer",
-			title: 'Meteosat pilvialueet',
-			abstract: 'Vesipilvet näkyvät kuvassa vaaleina, jäiset valkoisina, kasvillisuus vihreänä, maa ruskeana ja meri mustana.',
-			attribution: 'EUMETSAT',
-			disabled: false
-		},
-		'eumetsat4': {
-			url: 'https://eumetview.eumetsat.int/geoserv/meteosat/msg_airmass/wms',
-			refresh: 300000,
-			category: "satelliteLayer",
-			title: 'Meteosat ilmamassat',
-			abstract: 'Kylmä polaarinen ilma näkyy kuvassa violettina, lämmin trooppinen ilma vihreänä, kuiva ilma punaisena sekä paksut korkeat pilvet valkoisena.',
-			attribution: 'EUMETSAT',
-			disabled: true
-		},
-		ca: {
-			url: 'https://geo.weather.gc.ca/geomet/',
-			layer: 'RADAR_1KM_RRAI',
-			refresh: 300000,
-			category: 'radarLayer',
-			disabled: false
-		},
-		de: {
-			url: 'https://maps.dwd.de/geoserver/dwd/RX-Produkt/wms',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'Deutscher Wetterdienst',
-			disabled: true
-		},
-		nl: {
-			url: 'https://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'KNMI',
-			disabled: true
-		},
-		no: {
-			url: 'https://meteocore.app.meteo.fi/wms',
-			layer: 'met-radar-composite-dbz',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'MET Norway',
-			disabled: false
-		},
-		se: {
-			url: 'https://meteocore.app.meteo.fi/wms',
-			layer: 'smhi-radar-composite-dbz',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'SMHI',
-			disabled: false
-		},
-		dk: {
-			url: 'https://meteocore.app.meteo.fi/wms',
-			layer: 'dmi-radar-composite-dbz',
-			refresh: 60000,
-			category: 'radarLayer',
-			attribution: 'DMI',
-			disabled: false
-		},
-		vn: {
-			url: 'https://vietnam.smartmet.fi/wms',
-			namespace: 'vnmha:radar',
-			refresh: 60000,
-			category: "radarLayer",
-			attribution: 'VNMHA',
-			disabled: true
-		},
-		noaa: {
-			url: 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0q-t.cgi',
-			refresh: 60000,
-			category: "radarLayer",
-			attribution: 'NOAA',
-			disabled: true
-		}
-	}
+	wmsServerConfiguration: wmsServerConfiguration
 }
 
 let DEBUG = false;
@@ -868,8 +735,8 @@ function setMapLayer(maplayer) {
 			darkGrayReferenceLayer.setVisible(false);
 			lightGrayBaseLayer.setVisible(true);
 			lightGrayReferenceLayer.setVisible(true);
-			document.getElementById("mapLayerButton").classList.remove("selectedButton");
 			IS_DARK = false;
+			setButtonState("mapLayerButton", false);
 			typeof umami !== 'undefined' && umami.track('theme-light');
 			break;
 		case 'dark':
@@ -877,8 +744,8 @@ function setMapLayer(maplayer) {
 			darkGrayReferenceLayer.setVisible(true);
 			lightGrayBaseLayer.setVisible(false);
 			lightGrayReferenceLayer.setVisible(false);
-			document.getElementById("mapLayerButton").classList.add("selectedButton");
 			IS_DARK = true;
+			setButtonState("mapLayerButton", true);
 			typeof umami !== 'undefined' && umami.track('theme-dark');
 			break;	
 	}
@@ -1141,14 +1008,14 @@ function onChangeVisible (event) {
 		if (document.getElementById(wmslayer)) {
 			document.getElementById(wmslayer).classList.add("selected");
 		}
-		document.getElementById(name+"Button").classList.add("selectedButton");
+		setButtonState(name+"Button", true);
 		document.getElementById(name+'Info').classList.remove("playListDisabled");
 	} else {
 		debug("Deactivated " + name);
 		VISIBLE.delete(name);
 		localStorage.setItem("VISIBLE",JSON.stringify([...VISIBLE]));
 		document.getElementById(name+"Off").classList.add("selected");
-		document.getElementById(name+"Button").classList.remove("selectedButton");
+		setButtonState(name+"Button", false);
 		document.getElementById(name+'Info').classList.add("playListDisabled");
 	}
 	updateCanonicalPage();
@@ -1262,38 +1129,32 @@ window.addEventListener('touchend', function (e) {
 	});
 });
 
-function setButtonStates() {
-	if (IS_TRACKING) {
-		document.getElementById("locationLayerButton").classList.add("selectedButton");
-	} else {
-		document.getElementById("locationLayerButton").classList.remove("selectedButton");
-	}
-	if (IS_DARK) {
-		document.getElementById("mapLayerButton").classList.add("selectedButton");
-	} else {
-		document.getElementById("mapLayerButton").classList.remove("selectedButton");
-	}
-	if (VISIBLE.has("satelliteLayer")) {
-		document.getElementById("satelliteLayerButton").classList.add("selectedButton");
-	} else {
-		document.getElementById("satelliteLayerButton").classList.remove("selectedButton");
-	}
-	if (VISIBLE.has("radarLayer")) {
-		document.getElementById("radarLayerButton").classList.add("selectedButton");
-	} else {
-		document.getElementById("radarLayerButton").classList.remove("selectedButton");
-	}
-	if (VISIBLE.has("lightningLayer")) {
-		document.getElementById("lightningLayerButton").classList.add("selectedButton");
-	} else {
-		document.getElementById("lightningLayerButton").classList.remove("selectedButton");
-	}
-	if (VISIBLE.has("observationLayer")) {
-		document.getElementById("observationLayerButton").classList.add("selectedButton");
-	} else {
-		document.getElementById("observationLayerButton").classList.remove("selectedButton");
-	}
+function setButtonState(id, active) {
+	const el = document.getElementById(id);
+	el.classList.toggle("selectedButton", active);
+	el.setAttribute("aria-pressed", String(active));
 }
+
+function setButtonStates() {
+	setButtonState("locationLayerButton", IS_TRACKING);
+	setButtonState("mapLayerButton", IS_DARK);
+	setButtonState("satelliteLayerButton", VISIBLE.has("satelliteLayer"));
+	setButtonState("radarLayerButton", VISIBLE.has("radarLayer"));
+	setButtonState("lightningLayerButton", VISIBLE.has("lightningLayer"));
+	setButtonState("observationLayerButton", VISIBLE.has("observationLayer"));
+}
+
+// Press feedback for all navbar buttons
+document.querySelectorAll('.navbar > button').forEach(function(btn) {
+	function addPress() { btn.classList.add('pressing'); }
+	function removePress() { btn.classList.remove('pressing'); }
+	btn.addEventListener('mousedown', addPress);
+	btn.addEventListener('mouseup', removePress);
+	btn.addEventListener('mouseleave', removePress);
+	btn.addEventListener('touchstart', addPress);
+	btn.addEventListener('touchend', removePress);
+	btn.addEventListener('touchcancel', removePress);
+});
 
 document.getElementById('locationLayerButton').addEventListener('mouseup', function() {
 	if (IS_TRACKING) {
@@ -1342,100 +1203,27 @@ document.getElementById('lightningLayerTitle').addEventListener('mouseup', funct
 	toggleLayerVisibility(lightningLayer);
 });
 
-// Long press functionality for observation layer button
-// Generic long-press menu handler
-function createLongPressHandler(buttonId, menuId, olLayer, onSelect) {
-	let timer = null;
-	let triggered = false;
-	let startTime = 0;
-	let button = document.getElementById(buttonId);
+// Long press menus for layer buttons
+const observationMenu = createLongPressHandler('observationLayerButton', 'observationLongPressMenu',
+	function() { toggleLayerVisibility(observationLayer); },
+	function(id) { updateLayer(observationLayer, id); observationMenu.hide(); },
+	function() { return observationLayer.getSource().getParams().LAYERS; },
+	function() { return observationLayer.getVisible(); }
+);
 
-	function showMenu(e) {
-		let menu = document.getElementById(menuId);
-		let menuItems = menu.querySelectorAll('.menu-item');
-		let currentLayer = olLayer.getSource().getParams().LAYERS;
-		let isVisible = olLayer.getVisible();
-		menuItems.forEach(function(item) {
-			item.classList.toggle('selected', isVisible && item.getAttribute('data-layer') === currentLayer);
-		});
+const satelliteMenu = createLongPressHandler('satelliteLayerButton', 'satelliteLongPressMenu',
+	function() { toggleLayerVisibility(satelliteLayer); },
+	function(id) { updateLayer(satelliteLayer, id); satelliteMenu.hide(); },
+	function() { return satelliteLayer.getSource().getParams().LAYERS; },
+	function() { return satelliteLayer.getVisible(); }
+);
 
-		let vw = window.innerWidth, vh = window.innerHeight;
-		let br = button.getBoundingClientRect();
-		menu.style.display = 'block';
-		menu.style.visibility = 'hidden';
-		let mr = menu.getBoundingClientRect();
-		let left = Math.max(10, Math.min(br.left, vw - mr.width - 10));
-		let top = br.bottom + 5;
-		if (top + mr.height > vh - 10) {
-			top = Math.max(10, br.top - mr.height - 5);
-		}
-		menu.style.left = left + 'px';
-		menu.style.top = top + 'px';
-		menu.style.visibility = 'visible';
-	}
-
-	function hideMenu() {
-		document.getElementById(menuId).style.display = 'none';
-	}
-
-	function start(e) {
-		triggered = false;
-		startTime = Date.now();
-		timer = setTimeout(function() {
-			triggered = true;
-			showMenu(e);
-		}, 500);
-	}
-
-	function end() {
-		clearTimeout(timer);
-		if (!triggered && Date.now() - startTime < 500) {
-			toggleLayerVisibility(olLayer);
-		}
-	}
-
-	function cancel() {
-		clearTimeout(timer);
-		triggered = false;
-	}
-
-	button.addEventListener('mousedown', start);
-	button.addEventListener('mouseup', end);
-	button.addEventListener('mouseleave', cancel);
-	button.addEventListener('touchstart', function(e) { e.preventDefault(); start(e); });
-	button.addEventListener('touchend', function(e) { e.preventDefault(); end(e); });
-	button.addEventListener('touchmove', function(e) { e.preventDefault(); cancel(); });
-	button.addEventListener('touchcancel', function(e) { e.preventDefault(); cancel(); });
-
-	// Menu item click/touch handlers
-	document.querySelectorAll('#' + menuId + ' .menu-item').forEach(function(item) {
-		item.addEventListener('click', function() {
-			onSelect(this.getAttribute('data-layer'));
-		});
-		item.addEventListener('touchend', function(e) {
-			e.preventDefault();
-			e.stopPropagation();
-			onSelect(this.getAttribute('data-layer'));
-		});
-	});
-
-	return { show: showMenu, hide: hideMenu };
-}
-
-const observationMenu = createLongPressHandler('observationLayerButton', 'observationLongPressMenu', observationLayer, function(id) {
-	updateLayer(observationLayer, id);
-	observationMenu.hide();
-});
-
-const satelliteMenu = createLongPressHandler('satelliteLayerButton', 'satelliteLongPressMenu', satelliteLayer, function(id) {
-	updateLayer(satelliteLayer, id);
-	satelliteMenu.hide();
-});
-
-const radarMenu = createLongPressHandler('radarLayerButton', 'radarLongPressMenu', radarLayer, function(id) {
-	updateLayer(radarLayer, id);
-	radarMenu.hide();
-});
+const radarMenu = createLongPressHandler('radarLayerButton', 'radarLongPressMenu',
+	function() { toggleLayerVisibility(radarLayer); },
+	function(id) { updateLayer(radarLayer, id); radarMenu.hide(); },
+	function() { return radarLayer.getSource().getParams().LAYERS; },
+	function() { return radarLayer.getVisible(); }
+);
 
 document.getElementById('layersButton').addEventListener('mouseup', function() {
 	let div = document.getElementById('layers');


### PR DESCRIPTION
## Summary

- **Extract WMS server configuration** to `src/config.js` (~138 lines out of radar.js)
- **Extract `createLongPressHandler`** to `src/longpress.js` with decoupled callback API (no direct OL layer dependency)
- **Toolbar accessibility**: `<div>` → `<button>`, `<div>` → `<nav>`, ARIA attributes (`aria-pressed`, `aria-label`, `aria-haspopup`)
- **Toolbar UX**: stronger selected state (background + accent border), long-press affordance arrows, press feedback animation, focus-visible ring, CSS transitions, 48px min touch targets

radar.js reduced from 1831 → 1618 lines (-213 net).

## Test plan

- [ ] Verify all toolbar buttons toggle layers correctly (tap/click)
- [ ] Verify long-press menus open on satellite, radar, observation buttons (500ms hold)
- [ ] Verify long-press menu item selection switches layer source
- [ ] Verify selected button state is visually clear (background highlight + blue border)
- [ ] Verify press feedback (scale down) on button press
- [ ] Verify keyboard navigation (Tab through buttons, Enter/Space to activate)
- [ ] Test on iOS Safari (position:fixed, touch events, long-press)
- [ ] Verify localStorage state persistence still works across reloads
- [ ] Verify GPS button toggles tracking
- [ ] Verify dark/light map toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)