### PR TITLE
Fix dark mode OS detection and preference persistence

### DIFF
--- a/src/radar.js
+++ b/src/radar.js
@@ -77,7 +77,9 @@ if (ACTIVE.has('suomi_dbz_eureffin')) {
 	ACTIVE.add('fmi-radar-composite-dbz');
 	localStorage.setItem('ACTIVE', JSON.stringify([...ACTIVE]));
 }
-let IS_DARK = safeParseJSON('IS_DARK', true);
+// IS_DARK: null = auto (follow OS), true = user picked dark, false = user picked light
+let IS_DARK = safeParseJSON('IS_DARK', null);
+let currentMapTheme = 'dark';
 let IS_TRACKING = safeParseJSON('IS_TRACKING', false);
 let IS_FOLLOWING = safeParseJSON('IS_FOLLOWING', false);
 let IS_NAUTICAL = safeParseJSON('IS_NAUTICAL', false);
@@ -735,15 +737,24 @@ document.getElementById("cursorDistanceTxt").style.display = "none";
 
 
 
+function getEffectiveTheme() {
+	if (IS_DARK !== null) return IS_DARK ? 'dark' : 'light';
+	return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
 function setMapLayer(maplayer) {
 	debug('Set ' + maplayer + ' map.');
+	const darkBaseEl = document.getElementById('darkBase');
+	const lightBaseEl = document.getElementById('lightBase');
 	switch (maplayer) {
 		case 'light':
 			darkGrayBaseLayer.setVisible(false);
 			darkGrayReferenceLayer.setVisible(false);
 			lightGrayBaseLayer.setVisible(true);
 			lightGrayReferenceLayer.setVisible(true);
-			IS_DARK = false;
+			currentMapTheme = 'light';
+			darkBaseEl.classList.remove('selected');
+			lightBaseEl.classList.add('selected');
 			setButtonState("mapLayerButton", false);
 			typeof umami !== 'undefined' && umami.track('theme-light');
 			break;
@@ -752,24 +763,27 @@ function setMapLayer(maplayer) {
 			darkGrayReferenceLayer.setVisible(true);
 			lightGrayBaseLayer.setVisible(false);
 			lightGrayReferenceLayer.setVisible(false);
-			IS_DARK = true;
+			currentMapTheme = 'dark';
+			lightBaseEl.classList.remove('selected');
+			darkBaseEl.classList.add('selected');
 			setButtonState("mapLayerButton", true);
 			typeof umami !== 'undefined' && umami.track('theme-dark');
-			break;	
+			break;
 	}
-	localStorage.setItem("IS_DARK",JSON.stringify(IS_DARK));
+}
+
+function setUserTheme(maplayer) {
+	IS_DARK = maplayer === 'dark';
+	localStorage.setItem("IS_DARK", JSON.stringify(IS_DARK));
+	setMapLayer(maplayer);
 }
 
 document.getElementById('darkBase').addEventListener('mouseup', function (event) {
-	event.target.classList.add("selected");
-	document.getElementById("lightBase").classList.remove("selected");
-	setMapLayer('dark');
+	setUserTheme('dark');
 });
 
 document.getElementById('lightBase').addEventListener('mouseup', function (event) {
-	event.target.classList.add("selected");
-	document.getElementById("darkBase").classList.remove("selected");
-	setMapLayer('light');
+	setUserTheme('light');
 });
 
 function removeSelectedParameter(selector) {
@@ -1239,7 +1253,7 @@ function setButtonState(id, active) {
 
 function setButtonStates() {
 	setButtonState("locationLayerButton", IS_TRACKING);
-	setButtonState("mapLayerButton", IS_DARK);
+	setButtonState("mapLayerButton", currentMapTheme === 'dark');
 	setButtonState("satelliteLayerButton", VISIBLE.has("satelliteLayer"));
 	setButtonState("radarLayerButton", VISIBLE.has("radarLayer"));
 	setButtonState("lightningLayerButton", VISIBLE.has("lightningLayer"));
@@ -1284,11 +1298,7 @@ document.getElementById('cursorDistanceTxt').addEventListener('mouseup', functio
 });
 
 document.getElementById('mapLayerButton').addEventListener('mouseup', function() {
-	if (IS_DARK) {
-		setMapLayer('light');
-	} else {
-		setMapLayer('dark');
-	}
+	setUserTheme(currentMapTheme === 'dark' ? 'light' : 'dark');
 });
 
 
@@ -1618,7 +1628,7 @@ const main = () => {
 	
 	timeline = new Timeline (13, document.getElementById("timeline"));
 
-	setMapLayer(IS_DARK ? 'dark' : 'light');
+	setMapLayer(getEffectiveTheme());
 
 	updateClock();
 
@@ -1676,11 +1686,9 @@ const main = () => {
 	});
 
 	window.matchMedia("(prefers-color-scheme: dark)").addEventListener('change', function(x) {
-		if (x.matches) {
-			setMapLayer('dark');
-		} else {
-			setMapLayer('light');
-		}
+		// Only follow OS changes while in auto mode (no explicit user choice)
+		if (IS_DARK !== null) return;
+		setMapLayer(x.matches ? 'dark' : 'light');
 	});
 
 


### PR DESCRIPTION
## Summary
- `IS_DARK` now has three states: `null` (auto/follow OS), `true` (explicit dark), `false` (explicit light). Default is `null`, so first-time visitors get their OS preference instead of always-dark.
- New `setUserTheme()` is the only path that persists to `localStorage`. `setMapLayer()` no longer writes storage, so OS-triggered or init-time theme applications can no longer stomp the user's explicit choice.
- The `prefers-color-scheme` change listener now bails out when `IS_DARK !== null`, preserving explicit user selections against OS changes (and against iOS Safari's spurious change events on bfcache restore / auto time-of-day switching / low-power mode).
- `setMapLayer()` also syncs the `selected` class on the `darkBase`/`lightBase` info panel pills and tracks the currently-displayed theme in a new `currentMapTheme` variable (used by button state + toggle logic).

## Why
Reported bug: OS dark mode was not detected, and the user's manual theme selection kept resetting. Root cause was that (a) OS preference was never consulted on first load, and (b) the OS change listener unconditionally overwrote the stored preference every time it fired.

## Test plan
- [ ] Fresh load on a dark-mode phone with no prior `IS_DARK` value → app starts in dark mode, `localStorage.IS_DARK` remains unset
- [ ] Fresh load on a light-mode phone with no prior `IS_DARK` value → app starts in light mode, `localStorage.IS_DARK` remains unset
- [ ] Tap Light while auto → persists as `false`, survives reload
- [ ] Tap Dark while auto → persists as `true`, survives reload
- [ ] With explicit choice set, toggle OS theme → app does NOT change (explicit choice wins)
- [ ] Toggle via top-bar `mapLayerButton` → persists and updates the info panel pills
- [ ] Info panel `Dark`/`Light` pills stay in sync with the active theme across all code paths