### PR TITLE
Float toolbars inside iOS safe area for proper PWA fullscreen

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -17,6 +17,6 @@
   ],
   "start_url": "/index.html",
   "background_color": "#121212",
-  "display": "fullscreen",
+  "display": "standalone",
   "theme_color": "#121212"
 }

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -58,15 +58,15 @@ html, body {
 
 @media all and (max-width: 768px) {
   .toolbar {
-      left: 0;
-      width: 100%;
-      border-radius: 0px;
+      left: 8px;
+      right: 8px;
+      width: auto;
       margin: 0;
     }
 }
 
   .navbar {
-    top: 0;
+    top: calc(env(safe-area-inset-top, 0px) + 2px);
     display: flex;
     justify-content: space-around;
     align-items: stretch;
@@ -142,7 +142,7 @@ html, body {
 
   #timecontrol {
     top: auto;
-    bottom: 0;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 2px);
     color: var(--dark-theme-on-surface);
     display: flex;
     flex-direction: column;
@@ -207,15 +207,6 @@ html, body {
     border-left: 1px solid rgb(0, 84, 99);
   }
 
-@supports (padding: max(0px)) {
-    .navbar {
-        padding-top: max(8px, env(safe-area-inset-top));
-    }
-    #timecontrol {
-        padding-bottom: max(8px, env(safe-area-inset-bottom));
-    }
-}
-  
 .noselect {
     -webkit-touch-callout: none; /* iOS Safari */
       -webkit-user-select: none; /* Safari */


### PR DESCRIPTION
## Summary
- Position navbar and timecontrol at `env(safe-area-inset-*) + 2px` so the map extends through the status-bar and home-indicator strips
- Switch manifest display from `fullscreen` to `standalone` — iOS treats `fullscreen` oddly (opaque status bar, reserved dead zone at bottom); `standalone` lets `apple-mobile-web-app-status-bar-style: black-translucent` properly kick in
- Mobile toolbars now float with 8px side margins and keep rounded corners (was edge-to-edge, radius 0)
- Removed the `@supports (padding: max(0px))` block — toolbars now live inside the safe area, no longer need padding to push content away from system UI

## Test plan
- [ ] In Safari browser mode on iPhone, toolbars float with side margins and map extends under them
- [ ] Install to home screen, relaunch from icon (iOS caches aggressively — may need to remove & re-add)
- [ ] In PWA mode, map visible through the status bar (translucent) and in the home-indicator strip
- [ ] Top and bottom bars sit 2px above their respective safe-area boundaries
- [ ] Desktop layout (> 768px) unchanged — centered 450px-wide floating cards
- [ ] Rotation on iPhone still respects safe-area insets on the new side