### PR TITLE
Add Finland and Europe radar layers from meteocore

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -96,6 +96,24 @@ const wmsServerConfiguration = {
 		attribution: 'KNMI',
 		disabled: true
 	},
+	fi: {
+		url: 'https://meteocore.app.meteo.fi/wms',
+		layer: 'fmi-radar-composite-dbz',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'FMI',
+		license: 'CC-BY-4.0',
+		disabled: false
+	},
+	eu: {
+		url: 'https://meteocore.app.meteo.fi/wms',
+		layer: 'opera-precipitation',
+		refresh: 60000,
+		category: 'radarLayer',
+		attribution: 'EUMETNET OPERA',
+		license: 'CC-BY-4.0',
+		disabled: false
+	},
 	no: {
 		url: 'https://meteocore.app.meteo.fi/wms',
 		layer: 'met-radar-composite-dbz',

--- a/src/config.js
+++ b/src/config.js
@@ -107,7 +107,7 @@ const wmsServerConfiguration = {
 	},
 	eu: {
 		url: 'https://meteocore.app.meteo.fi/wms',
-		layer: 'opera-precipitation',
+		layer: 'opera-reflectivity',
 		refresh: 60000,
 		category: 'radarLayer',
 		attribution: 'EUMETNET OPERA',

--- a/src/index.html
+++ b/src/index.html
@@ -88,7 +88,7 @@
     <div class="infoItem" id="infoItemRadar">
       <div class="infoLabel" id="infoLabelRadar">SÄÄTUTKA</div>
       <!--div class="infoValue" id="radarTxt"></div-->
-      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
+      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="fmi-radar-composite-dbz" class="flexCell">FI</div><div id="opera-precipitation" class="flexCell">EU</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
     </div>
     <div class="infoItem" id="infoItemLightning">
       <div class="infoLabel" id="infoLabelLightning">SALAMAT</div>
@@ -252,6 +252,12 @@
     </div>
     <div class="menu-item" data-layer="radar:radar_finland_rr">
       <span class="menu-label">RATE</span>
+    </div>
+    <div class="menu-item" data-layer="fmi-radar-composite-dbz">
+      <span class="menu-label">Suomi</span>
+    </div>
+    <div class="menu-item" data-layer="opera-precipitation">
+      <span class="menu-label">Eurooppa</span>
     </div>
     <div class="menu-item" data-layer="smhi-radar-composite-dbz">
       <span class="menu-label">Ruotsi</span>

--- a/src/index.html
+++ b/src/index.html
@@ -88,7 +88,7 @@
     <div class="infoItem" id="infoItemRadar">
       <div class="infoLabel" id="infoLabelRadar">SÄÄTUTKA</div>
       <!--div class="infoValue" id="radarTxt"></div-->
-      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="fmi-radar-composite-dbz" class="flexCell">FI</div><div id="opera-precipitation" class="flexCell">EU</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
+      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="fmi-radar-composite-dbz" class="flexCell">FI</div><div id="opera-reflectivity" class="flexCell">EU</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
     </div>
     <div class="infoItem" id="infoItemLightning">
       <div class="infoLabel" id="infoLabelLightning">SALAMAT</div>
@@ -256,7 +256,7 @@
     <div class="menu-item" data-layer="fmi-radar-composite-dbz">
       <span class="menu-label">Suomi</span>
     </div>
-    <div class="menu-item" data-layer="opera-precipitation">
+    <div class="menu-item" data-layer="opera-reflectivity">
       <span class="menu-label">Eurooppa</span>
     </div>
     <div class="menu-item" data-layer="smhi-radar-composite-dbz">


### PR DESCRIPTION
## Summary
- Add Finland radar layer (FI) using `fmi-radar-composite-dbz` from meteocore
- Add Europe radar layer (EU) using `opera-reflectivity` from meteocore
- Both added to infopanel selector and radar long-press menu

## Test plan
- [ ] Select FI radar layer — verify Finnish radar data loads
- [ ] Select EU radar layer — verify European OPERA reflectivity data loads
- [ ] Verify attribution shows correctly with license info
- [ ] Test via long-press menu ("Suomi", "Eurooppa")