### PR TITLE
Respect horizontal safe area on narrow landscape viewports

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -58,8 +58,8 @@ html, body {
 
 @media all and (max-width: 768px) {
   .toolbar {
-      left: 8px;
-      right: 8px;
+      left: max(8px, env(safe-area-inset-left, 0px));
+      right: max(8px, env(safe-area-inset-right, 0px));
       width: auto;
       margin: 0;
     }


### PR DESCRIPTION
## Summary
Follow-up to #63. Mobile toolbars used flat `left: 8px; right: 8px` — in landscape on a notched device whose viewport lands at ≤768px (split-screen on a future notched iPad, unusual aspect ratios) the notch could clip the navbar's leftmost or rightmost button.

Using `max(8px, env(safe-area-inset-left/right, 0px))` keeps the 8px floor on devices without any horizontal safe area (iPads without notch, iPhone SE in landscape) but pushes the toolbar inward when a notch is present.

Defensive rather than a known-broken case: all current notched iPhones have landscape viewport > 768px and hit the desktop rule instead.

## Test plan
- [ ] Portrait iPhone PWA — toolbars unchanged (no horizontal safe area, falls back to 8px)
- [ ] Landscape iPhone PWA (viewport > 768px) — desktop centered layout, unchanged
- [ ] Desktop browser — unchanged (media query doesn't match)
- [ ] iPad split-screen at narrow width — toolbars still clear the screen edges