### PR TITLE
Redesign layer manager panel

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -373,105 +373,317 @@ html, body {
     visibility: visible;
 }
 
+/* Playlist backdrop scrim — covers map only, not timecontrol */
+#playListBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: calc(56px + max(8px, env(safe-area-inset-bottom)));
+  background: rgba(0,0,0,0.4);
+  z-index: 150;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 300ms ease;
+}
+
+#playListBackdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Layer manager panel — fixed, sits above timecontrol */
 #playList {
-    display: flex;
-    flex-direction: column;
-    background-color: rgba(0,0,0,0.8);
-    color: var(--dark-theme-on-surface);
-    position: absolute;
-    bottom: -90vh;
-    left: 0;
-    width: 100%;
-    height: auto;
-    max-height: 90vh;
-    padding-top: 5px;
-    padding-bottom: 75px;
-    transition: bottom 300ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
-    overflow-y: auto;
-    box-sizing: border-box;
-    border-radius: 10px;
-    border: 0px;
- }
-
- #playList > div {
-  flex-grow: 1;
-  padding: 5px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  margin: 5px;
-  margin-left: 10px;
-  margin-right: 10px;
-  background-color: var(--dark-theme-overlay-02dp);
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: calc(56px + max(8px, env(safe-area-inset-bottom)));
+  top: auto;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  background-color: rgba(18, 18, 18, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: var(--dark-theme-on-surface);
+  border-radius: 16px 16px 0 0;
+  transform: translateY(calc(100% + 56px + max(8px, env(safe-area-inset-bottom))));
+  transition: transform 300ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  max-height: calc(80vh - 56px);
+  padding-bottom: 8px;
+  box-sizing: border-box;
 }
 
-#playList > div:hover {
-  background-color: var(--dark-theme-overlay-04dp);
+@media all and (min-width: 769px) {
+  #playList {
+    left: 50%;
+    right: auto;
+    width: 450px;
+    margin-left: -233px;
+  }
 }
 
-#playList > div > div {
-  padding: 1px;
+#playList.open {
+  transform: translateY(0);
 }
 
-.playListDisabled {
-  color: var(--dark-disabled-label-color);
-  background-color: var(--dark-disabled-container-color);
+/* Drag handle */
+.playlist-handle {
+  width: 36px;
+  height: 4px;
+  background: var(--dark-medium-emphasis-text-color);
+  border-radius: 2px;
+  margin: 10px auto 6px;
 }
 
-.name {
+/* Panel header */
+.playlist-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 16px 8px;
+  border-bottom: 1px solid var(--dark-theme-overlay-04dp);
+  margin-bottom: 4px;
+}
+
+.playlist-header h2 {
+  font-size: 1em;
+  font-weight: 500;
+  color: var(--dark-high-emphasis-text-color);
+  margin: 0;
+}
+
+#playlistCloseButton {
+  cursor: pointer;
   color: var(--dark-medium-emphasis-text-color);
+  padding: 4px;
+}
+
+/* Layer cards */
+.layer-card {
+  margin: 6px 12px;
+  padding: 12px;
+  background: var(--dark-theme-overlay-02dp);
+  border-radius: 12px;
+  border-left: 3px solid var(--dark-primary-color);
+  transition: background 0.2s;
+}
+
+.layer-card:hover {
+  background: var(--dark-theme-overlay-04dp);
+}
+
+.layer-card.playListDisabled {
+  border-left-color: transparent;
+  background: var(--dark-theme-overlay-01dp);
+}
+
+.layer-card.playListDisabled:hover {
+  background: var(--dark-theme-overlay-02dp);
+}
+
+/* Card header */
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.card-category-icon {
+  font-size: 18px;
+  color: var(--dark-primary-color);
+}
+
+.layer-card.playListDisabled .card-category-icon {
+  color: var(--dark-disabled-label-color);
+}
+
+.card-category-name {
   font-size: 0.7em;
+  color: var(--dark-medium-emphasis-text-color);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex: 1;
 }
 
-.title {
-  color: var(--dark-theme-on-surface-color);
-  font-size: 1.1em;
-  padding-bottom: 2px;
+.card-visibility-toggle {
+  cursor: pointer;
+  color: var(--dark-medium-emphasis-text-color);
+  padding: 4px;
+  border-radius: 50%;
+  transition: background 0.15s;
 }
 
-#layers > div > .title {
+.card-visibility-toggle:hover {
+  background: var(--dark-theme-overlay-04dp);
+}
+
+/* Card title */
+.card-title {
+  font-size: 1.05em;
+  font-weight: 400;
+  color: var(--dark-high-emphasis-text-color);
+  margin-bottom: 2px;
+}
+
+.layer-card.playListDisabled .card-title {
+  color: var(--dark-medium-emphasis-text-color);
+}
+
+#layers > div > .card-title {
   height: 3em;
 }
 
-.abstract {
+/* Card abstract */
+.card-abstract {
+  font-size: 0.8em;
   color: var(--dark-high-emphasis-text-color);
-  font-size: 0.8em;
-  padding-bottom: 5px;
-  text-align: justify;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 8px;
 }
 
-.attribution {
+.layer-card.playListDisabled .card-abstract {
   color: var(--dark-medium-emphasis-text-color);
-  font-size: 0.8em;
 }
 
-.styles {
+/* Card attribution */
+.card-attribution {
+  font-size: 0.75em;
+  color: var(--dark-medium-emphasis-text-color);
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--dark-theme-overlay-04dp);
+}
+
+.layer-card.playListDisabled .card-attribution {
+  border-top-color: transparent;
+}
+
+/* Disabled cards: hide controls only, keep text readable */
+.layer-card.playListDisabled .card-opacity,
+.layer-card.playListDisabled .card-styles {
+  display: none;
+}
+
+/* Opacity control */
+.card-opacity {
+  margin: 8px 0;
+}
+
+.opacity-label-row {
   display: flex;
-  flex-direction: row;
-  overflow-x: auto;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
 }
 
-.styles > div {
-  background-color: var(--dark-primary-color-bg);
+.opacity-label {
+  font-size: 0.75em;
+  font-weight: 500;
+  color: var(--dark-medium-emphasis-text-color);
+}
+
+.opacity-value {
+  font-size: 0.75em;
+  font-weight: 500;
   color: var(--dark-primary-color);
-  border-radius: 3px;
-  padding: 4px;
-  margin-top: 2px;
-  margin-bottom: 2px;
-  margin-right: 5px;
-  font-size: 0.8em;
-  border-radius: 3px; 
 }
 
+/* Opacity slider */
 .slider {
   -webkit-appearance: none;
-  /* width: 100%; */
-  height: 15px;
-  border-radius: 5px;   
-  background: #00D8FF;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(to right, var(--dark-primary-color) 70%, var(--dark-theme-overlay-06dp) 70%);
   outline: none;
-  opacity: 0.7;
-  -webkit-transition: .2s;
-  transition: opacity .2s;
+  cursor: pointer;
+  margin: 0;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--dark-primary-color);
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+  border: 2px solid rgba(255,255,255,0.2);
+  margin-top: -8px;
+}
+
+.slider::-moz-range-thumb {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--dark-primary-color);
+  cursor: pointer;
+  border: 2px solid rgba(255,255,255,0.2);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+}
+
+.slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 3px;
+}
+
+.slider::-moz-range-track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--dark-theme-overlay-06dp);
+}
+
+.slider::-moz-range-progress {
+  background: var(--dark-primary-color);
+  height: 6px;
+  border-radius: 3px;
+}
+
+/* Style chips */
+.card-styles {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 4px 0;
+  margin: 4px 0;
+}
+
+.card-styles > div {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 6px 14px;
+  border-radius: 16px;
+  font-size: 0.8em;
+  font-weight: 400;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+  background: var(--dark-theme-overlay-04dp);
+  color: var(--dark-medium-emphasis-text-color);
+}
+
+.card-styles > div:hover {
+  border-color: var(--dark-primary-color);
+}
+
+.card-styles > div.activeStyle {
+  background: var(--dark-primary-color);
+  color: #000;
+  font-weight: 500;
 }
 
 .layerStyle {

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -398,7 +398,7 @@ html, body {
   z-index: 99; /* below timecontrol (100) so it slides behind it */
   display: flex;
   flex-direction: column;
-  background-color: rgba(18, 18, 18, 0.85);
+  background-color: rgba(18, 18, 18, 0.7);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   color: var(--dark-theme-on-surface);

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -398,7 +398,7 @@ html, body {
   z-index: 99; /* below timecontrol (100) so it slides behind it */
   display: flex;
   flex-direction: column;
-  background-color: rgba(18, 18, 18, 0.95);
+  background-color: rgba(18, 18, 18, 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   color: var(--dark-theme-on-surface);

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -373,23 +373,19 @@ html, body {
     visibility: visible;
 }
 
-/* Playlist backdrop scrim — covers map only, not timecontrol */
+/* Playlist backdrop — invisible, catches taps to close panel */
 #playListBackdrop {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: calc(56px + max(8px, env(safe-area-inset-bottom)));
-  background: rgba(0,0,0,0.4);
   z-index: 150;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 300ms ease;
+  display: none;
 }
 
 #playListBackdrop.open {
-  opacity: 1;
-  pointer-events: auto;
+  display: block;
 }
 
 /* Layer manager panel — fixed, sits above timecontrol */

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -379,8 +379,8 @@ html, body {
   top: 0;
   left: 0;
   right: 0;
-  bottom: calc(56px + max(8px, env(safe-area-inset-bottom)));
-  z-index: 150;
+  bottom: 0;
+  z-index: 98;
   display: none;
 }
 
@@ -388,14 +388,14 @@ html, body {
   display: block;
 }
 
-/* Layer manager panel — fixed, sits above timecontrol */
+/* Layer manager panel — fixed, slides up from behind timecontrol */
 #playList {
   position: fixed;
   left: 0;
   right: 0;
-  bottom: calc(56px + max(8px, env(safe-area-inset-bottom)));
+  bottom: 0;
   top: auto;
-  z-index: 200;
+  z-index: 99; /* below timecontrol (100) so it slides behind it */
   display: flex;
   flex-direction: column;
   background-color: rgba(18, 18, 18, 0.95);
@@ -403,12 +403,12 @@ html, body {
   -webkit-backdrop-filter: blur(12px);
   color: var(--dark-theme-on-surface);
   border-radius: 16px 16px 0 0;
-  transform: translateY(calc(100% + 56px + max(8px, env(safe-area-inset-bottom))));
+  transform: translateY(100%);
   transition: transform 300ms cubic-bezier(0.17, 0.04, 0.03, 0.94);
   overflow-y: auto;
   overscroll-behavior: contain;
   max-height: calc(80vh - 56px);
-  padding-bottom: 8px;
+  padding-bottom: calc(56px + 8px + max(8px, env(safe-area-inset-bottom)));
   box-sizing: border-box;
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -78,7 +78,7 @@ const wmsServerConfiguration = {
 		layer: 'RADAR_1KM_RRAI',
 		refresh: 300000,
 		category: 'radarLayer',
-		disabled: false
+		disabled: true
 	},
 	de: {
 		url: 'https://meteocore.app.meteo.fi/wms',

--- a/src/config.js
+++ b/src/config.js
@@ -81,11 +81,13 @@ const wmsServerConfiguration = {
 		disabled: false
 	},
 	de: {
-		url: 'https://maps.dwd.de/geoserver/dwd/RX-Produkt/wms',
+		url: 'https://meteocore.app.meteo.fi/wms',
+		layer: 'dwd-radar-composite-dbz',
 		refresh: 60000,
 		category: 'radarLayer',
-		attribution: 'Deutscher Wetterdienst',
-		disabled: true
+		attribution: 'DWD',
+		license: 'CC-BY-4.0',
+		disabled: false
 	},
 	nl: {
 		url: 'https://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi',
@@ -100,6 +102,7 @@ const wmsServerConfiguration = {
 		refresh: 60000,
 		category: 'radarLayer',
 		attribution: 'MET Norway',
+		license: 'CC-BY-4.0',
 		disabled: false
 	},
 	se: {
@@ -108,6 +111,7 @@ const wmsServerConfiguration = {
 		refresh: 60000,
 		category: 'radarLayer',
 		attribution: 'SMHI',
+		license: 'CC-BY-4.0',
 		disabled: false
 	},
 	dk: {
@@ -116,6 +120,7 @@ const wmsServerConfiguration = {
 		refresh: 60000,
 		category: 'radarLayer',
 		attribution: 'DMI',
+		license: 'CC-BY-4.0',
 		disabled: false
 	},
 	vn: {

--- a/src/index.html
+++ b/src/index.html
@@ -130,40 +130,63 @@
       <div><div id="currentMapTime"></div><div id="currentMapDate"></div></div>
     </div>
     <div id="timeline"></div>
-    <div id="playList">
-        <div id="satelliteLayerInfo">
-          <div id="satelliteLayerName" class="name">Sääsatelliitti</div>
-          <div id="satelliteLayerTitle" class="title">Sääsatelliitti</div>
-          <div id="satelliteLayerAbstract" class="abstract"></div>
-          <div id="satelliteLayerOpacity" class="opacity"></div>
-          <div id="satelliteLayerStyles" class="styles"></div>
-          <div id="satelliteLayerAttribution" class="attribution">EUMETSAT</div>
-        </div>
-        <div id="radarLayerInfo" class="playListContainer">
-          <div id="radarLayerName" class="name">Säätutka</div>
-          <div id="radarLayerTitle" class="title">Säätutka</div>
-          <div id="radarLayerAbstract" class="abstract"></div>
-          <div id="radarLayerOpacity" class="opacity"></div>
-          <div id="radarLayerStyles" class="styles"></div>
-          <div id="radarLayerAttribution" class="attribution">FMI (CC-BY-4.0)</div>
-        </div>
-        <div id="lightningLayerInfo">
-          <div id="lightningLayerName" class="name">Salamapaikannus</div>
-          <div id="lightningLayerTitle" class="title">Salamapaikannus</div>
-          <div id="lightningLayerAbstract" class="abstract"></div>
-          <div id="lightningLayerOpacity" class="opacity"></div>
-          <div id="lightningLayerStyles" class="styles"></div>
-          <div id="lightningLayerAttribution" class="attribution">FMI (CC-BY-4.0)</div>
-        </div>
-        <div id="observationLayerInfo">
-          <div id="observationLayerName" class="name">Säähavainto</div>
-          <div id="observationLayerTitle" class="title">Säähavainto</div>
-          <div id="observationLayerAbstract" class="abstract"></div>
-          <div id="observationLayerOpacity" class="opacity"></div>
-          <div id="observationLayerStyles" class="styles"></div>
-          <div id="observationLayerAttribution" class="attribution">FMI (CC-BY-4.0)</div>
-        </div>
+  </div>
+
+  <div id="playListBackdrop"></div>
+  <div id="playList">
+    <div class="playlist-handle"></div>
+    <div class="playlist-header">
+      <h2>Tasot</h2>
+      <div id="playlistCloseButton"><i class="material-icons">close</i></div>
+    </div>
+    <div id="satelliteLayerInfo" class="layer-card">
+      <div class="card-header">
+        <i class="material-icons card-category-icon">satellite_alt</i>
+        <span id="satelliteLayerName" class="card-category-name">Sääsatelliitti</span>
+        <div class="card-visibility-toggle" data-layer="satelliteLayer"><i class="material-icons">visibility</i></div>
       </div>
+      <div id="satelliteLayerTitle" class="card-title">Sääsatelliitti</div>
+      <div id="satelliteLayerAbstract" class="card-abstract"></div>
+      <div id="satelliteLayerOpacity" class="card-opacity"></div>
+      <div id="satelliteLayerStyles" class="card-styles"></div>
+      <div id="satelliteLayerAttribution" class="card-attribution">EUMETSAT</div>
+    </div>
+    <div id="radarLayerInfo" class="layer-card">
+      <div class="card-header">
+        <i class="material-icons card-category-icon">radar</i>
+        <span id="radarLayerName" class="card-category-name">Säätutka</span>
+        <div class="card-visibility-toggle" data-layer="radarLayer"><i class="material-icons">visibility</i></div>
+      </div>
+      <div id="radarLayerTitle" class="card-title">Säätutka</div>
+      <div id="radarLayerAbstract" class="card-abstract"></div>
+      <div id="radarLayerOpacity" class="card-opacity"></div>
+      <div id="radarLayerStyles" class="card-styles"></div>
+      <div id="radarLayerAttribution" class="card-attribution">FMI (CC-BY-4.0)</div>
+    </div>
+    <div id="lightningLayerInfo" class="layer-card">
+      <div class="card-header">
+        <i class="material-icons card-category-icon">flash_on</i>
+        <span id="lightningLayerName" class="card-category-name">Salamapaikannus</span>
+        <div class="card-visibility-toggle" data-layer="lightningLayer"><i class="material-icons">visibility</i></div>
+      </div>
+      <div id="lightningLayerTitle" class="card-title">Salamapaikannus</div>
+      <div id="lightningLayerAbstract" class="card-abstract"></div>
+      <div id="lightningLayerOpacity" class="card-opacity"></div>
+      <div id="lightningLayerStyles" class="card-styles"></div>
+      <div id="lightningLayerAttribution" class="card-attribution">FMI (CC-BY-4.0)</div>
+    </div>
+    <div id="observationLayerInfo" class="layer-card">
+      <div class="card-header">
+        <i class="material-icons card-category-icon">thermostat</i>
+        <span id="observationLayerName" class="card-category-name">Säähavainto</span>
+        <div class="card-visibility-toggle" data-layer="observationLayer"><i class="material-icons">visibility</i></div>
+      </div>
+      <div id="observationLayerTitle" class="card-title">Säähavainto</div>
+      <div id="observationLayerAbstract" class="card-abstract"></div>
+      <div id="observationLayerOpacity" class="card-opacity"></div>
+      <div id="observationLayerStyles" class="card-styles"></div>
+      <div id="observationLayerAttribution" class="card-attribution">FMI (CC-BY-4.0)</div>
+    </div>
   </div>
 
   <div id="help">

--- a/src/index.html
+++ b/src/index.html
@@ -88,7 +88,7 @@
     <div class="infoItem" id="infoItemRadar">
       <div class="infoLabel" id="infoLabelRadar">SÄÄTUTKA</div>
       <!--div class="infoValue" id="radarTxt"></div-->
-      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div><div id="RADAR_1KM_RDBR" class="flexCell">CA</div></div>
+      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
     </div>
     <div class="infoItem" id="infoItemLightning">
       <div class="infoLabel" id="infoLabelLightning">SALAMAT</div>
@@ -264,9 +264,6 @@
     </div>
     <div class="menu-item" data-layer="dwd-radar-composite-dbz">
       <span class="menu-label">Saksa</span>
-    </div>
-    <div class="menu-item" data-layer="RADAR_1KM_RDBR">
-      <span class="menu-label">CA</span>
     </div>
   </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -88,7 +88,7 @@
     <div class="infoItem" id="infoItemRadar">
       <div class="infoLabel" id="infoLabelRadar">SÄÄTUTKA</div>
       <!--div class="infoValue" id="radarTxt"></div-->
-      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><!--div id="RX-Produkt" class="flexCell">DE</div><div id="bs:radar:correctedreflectivity" class="flexCell">BS</div><div id="vnmha:radar:comp_dbz" class="flexCell">VN</div><div id="RADNL_OPER_R___25PCPRR_L3_COLOR" class="flexCell">NL</div><div id="nexrad-n0q-wmst" class="flexCell">US</div--><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="RADAR_1KM_RDBR" class="flexCell">CA</div></div>
+      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div><div id="RADAR_1KM_RDBR" class="flexCell">CA</div></div>
     </div>
     <div class="infoItem" id="infoItemLightning">
       <div class="infoLabel" id="infoLabelLightning">SALAMAT</div>
@@ -261,6 +261,9 @@
     </div>
     <div class="menu-item" data-layer="dmi-radar-composite-dbz">
       <span class="menu-label">Tanska</span>
+    </div>
+    <div class="menu-item" data-layer="dwd-radar-composite-dbz">
+      <span class="menu-label">Saksa</span>
     </div>
     <div class="menu-item" data-layer="RADAR_1KM_RDBR">
       <span class="menu-label">CA</span>

--- a/src/radar.js
+++ b/src/radar.js
@@ -926,29 +926,60 @@ function layerInfoPlaylist(event) {
 
 	if (typeof info === "undefined") return
 
-	// Only do full DOM rebuild when playlist is visible
-	let playList = document.getElementById('playList');
-	if (playList.style.display === 'none' || playList.offsetParent === null) {
-		// Still update the visibility class (cheap)
-		if (layer.getVisible()) {
-			document.getElementById(name + 'Info').classList.remove("playListDisabled");
-		} else {
-			document.getElementById(name + 'Info').classList.add("playListDisabled");
+	// If only opacity changed, update slider value without full DOM rebuild
+	if (event.key === 'opacity') {
+		let existingSlider = document.getElementById(name + 'Slider');
+		if (existingSlider) {
+			existingSlider.value = opacity;
+			existingSlider.style.background = 'linear-gradient(to right, var(--dark-primary-color) ' + opacity + '%, var(--dark-theme-overlay-06dp) ' + opacity + '%)';
+			let valEl = document.getElementById(name + 'OpacityValue');
+			if (valEl) valEl.textContent = Math.round(opacity) + '%';
 		}
+		return;
+	}
+
+	// Always update text content and visibility state (cheap DOM updates)
+	document.getElementById(name + 'Title').textContent = info.title || "";
+	document.getElementById(name + 'Abstract').textContent = info.abstract || "";
+	document.getElementById(name + 'Attribution').textContent = (info.attribution && info.attribution.Title) || "";
+	if (layer.getVisible()) {
+		document.getElementById(name + 'Info').classList.remove("playListDisabled");
+		let ti = document.querySelector('#' + name + 'Info .card-visibility-toggle .material-icons');
+		if (ti) ti.textContent = 'visibility';
+	} else {
+		document.getElementById(name + 'Info').classList.add("playListDisabled");
+		let ti = document.querySelector('#' + name + 'Info .card-visibility-toggle .material-icons');
+		if (ti) ti.textContent = 'visibility_off';
+	}
+
+	// Only do full DOM rebuild (slider, style chips) when playlist is visible
+	let playList = document.getElementById('playList');
+	if (!playList.classList.contains('open')) {
 		return;
 	}
 
 	debug("Updating playlist for " + name);
 
+	const activeStyleParam = layer.getSource().getParams().STYLES || '';
 	if (typeof info.style !== "undefined") {
 		if (info.style.length > 1) {
+			// If no explicit style set, first style is the WMS default
+			const activeStyleName = activeStyleParam || (info.style[0] && info.style[0].Name) || '';
 			const parent = document.getElementById(name + 'Styles');
 			while (parent.firstChild) parent.removeChild(parent.firstChild);
 			info.style.forEach(style => {
 				let div = document.createElement("div");
 				div.textContent = style.Title;
 				div.id = style.Name;
-				div.addEventListener('mouseup', function () { layer.setLayerStyle(style.Name) });
+				if (style.Name === activeStyleName) {
+					div.classList.add('activeStyle');
+				}
+				div.addEventListener('mouseup', function () {
+					layer.setLayerStyle(style.Name);
+					// Update active chip immediately
+					parent.querySelectorAll('.activeStyle').forEach(function(el) { el.classList.remove('activeStyle'); });
+					div.classList.add('activeStyle');
+				});
 				parent.appendChild(div);
 			});
 		} else {
@@ -958,16 +989,26 @@ function layerInfoPlaylist(event) {
 		document.getElementById(name + 'Styles').textContent = "";
 	}
 
-	document.getElementById(name + 'Title').textContent = info.title || "";
-	document.getElementById(name + 'Abstract').textContent = info.abstract || "";
-	document.getElementById(name + 'Attribution').textContent = (info.attribution && info.attribution.Title) || "";
-
-	// Build slider without innerHTML
+	// Build opacity control with label row + slider
 	let opacityContainer = document.getElementById(name + 'Opacity');
 	opacityContainer.textContent = '';
+
+	let labelRow = document.createElement('div');
+	labelRow.className = 'opacity-label-row';
+
 	let label = document.createElement('label');
 	label.setAttribute('for', name + 'Slider');
+	label.className = 'opacity-label';
 	label.textContent = 'Läpikuultavuus';
+
+	let valueSpan = document.createElement('span');
+	valueSpan.className = 'opacity-value';
+	valueSpan.id = name + 'OpacityValue';
+	valueSpan.textContent = Math.round(opacity) + '%';
+
+	labelRow.appendChild(label);
+	labelRow.appendChild(valueSpan);
+
 	let slider = document.createElement('input');
 	slider.type = 'range';
 	slider.min = '1';
@@ -975,21 +1016,21 @@ function layerInfoPlaylist(event) {
 	slider.value = opacity;
 	slider.className = 'slider';
 	slider.id = name + 'Slider';
-	opacityContainer.appendChild(label);
-	opacityContainer.appendChild(slider);
+	slider.style.background = 'linear-gradient(to right, var(--dark-primary-color) ' + opacity + '%, var(--dark-theme-overlay-06dp) ' + opacity + '%)';
 
-	if (layer.getVisible()) {
-		document.getElementById(name + 'Info').classList.remove("playListDisabled");
-	} else {
-		document.getElementById(name + 'Info').classList.add("playListDisabled");
-	}
+	opacityContainer.appendChild(labelRow);
+	opacityContainer.appendChild(slider);
 
 	// Remove previous slider listener to prevent leaks
 	if (_playlistSliderHandlers[name]) {
 		slider.removeEventListener('input', _playlistSliderHandlers[name]);
 	}
 	_playlistSliderHandlers[name] = function (e) {
-		layer.setOpacity(e.target.value / 100);
+		const val = e.target.value;
+		layer.setOpacity(val / 100);
+		let valEl = document.getElementById(name + 'OpacityValue');
+		if (valEl) valEl.textContent = Math.round(val) + '%';
+		e.target.style.background = 'linear-gradient(to right, var(--dark-primary-color) ' + val + '%, var(--dark-theme-overlay-06dp) ' + val + '%)';
 		e.stopPropagation();
 	};
 	slider.addEventListener('input', _playlistSliderHandlers[name]);
@@ -1010,6 +1051,8 @@ function onChangeVisible (event) {
 		}
 		setButtonState(name+"Button", true);
 		document.getElementById(name+'Info').classList.remove("playListDisabled");
+		let toggleIcon = document.querySelector('#' + name + 'Info .card-visibility-toggle .material-icons');
+		if (toggleIcon) toggleIcon.textContent = 'visibility';
 	} else {
 		debug("Deactivated " + name);
 		VISIBLE.delete(name);
@@ -1017,6 +1060,8 @@ function onChangeVisible (event) {
 		document.getElementById(name+"Off").classList.add("selected");
 		setButtonState(name+"Button", false);
 		document.getElementById(name+'Info').classList.add("playListDisabled");
+		let toggleIcon = document.querySelector('#' + name + 'Info .card-visibility-toggle .material-icons');
+		if (toggleIcon) toggleIcon.textContent = 'visibility_off';
 	}
 	updateCanonicalPage();
 	updateLayerSelectionSelected();
@@ -1071,14 +1116,43 @@ document.getElementById('skipPreviousButton').addEventListener('mouseup', functi
 	skipPrevious();
 });
 
-document.getElementById('playlistButton').addEventListener('mouseup', function() {
+function openPlaylist() {
+	document.getElementById("playList").classList.add('open');
+	document.getElementById("playListBackdrop").classList.add('open');
+	// Force full rebuild of all layer cards (slider, style chips)
+	[satelliteLayer, radarLayer, lightningLayer, observationLayer].forEach(function(layer) {
+		layerInfoPlaylist({ target: layer, key: 'info' });
+	});
+}
+
+function closePlaylist() {
+	document.getElementById("playList").classList.remove('open');
+	document.getElementById("playListBackdrop").classList.remove('open');
+}
+
+function togglePlaylist() {
 	debug("playlist");
-	let elem = document.getElementById("playList");
-	if (elem.style.bottom === '0px') {
-		elem.style.bottom = '-90vh';
+	if (document.getElementById("playList").classList.contains('open')) {
+		closePlaylist();
 	} else {
-		elem.style.bottom = '0px';
+		openPlaylist();
 	}
+}
+
+document.getElementById('playlistButton').addEventListener('mouseup', togglePlaylist);
+
+document.getElementById('playlistCloseButton').addEventListener('mouseup', closePlaylist);
+
+document.getElementById('playListBackdrop').addEventListener('mouseup', closePlaylist);
+
+// Visibility toggle buttons inside layer cards
+document.querySelectorAll('.card-visibility-toggle').forEach(function(toggle) {
+	toggle.addEventListener('mouseup', function(e) {
+		const layerName = toggle.getAttribute('data-layer');
+		const layerObj = layerss[layerName];
+		if (layerObj) toggleLayerVisibility(layerObj);
+		e.stopPropagation();
+	});
 });
 
 // Close playlist if clicked outside of playlist
@@ -1086,10 +1160,7 @@ window.addEventListener('mouseup', function (e) {
 	// playlist
 	if (!document.getElementById('playList').contains(e.target)) {
 		if (document.getElementById('playlistButton').contains(e.target)) return
-		let elem = document.getElementById("playList");
-		if (elem.style.bottom === '0px') {
-			elem.style.bottom = '-90vh';
-		} 
+		closePlaylist();
 	}
 
 	// Layers

--- a/src/radar.js
+++ b/src/radar.js
@@ -91,6 +91,7 @@ ImageLayer.prototype.setLayerUrl = function (url) {
 ImageLayer.prototype.setLayerStyle = function (style) {
 	debug("Set layer style: " + style);
 	this.getSource().updateParams({ 'STYLES': style });
+	typeof umami !== 'undefined' && umami.track('layer-style', { style: style, category: this.get('name') });
 }
 
 ImageLayer.prototype.setLayerTime = function (time) {
@@ -773,6 +774,7 @@ function removeSelectedParameter(selector) {
 
 function updateLayer(layer, wmslayer) {
 	debug("Activated layer " + wmslayer);
+	typeof umami !== 'undefined' && umami.track('layer-switch', { layer: wmslayer, category: layer.get('name') });
 	debug(layerInfo[wmslayer]);
 	let info = layerInfo[wmslayer];
 	layer.set('info', info);
@@ -1048,6 +1050,7 @@ function onChangeVisible (event) {
 	let name = layer.get('name');
 	let isVisible = layer.getVisible();
 	removeSelectedParameter("#" + name + " > div");
+	typeof umami !== 'undefined' && umami.track('layer-visibility', { layer: wmslayer, category: name, visible: isVisible });
 	if (isVisible) {
 		debug("Activated " + name);
 		VISIBLE.add(name);

--- a/src/radar.js
+++ b/src/radar.js
@@ -909,7 +909,9 @@ function layerInfoDiv(wmslayer) {
 		div.appendChild(createLayerInfoElement('Aikatiedot ei saatavilla','time'));
 	}
 	if (info && info.attribution && info.attribution.Title) {
-		div.appendChild(createLayerInfoElement(info.attribution.Title,'attribution'));
+		let attrText = info.attribution.Title;
+		if (info.license) attrText += ' (' + info.license + ')';
+		div.appendChild(createLayerInfoElement(attrText,'attribution'));
 	} else {
 		div.appendChild(createLayerInfoElement('','attribution'));
 	}
@@ -941,7 +943,11 @@ function layerInfoPlaylist(event) {
 	// Always update text content and visibility state (cheap DOM updates)
 	document.getElementById(name + 'Title').textContent = info.title || "";
 	document.getElementById(name + 'Abstract').textContent = info.abstract || "";
-	document.getElementById(name + 'Attribution').textContent = (info.attribution && info.attribution.Title) || "";
+	let attributionText = (info.attribution && info.attribution.Title) || "";
+	if (info.license) {
+		attributionText += (attributionText ? ' (' + info.license + ')' : info.license);
+	}
+	document.getElementById(name + 'Attribution').textContent = attributionText;
 	if (layer.getVisible()) {
 		document.getElementById(name + 'Info').classList.remove("playListDisabled");
 		let ti = document.querySelector('#' + name + 'Info .card-visibility-toggle .material-icons');
@@ -1516,6 +1522,10 @@ function getLayerInfo(layer,wms) {
 		product.attribution = layer.Attribution;
 	} else if (typeof wms.attribution !== "undefined") {
 		product.attribution = {Title: wms.attribution};
+	}
+
+	if (typeof wms.license !== "undefined") {
+		product.license = wms.license;
 	}
 
 	if (typeof layer.Dimension !== "undefined") {


### PR DESCRIPTION
## Summary
- Redesign layer manager panel: move out of timecontrol to fixed position, slides up from behind playbar
- Layer cards with category icons, visibility toggles, and clear active/disabled states
- Fix opacity slider: full-width with gradient track fill, percentage display, no DOM rebuild during drag
- Pill-shaped style chips with active state highlighting (default style highlighted on open)
- Disabled layers keep title/description/attribution visible, only hide controls
- Semi-transparent panel (0.7 opacity) with backdrop blur so map remains visible
- Add license info (CC-BY-4.0) to meteocore WMS services (NO, SE, DK, DE)
- Add Germany radar via meteocore (dwd-radar-composite-dbz)
- Add Finland (FI, fmi-radar-composite-dbz) and Europe (EU, opera-reflectivity) radar layers
- Disable Canada radar layer
- Track layer visibility, product switch, and style changes as Umami analytics events

## Test plan
- [ ] Open layer manager via layers button in playbar
- [ ] Verify panel slides up from behind timecontrol bar
- [ ] Verify map is visible through semi-transparent panel
- [ ] Close panel via: close button, tap outside, layers button
- [ ] Toggle layer visibility via eye icon on each card
- [ ] Drag opacity sliders — verify smooth dragging and percentage updates
- [ ] Click style chips — verify active highlight changes immediately
- [ ] Verify disabled layers show title/description but hide slider/styles
- [ ] Switch to NO, SE, DK, DE, FI, EU radar layers — verify attribution includes license
- [ ] Test on mobile viewport (375px width)
- [ ] Verify localStorage persistence survives page reload
- [ ] Check Umami for layer-visibility, layer-switch, layer-style events