### PR TITLE
Fix layer switch with incompatible WMS style

### DIFF
--- a/src/radar.js
+++ b/src/radar.js
@@ -785,7 +785,21 @@ function updateLayer(layer, wmslayer) {
 	if (info && info.url) {
 		layer.setLayerUrl(info.url);
 	}
-	layer.getSource().updateParams({ 'LAYERS': wmslayer });
+	// Reset style if the new layer doesn't support the currently active style
+	const currentStyle = layer.getSource().getParams().STYLES || '';
+	if (currentStyle && info && info.style) {
+		const validStyles = info.style.map(s => s.Name);
+		if (!validStyles.includes(currentStyle)) {
+			layer.getSource().updateParams({ 'LAYERS': wmslayer, 'STYLES': '' });
+		} else {
+			layer.getSource().updateParams({ 'LAYERS': wmslayer });
+		}
+	} else if (currentStyle) {
+		// No style info available for new layer, reset to default
+		layer.getSource().updateParams({ 'LAYERS': wmslayer, 'STYLES': '' });
+	} else {
+		layer.getSource().updateParams({ 'LAYERS': wmslayer });
+	}
 	if (layer.getVisible()) {
 		updateCanonicalPage();
 	} else {


### PR DESCRIPTION
## Summary
- When switching layers via the long press menu, the WMS `STYLES` parameter was preserved from the previous layer
- If that style doesn't exist on the new layer/service, the WMS request fails silently (no tiles rendered)
- Now validates the current style against the new layer's available styles and resets to default when incompatible

## Test plan
- [ ] Select a radar layer (e.g. DBZ) and change its style in the layer manager
- [ ] Switch to a different radar layer via long press menu (e.g. FMI → RATE)
- [ ] Verify the new layer renders correctly (style reset to default if incompatible)
- [ ] Switch between layers that share the same style and verify it's preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)