### PR TITLE
Use meteocore FMI radar as default, disable openwms

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ const wmsServerConfiguration = {
 		refresh: 60000,
 		category: 'radarLayer',
 		attribution: 'FMI (CC-BY-4.0)',
-		disabled: false
+		disabled: true
 	},
 	'meteo-radar': {
 		url: 'https://wms.meteo.fi/geoserver/wms',

--- a/src/index.html
+++ b/src/index.html
@@ -29,12 +29,11 @@
   <!-- Resource hints - only preconnect origins needed at initial load -->
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preconnect" href="https://openwms.fmi.fi" crossorigin>
+  <link rel="preconnect" href="https://meteocore.app.meteo.fi" crossorigin>
   <link rel="preconnect" href="https://server.arcgisonline.com" crossorigin>
   <!-- DNS prefetch for origins used when user activates layers -->
   <link rel="dns-prefetch" href="https://wms.meteo.fi">
   <link rel="dns-prefetch" href="https://wms-obs.app.meteo.fi">
-  <link rel="dns-prefetch" href="https://meteocore.app.meteo.fi">
   <link rel="dns-prefetch" href="https://view.eumetsat.int">
   <link rel="dns-prefetch" href="https://geo.weather.gc.ca">
  

--- a/src/index.html
+++ b/src/index.html
@@ -88,7 +88,7 @@
     <div class="infoItem" id="infoItemRadar">
       <div class="infoLabel" id="infoLabelRadar">SÄÄTUTKA</div>
       <!--div class="infoValue" id="radarTxt"></div-->
-      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="suomi_dbz_eureffin" class="flexCell selected">FMI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="fmi-radar-composite-dbz" class="flexCell">FI</div><div id="opera-reflectivity" class="flexCell">EU</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
+      <div class="infoValue flexColumn" id="radarLayer"><div id="radarLayerOff" class="flexCell">OFF</div><div id="fmi-radar-composite-dbz" class="flexCell selected">FI</div><div id="radar:radar_finland_dbz" class="flexCell">DBZ</div><div id="radar:radar_finland_rr" class="flexCell">RATE</div><div id="opera-reflectivity" class="flexCell">EU</div><div id="met-radar-composite-dbz" class="flexCell">NO</div><div id="smhi-radar-composite-dbz" class="flexCell">SE</div><div id="dmi-radar-composite-dbz" class="flexCell">DK</div><div id="dwd-radar-composite-dbz" class="flexCell">DE</div></div>
     </div>
     <div class="infoItem" id="infoItemLightning">
       <div class="infoLabel" id="infoLabelLightning">SALAMAT</div>
@@ -244,7 +244,7 @@
 
   <!-- Long press radar parameter menu -->
   <div id="radarLongPressMenu">
-    <div class="menu-item" data-layer="suomi_dbz_eureffin">
+    <div class="menu-item" data-layer="fmi-radar-composite-dbz">
       <span class="menu-label">Suomi</span>
     </div>
     <div class="menu-item" data-layer="radar:radar_finland_dbz">
@@ -252,9 +252,6 @@
     </div>
     <div class="menu-item" data-layer="radar:radar_finland_rr">
       <span class="menu-label">RATE</span>
-    </div>
-    <div class="menu-item" data-layer="fmi-radar-composite-dbz">
-      <span class="menu-label">Suomi</span>
     </div>
     <div class="menu-item" data-layer="opera-reflectivity">
       <span class="menu-label">Eurooppa</span>

--- a/src/radar.js
+++ b/src/radar.js
@@ -317,7 +317,7 @@ const radarLayer = new ImageLayer({
 	visible: VISIBLE.has("radarLayer"),
 	opacity: 0.7,
 	source: new ImageWMS({
-		url: options.wmsServerConfiguration["fmi-radar"].url,
+		url: options.wmsServerConfiguration.fi.url,
 		params: { 'LAYERS': options.defaultRadarLayer },
 		attributions: 'FMI (CC-BY-4.0)',
 		ratio: options.imageRatio,

--- a/src/radar.js
+++ b/src/radar.js
@@ -37,7 +37,7 @@ dayjs.extend(localizedFormat);
 dayjs.extend(durationPlugin);
 
 const options = {
-	defaultRadarLayer: 'suomi_dbz_eureffin',
+	defaultRadarLayer: 'fmi-radar-composite-dbz',
 	defaultLightningLayer: 'observation:lightning',
 	defaultObservationLayer: 'observation:airtemperature',
 	rangeRingSpacing: 50,
@@ -70,6 +70,13 @@ let mapTime = '';
 
 let VISIBLE = new Set(safeParseJSON('VISIBLE', ['radarLayer']));
 let ACTIVE = new Set(safeParseJSON('ACTIVE', [options.defaultRadarLayer]));
+
+// Migrate deprecated FMI openwms layer to meteocore equivalent
+if (ACTIVE.has('suomi_dbz_eureffin')) {
+	ACTIVE.delete('suomi_dbz_eureffin');
+	ACTIVE.add('fmi-radar-composite-dbz');
+	localStorage.setItem('ACTIVE', JSON.stringify([...ACTIVE]));
+}
 let IS_DARK = safeParseJSON('IS_DARK', true);
 let IS_TRACKING = safeParseJSON('IS_TRACKING', false);
 let IS_FOLLOWING = safeParseJSON('IS_FOLLOWING', false);


### PR DESCRIPTION
## Summary
- Switch default radar layer from openwms \`suomi_dbz_eureffin\` to meteocore \`fmi-radar-composite-dbz\`
- Disable the \`fmi-radar\` (openwms.fmi.fi) service in config
- Remove \`suomi_dbz_eureffin\` from infopanel selector and radar long-press menu
- Mark \`fmi-radar-composite-dbz\` (FI) as the default selected entry
- Add one-time localStorage migration so existing users with \`suomi_dbz_eureffin\` in their \`ACTIVE\` set get silently upgraded to \`fmi-radar-composite-dbz\` on next load

## Test plan
- [ ] Fresh visit loads \`fmi-radar-composite-dbz\` as default radar layer
- [ ] Existing user with old layer in localStorage gets migrated on next load
- [ ] Long-press menu on radar button no longer shows the openwms FMI entry
- [ ] Infopanel radar selector shows FI as default selected
- [ ] Other radar layers (DBZ, RATE, EU, NO, SE, DK, DE) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)