### PR TITLE
Redesign top toolbar as floating pill with POI toggles

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -24,6 +24,7 @@
   --dark-theme-shadow-24dp: 0 9px 46px 8px rgba(0, 0, 0, 0.14),
                             0 11px 15px -7px rgba(0, 0, 0, 0.12),
                             0 24px 38px 3px rgba(0, 0, 0, 0.20);
+  --timecontrol-height: 84px;
 }
 
 html, body {
@@ -65,79 +66,340 @@ html, body {
     }
 }
 
-  .navbar {
-    top: calc(env(safe-area-inset-top, 0px) + 2px);
+  /* ========================================================================
+     Primary toolbar — segmented pill + detached menu button, floating
+     ======================================================================== */
+  #primaryToolbar {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
     display: flex;
-    justify-content: space-around;
-    align-items: stretch;
-    color: var(--dark-medium-emphasis-text-color);
-    flex-flow: row nowrap;
+    align-items: center;
+    gap: 10px;
     touch-action: none;
-    gap: 4px;
+    pointer-events: none;
+  }
+  #primaryToolbar > * { pointer-events: auto; }
+
+  .pill {
+    display: flex;
+    align-items: center;
+    height: 52px;
+    padding: 0;
+    border-radius: 26px;
+    background: rgba(22, 22, 24, 0.62);
+    background-color: rgba(0, 0, 0, 0.60); /* contrast floor */
+    -webkit-backdrop-filter: blur(24px) saturate(140%);
+    backdrop-filter: blur(24px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+    position: relative;
+    overflow: hidden;
+  }
+  .pill::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(22, 22, 24, 0.28);
+    border-radius: inherit;
+    z-index: -1;
   }
 
-  .navbar > button {
-    flex: 1 1 0;
-    display: flex;
+  .seg {
+    all: unset;
+    width: 62px;
+    height: 52px;
+    display: inline-flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    text-align: center;
-    font-size: 0.75em;
-    font-family: 'Roboto', sans-serif;
-    color: var(--dark-medium-emphasis-text-color);
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    border-radius: 6px;
-    padding: 6px 4px;
-    min-height: 48px;
+    padding-top: 4px;
     cursor: pointer;
-    box-sizing: border-box;
-    transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+    color: rgba(255, 255, 255, 0.82);
+    position: relative;
+    transition: color 180ms ease, background-color 180ms ease, transform 120ms ease;
     outline: none;
   }
+  .seg + .seg::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 14px;
+    bottom: 14px;
+    width: 1px;
+    background: rgba(255, 255, 255, 0.08);
+  }
+  .seg:hover { background-color: rgba(255, 255, 255, 0.04); }
+  .seg:active,
+  .seg.pressing { transform: scale(0.95); background-color: rgba(255, 255, 255, 0.06); }
+  .seg:focus-visible { box-shadow: inset 0 0 0 2px var(--dark-primary-color); border-radius: 24px; }
+  .seg .material-icons { font-size: 22px; line-height: 1; }
 
-  .navbar > button:hover {
-    background-color: var(--dark-theme-surface-hovered);
+  /* Always-visible indicator bar under each segment. Cues that the segment has
+     a long-press variant menu and doubles as the active-state signal. */
+  .seg .indicator {
+    display: block;
+    width: 8px;
+    height: 2px;
+    margin-top: 6px;
+    border-radius: 1px;
+    background: rgba(255, 255, 255, 0.32);
+    transition: width 200ms ease, background-color 200ms ease;
   }
 
-  .navbar > button:active,
-  .navbar > button.pressing {
-    background-color: var(--dark-theme-surface-focused);
-    transform: scale(0.93);
-  }
-
-  .navbar > button:focus-visible {
-    outline: 2px solid var(--dark-primary-color);
-    outline-offset: -2px;
-  }
-
-  .btn-label {
-    font-size: inherit;
-    line-height: 1.3;
-  }
-
-  .menu-indicator {
-    font-size: 7px;
+  /* Active: soft fill + icon recolor + indicator turns cyan and grows */
+  .seg[aria-pressed="true"],
+  .seg.selectedButton {
     color: var(--dark-primary-color);
-    opacity: 0.7;
-    line-height: 1;
+  }
+  .seg[aria-pressed="true"]::after,
+  .seg.selectedButton::after {
+    content: '';
+    position: absolute;
+    inset: 4px 3px;
+    background: rgba(18, 188, 250, 0.18);
+    border-radius: 22px;
+    z-index: -1;
+  }
+  .seg[aria-pressed="true"] .indicator,
+  .seg.selectedButton .indicator {
+    background: var(--dark-primary-color);
+    width: 16px;
+  }
+  /* Hide dividers either side of active segment so the fill reads clean */
+  .seg[aria-pressed="true"]::before,
+  .seg[aria-pressed="true"] + .seg::before,
+  .seg.selectedButton::before,
+  .seg.selectedButton + .seg::before {
+    background: transparent;
   }
 
-  .menu-indicator .material-icons {
-    font-size: 10px;
+  /* Floating round buttons: overflow-menu trigger + GPS FAB share a common base */
+  .glass-fab,
+  .location-fab {
+    all: unset;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.82);
+    background: rgba(22, 22, 24, 0.62);
+    background-color: rgba(0, 0, 0, 0.60);
+    -webkit-backdrop-filter: blur(24px) saturate(140%);
+    backdrop-filter: blur(24px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+    transition: color 180ms ease, background-color 180ms ease, transform 120ms ease;
+    position: relative;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+  .glass-fab::before,
+  .location-fab::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(22, 22, 24, 0.28);
+    border-radius: inherit;
+    z-index: -1;
+  }
+  .glass-fab:hover,
+  .location-fab:hover { background-color: rgba(22, 22, 24, 0.78); }
+  .glass-fab:active,
+  .glass-fab.pressing,
+  .location-fab:active,
+  .location-fab.pressing { transform: scale(0.94); }
+  .glass-fab:focus-visible,
+  .location-fab:focus-visible { box-shadow: 0 0 0 2px var(--dark-primary-color); }
+  .glass-fab .material-icons { font-size: 20px; }
+
+  #menuButton[aria-expanded="true"] { color: var(--dark-primary-color); }
+
+  /* Location FAB: larger, bottom-right, sits above the time-control pill */
+  .location-fab {
+    position: fixed;
+    right: max(16px, env(safe-area-inset-right, 0px) + 16px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 16px);
+    width: 52px;
+    height: 52px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+    z-index: 100;
+  }
+  .location-fab .material-icons { font-size: 24px; }
+  .location-fab[aria-pressed="true"],
+  .location-fab.selectedButton {
+    color: var(--dark-primary-color);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4), inset 0 0 0 1.5px var(--dark-primary-color);
   }
 
-  .menu-spacer {
-    font-size: 7px;
-    line-height: 1;
-    visibility: hidden;
+  /* ========================================================================
+     Overflow menu (three-dots) — drops below top bar, anchored to menu button
+     ======================================================================== */
+  #overflowMenuBackdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 110;
+    display: none;
+  }
+  #overflowMenuBackdrop.open { display: block; }
+
+  #overflowMenu {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 8px + 52px + 10px);
+    right: max(12px, env(safe-area-inset-right, 0px) + 12px);
+    width: min(300px, calc(100vw - 24px));
+    z-index: 120;
+    background: rgba(22, 22, 24, 0.82);
+    -webkit-backdrop-filter: blur(24px) saturate(140%);
+    backdrop-filter: blur(24px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 16px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+    padding: 8px 0 12px;
+    transform-origin: top right;
+    transform: translateY(-8px) scale(0.96);
+    opacity: 0;
+    transition: opacity 180ms ease, transform 180ms ease;
+    pointer-events: none;
+    box-sizing: border-box;
+  }
+  #overflowMenu.open {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+  }
+  #overflowMenu[hidden] { display: none !important; }
+
+  #overflowMenu .menu-header {
+    padding: 6px 16px 4px;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dark-medium-emphasis-text-color);
   }
 
-  .menu-spacer .material-icons {
-    font-size: 10px;
+  #overflowMenu .menu-row {
+    display: flex;
+    align-items: center;
+    height: 48px;
+    padding: 0 16px;
+    gap: 14px;
+    cursor: pointer;
+    color: var(--dark-high-emphasis-text-color);
+    transition: background-color 120ms ease;
+    outline: none;
   }
+  #overflowMenu .menu-row:hover { background-color: rgba(255, 255, 255, 0.04); }
+  #overflowMenu .menu-row:focus-visible { background-color: rgba(255, 255, 255, 0.06); }
+  #overflowMenu .menu-row .material-icons {
+    font-size: 20px;
+    color: var(--dark-medium-emphasis-text-color);
+    flex-shrink: 0;
+  }
+  #overflowMenu .menu-row[aria-checked="true"] .material-icons {
+    color: var(--dark-primary-color);
+  }
+  #overflowMenu .menu-row .menu-label {
+    flex: 1;
+    font-size: 14px;
+    font-weight: 400;
+  }
+
+  #overflowMenu .switch {
+    width: 36px;
+    height: 22px;
+    border-radius: 11px;
+    background: rgba(255, 255, 255, 0.16);
+    position: relative;
+    transition: background 180ms ease;
+    flex-shrink: 0;
+  }
+  #overflowMenu .switch::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    transition: transform 180ms ease;
+  }
+  #overflowMenu .menu-row[aria-checked="true"] .switch {
+    background: var(--dark-primary-color);
+  }
+  #overflowMenu .menu-row[aria-checked="true"] .switch::after {
+    transform: translateX(14px);
+  }
+
+  #overflowMenu .menu-divider {
+    height: 1px;
+    background: rgba(255, 255, 255, 0.08);
+    margin: 6px 16px;
+  }
+
+  #overflowMenu .theme-chips {
+    display: flex;
+    gap: 6px;
+    padding: 4px 12px 6px;
+  }
+  #overflowMenu .chip {
+    all: unset;
+    flex: 1;
+    text-align: center;
+    padding: 8px 6px;
+    font-family: 'Roboto', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--dark-medium-emphasis-text-color);
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+  }
+  #overflowMenu .chip:hover { background: rgba(255, 255, 255, 0.1); }
+  #overflowMenu .chip[aria-checked="true"] {
+    background: var(--dark-primary-color-bg);
+    color: var(--dark-primary-color);
+    box-shadow: inset 0 0 0 1px rgba(18, 188, 250, 0.55);
+  }
+  #overflowMenu .chip:focus-visible {
+    box-shadow: 0 0 0 2px var(--dark-primary-color);
+  }
+
+  /* ========================================================================
+     Coachmark toast — shows Finnish layer name briefly on activation
+     ======================================================================== */
+  #coachmark {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 8px + 52px + 14px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 130;
+    padding: 6px 12px;
+    background: rgba(0, 0, 0, 0.85);
+    color: var(--dark-high-emphasis-text-color);
+    font-family: 'Roboto', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 12px;
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    opacity: 0;
+    transition: opacity 200ms ease;
+    pointer-events: none;
+    white-space: nowrap;
+  }
+  #coachmark.show { opacity: 1; }
+  #coachmark[hidden] { display: none; }
 
 
   #timecontrol {
@@ -294,7 +556,7 @@ html, body {
     }
 }
 
-#layersButton, #infoItemMap {
+#infoItemMap {
     display: none;
 }
 
@@ -331,12 +593,6 @@ html, body {
 
 .selectedButton {
     color: var(--dark-theme-on-surface);
-}
-
-.navbar > button.selectedButton {
-    color: var(--dark-theme-on-surface);
-    background-color: var(--dark-primary-color-bg);
-    border-bottom-color: var(--dark-primary-color);
 }
 
 .flexColumn {

--- a/design/toolbar-mockup.html
+++ b/design/toolbar-mockup.html
@@ -1,0 +1,1057 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>Säätutka — toolbar redesign mockup</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Material+Icons&display=swap">
+
+  <style>
+    :root {
+      /* Design tokens from the designer spec */
+      --glass-bg: rgba(22, 22, 24, 0.62);
+      --glass-bg-floor: rgba(0, 0, 0, 0.60);
+      --glass-border: rgba(255, 255, 255, 0.08);
+      --glass-border-strong: rgba(255, 255, 255, 0.14);
+      --glass-blur: blur(24px) saturate(140%);
+      --glass-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+      --elev-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+
+      --accent: #12BCFA;
+      --accent-fill: rgba(18, 188, 250, 0.22);
+      --accent-ring: rgba(18, 188, 250, 0.55);
+      --accent-soft: rgba(18, 188, 250, 0.14);
+
+      --icon-idle: rgba(255, 255, 255, 0.82);
+      --icon-dim: rgba(255, 255, 255, 0.60);
+      --text-hi: rgba(255, 255, 255, 0.92);
+      --text-md: rgba(255, 255, 255, 0.72);
+      --text-lo: rgba(255, 255, 255, 0.52);
+      --divider: rgba(255, 255, 255, 0.08);
+
+      --timecontrol-height: 84px;
+
+      /* Safe-area fallbacks for viewing on desktop */
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+    }
+
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0a0d;
+      color: var(--text-hi);
+      -webkit-font-smoothing: antialiased;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    i.material-icons { font-feature-settings: 'liga'; }
+    i.material-icons:before { display: none; } /* prevent flash */
+
+    button {
+      font-family: inherit;
+      -webkit-tap-highlight-color: transparent;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    /* ==================================================================
+       Backdrop scenes — simulate real map content for contrast testing
+       ================================================================== */
+    .backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      background-color: #0a0a0d;
+      transition: background 600ms ease, opacity 600ms ease;
+    }
+
+    /* Dark map tiles (default-like base layer) */
+    body[data-backdrop="map-dark"] .backdrop {
+      background:
+        radial-gradient(ellipse 900px 600px at 30% 40%, rgba(40, 60, 80, 0.35), transparent 60%),
+        radial-gradient(ellipse 700px 900px at 70% 80%, rgba(20, 40, 60, 0.3), transparent 60%),
+        linear-gradient(180deg, #0d1218 0%, #0a0e12 100%);
+    }
+    body[data-backdrop="map-dark"] .backdrop::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image:
+        repeating-linear-gradient(45deg, rgba(255,255,255,0.015) 0 2px, transparent 2px 120px),
+        repeating-linear-gradient(-30deg, rgba(255,255,255,0.02) 0 1px, transparent 1px 80px);
+      opacity: 0.9;
+    }
+
+    /* Night sky — pitch black */
+    body[data-backdrop="sky-dark"] .backdrop {
+      background:
+        radial-gradient(ellipse 400px 260px at 82% 18%, rgba(180, 200, 220, 0.12), transparent 70%),
+        linear-gradient(160deg, #04060a 0%, #000000 100%);
+    }
+
+    /* Bright radar precipitation — simulates active storm */
+    body[data-backdrop="radar-precip"] .backdrop {
+      background:
+        radial-gradient(circle 180px at 22% 38%, rgba(255, 30, 30, 0.72), rgba(255, 120, 40, 0.55) 45%, rgba(240, 200, 40, 0.4) 70%, transparent 100%),
+        radial-gradient(circle 240px at 30% 44%, rgba(140, 230, 80, 0.55), rgba(60, 180, 60, 0.35) 60%, transparent 100%),
+        radial-gradient(circle 220px at 68% 60%, rgba(255, 200, 40, 0.55), rgba(120, 200, 60, 0.35) 60%, transparent 100%),
+        radial-gradient(circle 300px at 75% 28%, rgba(60, 170, 60, 0.32), transparent 70%),
+        radial-gradient(ellipse 1200px 700px at 50% 50%, #10171f 0%, #06090d 100%);
+    }
+
+    /* Bright white snow satellite (HRV cloud-tops) */
+    body[data-backdrop="sat-snow"] .backdrop {
+      background:
+        radial-gradient(ellipse 500px 380px at 28% 32%, rgba(255,255,255,0.95), rgba(230,240,250,0.7) 50%, transparent 85%),
+        radial-gradient(ellipse 420px 300px at 72% 66%, rgba(250,252,255,0.92), rgba(210,225,240,0.65) 55%, transparent 90%),
+        radial-gradient(ellipse 300px 260px at 55% 22%, rgba(255,255,255,0.88), transparent 80%),
+        linear-gradient(180deg, #b6c7d6 0%, #8ba0b4 100%);
+    }
+
+    /* Natural RGB — greens and browns */
+    body[data-backdrop="sat-natural"] .backdrop {
+      background:
+        radial-gradient(ellipse 400px 320px at 30% 58%, rgba(80, 120, 70, 0.65), transparent 75%),
+        radial-gradient(ellipse 320px 260px at 65% 35%, rgba(170, 170, 160, 0.5), transparent 80%),
+        radial-gradient(ellipse 500px 300px at 70% 72%, rgba(120, 140, 100, 0.55), transparent 80%),
+        linear-gradient(170deg, #2f3a2a 0%, #1d2418 100%);
+    }
+
+    /* Faint "landmass" overlay for all but sky-dark for realism */
+    .landmass {
+      position: fixed;
+      inset: 0;
+      z-index: 1;
+      pointer-events: none;
+      opacity: 0.35;
+      transition: opacity 400ms ease;
+    }
+    body[data-backdrop="sky-dark"] .landmass { opacity: 0.1; }
+    body[data-backdrop="sat-snow"] .landmass { opacity: 0.18; }
+
+    /* ==================================================================
+       Primary top toolbar — segmented pill variant
+       ================================================================== */
+    #primaryToolbar {
+      position: fixed;
+      top: calc(var(--safe-top) + 12px);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      pointer-events: none; /* children re-enable */
+    }
+    #primaryToolbar > * { pointer-events: auto; }
+
+    /* Segmented pill */
+    .pill {
+      display: flex;
+      align-items: center;
+      height: 52px;
+      padding: 0;
+      border-radius: 26px;
+      background: var(--glass-bg);
+      background-color: var(--glass-bg-floor); /* fallback floor */
+      -webkit-backdrop-filter: var(--glass-blur);
+      backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow);
+      overflow: hidden;
+      position: relative;
+    }
+    /* Stacked glass + floor for guaranteed contrast */
+    .pill::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: rgba(22, 22, 24, 0.28);
+      z-index: -1;
+      border-radius: inherit;
+    }
+
+    .seg {
+      all: unset;
+      width: 62px;
+      height: 52px;
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      color: var(--icon-idle);
+      position: relative;
+      padding-top: 4px;
+      transition: color 180ms ease, background-color 180ms ease;
+      outline: none;
+    }
+    .seg + .seg::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 14px;
+      bottom: 14px;
+      width: 1px;
+      background: var(--divider);
+    }
+    .seg:hover { background-color: rgba(255, 255, 255, 0.04); }
+    .seg:focus-visible { box-shadow: inset 0 0 0 2px var(--accent); border-radius: 24px; }
+    .seg .material-icons { font-size: 22px; line-height: 1; }
+
+    /* Always-visible indicator bar: shows that the segment has a variant menu
+       and communicates active state. Dim when off, cyan+wider when on. */
+    .seg .indicator {
+      display: block;
+      width: 8px;
+      height: 2px;
+      margin-top: 6px;
+      border-radius: 1px;
+      background: rgba(255, 255, 255, 0.32);
+      transition: width 200ms ease, background-color 200ms ease, height 200ms ease;
+    }
+    .seg:not([data-has-variants="true"]) .indicator { visibility: hidden; }
+
+    /* Active state: soft fill + icon recolor + indicator turns cyan and grows */
+    .seg[aria-pressed="true"] {
+      color: var(--accent);
+    }
+    .seg[aria-pressed="true"]::after {
+      content: '';
+      position: absolute;
+      inset: 4px 3px;
+      background: var(--accent-fill);
+      border-radius: 22px;
+      z-index: -1;
+    }
+    .seg[aria-pressed="true"] .indicator {
+      background: var(--accent);
+      width: 16px;
+      height: 2px;
+    }
+    /* Hide divider either side of active segment so the fill reads as one pill */
+    .seg[aria-pressed="true"]::before,
+    .seg[aria-pressed="true"] + .seg::before {
+      background: transparent;
+    }
+
+    /* Menu trigger (three-dots) */
+    .glass-fab {
+      all: unset;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      color: var(--icon-idle);
+      background: var(--glass-bg);
+      background-color: var(--glass-bg-floor);
+      -webkit-backdrop-filter: var(--glass-blur);
+      backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow);
+      transition: color 180ms ease, background-color 180ms ease, transform 180ms ease;
+      position: relative;
+      overflow: hidden;
+    }
+    .glass-fab::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: rgba(22, 22, 24, 0.28);
+      z-index: -1;
+      border-radius: inherit;
+    }
+    .glass-fab:hover { background-color: rgba(22, 22, 24, 0.78); }
+    .glass-fab:active { transform: scale(0.94); }
+    .glass-fab .material-icons { font-size: 20px; }
+
+    #menuButton[aria-expanded="true"] {
+      color: var(--accent);
+    }
+
+    /* ==================================================================
+       Four-FAB variant (alternative layout)
+       ================================================================== */
+    #primaryToolbar[data-variant="fabs"] .pill { display: none; }
+    #primaryToolbar[data-variant="fabs"] .fab-row { display: flex; }
+    .fab-row {
+      display: none;
+      gap: 10px;
+      align-items: center;
+    }
+    .fab-row .fab-item {
+      all: unset;
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      color: var(--icon-idle);
+      background: var(--glass-bg);
+      background-color: var(--glass-bg-floor);
+      -webkit-backdrop-filter: var(--glass-blur);
+      backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--glass-shadow);
+      transition: color 180ms ease, background-color 180ms ease;
+      position: relative;
+    }
+    .fab-row .fab-item .material-icons { font-size: 22px; }
+    .fab-row .fab-item[aria-pressed="true"] {
+      color: var(--accent);
+      border-color: var(--accent-ring);
+      background-color: rgba(18, 188, 250, 0.14);
+      box-shadow: var(--glass-shadow), inset 0 0 0 1px var(--accent-ring);
+    }
+
+    /* ==================================================================
+       Overflow menu sheet
+       ================================================================== */
+    #overflowMenu {
+      position: fixed;
+      top: calc(var(--safe-top) + 12px + 52px + 10px); /* below pill */
+      right: max(16px, var(--safe-right) + 16px);
+      width: min(320px, calc(100vw - 32px));
+      z-index: 120;
+      background: var(--glass-bg);
+      background-color: rgba(22, 22, 24, 0.82);
+      -webkit-backdrop-filter: var(--glass-blur);
+      backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border-strong);
+      border-radius: 16px;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+      padding: 8px 0 12px;
+      transform-origin: top right;
+      transform: translateY(-8px) scale(0.96);
+      opacity: 0;
+      transition: opacity 180ms ease, transform 180ms ease;
+      pointer-events: none;
+    }
+    #overflowMenu.open {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      pointer-events: auto;
+    }
+    #overflowMenu[hidden] { display: none !important; }
+
+    .menu-header {
+      padding: 8px 16px 4px;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-lo);
+    }
+
+    .menu-row {
+      display: flex;
+      align-items: center;
+      height: 48px;
+      padding: 0 16px;
+      cursor: pointer;
+      gap: 14px;
+      color: var(--text-hi);
+      transition: background-color 120ms ease;
+    }
+    .menu-row:hover { background-color: rgba(255, 255, 255, 0.04); }
+    .menu-row .material-icons {
+      font-size: 20px;
+      color: var(--icon-dim);
+      flex-shrink: 0;
+    }
+    .menu-row[aria-checked="true"] .material-icons { color: var(--accent); }
+    .menu-label {
+      flex: 1;
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--text-hi);
+    }
+    .menu-row.disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+    .menu-row.disabled .menu-label { font-style: italic; }
+
+    /* iOS-style switch */
+    .switch {
+      width: 36px;
+      height: 22px;
+      border-radius: 11px;
+      background: rgba(255, 255, 255, 0.16);
+      position: relative;
+      transition: background 180ms ease;
+      flex-shrink: 0;
+    }
+    .switch::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: #fff;
+      transition: transform 180ms ease;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    }
+    .menu-row[aria-checked="true"] .switch {
+      background: var(--accent);
+    }
+    .menu-row[aria-checked="true"] .switch::after {
+      transform: translateX(14px);
+    }
+
+    .menu-divider {
+      height: 1px;
+      background: var(--divider);
+      margin: 6px 16px;
+    }
+
+    .theme-chips {
+      display: flex;
+      gap: 6px;
+      padding: 4px 16px 6px;
+    }
+    .chip {
+      all: unset;
+      flex: 1;
+      text-align: center;
+      padding: 8px 4px;
+      font-size: 13px;
+      font-weight: 500;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--text-md);
+      cursor: pointer;
+      transition: all 120ms ease;
+    }
+    .chip:hover { background: rgba(255, 255, 255, 0.1); }
+    .chip.active {
+      background: var(--accent-fill);
+      color: var(--accent);
+      box-shadow: inset 0 0 0 1px var(--accent-ring);
+    }
+
+    /* Menu backdrop (invisible, catches outside clicks) */
+    #menuBackdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 110;
+      display: none;
+    }
+    #menuBackdrop.open { display: block; }
+
+    /* ==================================================================
+       Bottom time-control pill (kept roughly as today, shown for spatial
+       context)
+       ================================================================== */
+    #timecontrol {
+      position: fixed;
+      left: 50%;
+      bottom: calc(var(--safe-bottom) + 8px);
+      transform: translateX(-50%);
+      width: min(calc(100vw - 24px), 460px);
+      z-index: 100;
+      background: var(--glass-bg);
+      background-color: rgba(0, 0, 0, 0.72);
+      -webkit-backdrop-filter: var(--glass-blur);
+      backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      border-radius: 14px;
+      box-shadow: var(--glass-shadow);
+      padding: 8px 10px 6px;
+    }
+
+    .playbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 4px;
+      color: var(--text-hi);
+    }
+    .playbar > button {
+      all: unset;
+      flex: 1;
+      min-height: 40px;
+      text-align: center;
+      color: var(--icon-idle);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    .playbar > button:hover { background: rgba(255, 255, 255, 0.05); }
+    .playbar > button .material-icons { font-size: 22px; }
+    .playbar > button.primary .material-icons { font-size: 26px; color: var(--text-hi); }
+    .time-block {
+      flex: 1;
+      text-align: center;
+      min-width: 72px;
+      padding: 0 6px;
+    }
+    .time-h { font-size: 17px; font-weight: 500; color: var(--text-hi); line-height: 1.1; }
+    .time-d { font-size: 11px; color: var(--text-md); }
+
+    .timeline {
+      display: flex;
+      width: 100%;
+      margin-top: 6px;
+      gap: 1px;
+    }
+    .timeline > div {
+      flex: 1;
+      height: 4px;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 2px;
+    }
+    .timeline > div.loaded { background: rgba(255, 255, 255, 0.22); }
+    .timeline > div.current { background: var(--accent); }
+
+    /* ==================================================================
+       GPS FAB (bottom-right, above time-control)
+       ================================================================== */
+    #locationFab {
+      position: fixed;
+      right: max(16px, var(--safe-right) + 16px);
+      bottom: calc(var(--safe-bottom) + var(--timecontrol-height) + 16px);
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      color: var(--icon-idle);
+      background: var(--glass-bg);
+      background-color: var(--glass-bg-floor);
+      -webkit-backdrop-filter: var(--glass-blur);
+      backdrop-filter: var(--glass-blur);
+      border: 1px solid var(--glass-border);
+      box-shadow: var(--elev-shadow);
+      z-index: 100;
+      transition: all 220ms ease;
+      padding: 0;
+    }
+    #locationFab .material-icons { font-size: 24px; }
+    #locationFab[data-state="following"] {
+      color: var(--accent);
+      box-shadow: var(--elev-shadow), inset 0 0 0 1.5px var(--accent);
+    }
+    #locationFab[data-state="tracking"] {
+      background-color: var(--accent);
+      color: #0a0a0a;
+      border-color: var(--accent);
+      box-shadow: var(--elev-shadow), 0 0 0 6px rgba(18, 188, 250, 0.18);
+    }
+    #locationFab:active { transform: scale(0.94); }
+
+    /* ==================================================================
+       Coachmark toast (onboarding the Finnish name)
+       ================================================================== */
+    #coachmark {
+      position: fixed;
+      top: calc(var(--safe-top) + 12px + 52px + 14px);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 130;
+      padding: 6px 12px;
+      background: rgba(0, 0, 0, 0.85);
+      color: var(--text-hi);
+      font-size: 13px;
+      font-weight: 500;
+      border-radius: 12px;
+      -webkit-backdrop-filter: blur(16px);
+      backdrop-filter: blur(16px);
+      border: 1px solid var(--glass-border);
+      opacity: 0;
+      transition: opacity 200ms ease, transform 200ms ease;
+      pointer-events: none;
+      white-space: nowrap;
+    }
+    #coachmark.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+    #coachmark[hidden] { display: none; }
+
+    /* ==================================================================
+       Dev panel (mockup-only — not part of the design)
+       ================================================================== */
+    .dev-panel {
+      position: fixed;
+      left: max(12px, var(--safe-left) + 12px);
+      top: max(12px, var(--safe-top) + 12px);
+      z-index: 200;
+      width: 240px;
+      background: rgba(12, 12, 16, 0.92);
+      border: 1px solid var(--glass-border-strong);
+      border-radius: 12px;
+      color: var(--text-hi);
+      font-size: 12px;
+      box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+    }
+    .dev-panel header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      font-size: 10px;
+      color: var(--text-md);
+      border-bottom: 1px solid var(--divider);
+    }
+    .dev-panel header button {
+      all: unset;
+      cursor: pointer;
+      width: 20px;
+      height: 20px;
+      text-align: center;
+      border-radius: 4px;
+      color: var(--text-md);
+    }
+    .dev-panel header button:hover { background: rgba(255,255,255,0.06); }
+    .dev-panel .dev-body { padding: 10px 12px 12px; display: flex; flex-direction: column; gap: 10px; }
+    .dev-panel.collapsed .dev-body { display: none; }
+    .dev-panel label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 11px;
+      color: var(--text-md);
+    }
+    .dev-panel label.check {
+      flex-direction: row;
+      align-items: center;
+      gap: 8px;
+    }
+    .dev-panel select, .dev-panel input[type="text"] {
+      font-family: inherit;
+      padding: 6px 8px;
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--text-hi);
+      border: 1px solid var(--divider);
+      font-size: 12px;
+    }
+    .dev-panel input[type="checkbox"] {
+      accent-color: var(--accent);
+    }
+    .dev-hint {
+      margin: 0;
+      font-size: 10px;
+      color: var(--text-lo);
+      line-height: 1.4;
+    }
+
+    /* ==================================================================
+       Annotation overlay
+       ================================================================== */
+    #annotations {
+      position: fixed;
+      inset: 0;
+      z-index: 150;
+      pointer-events: none;
+    }
+    #annotations[hidden] { display: none; }
+    .anno {
+      position: absolute;
+      font-size: 11px;
+      color: var(--accent);
+      background: rgba(10, 10, 14, 0.92);
+      border: 1px dashed var(--accent-ring);
+      padding: 4px 8px;
+      border-radius: 6px;
+      line-height: 1.35;
+      max-width: 200px;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    }
+    .anno::before {
+      content: '';
+      position: absolute;
+      width: 1px;
+      height: 24px;
+      background: var(--accent-ring);
+    }
+    .anno[data-side="top"]::before { top: -24px; left: 50%; }
+    .anno[data-side="right"]::before { top: 50%; right: -24px; height: 1px; width: 24px; }
+    .anno[data-side="left"]::before { top: 50%; left: -24px; height: 1px; width: 24px; }
+
+    /* ==================================================================
+       Narrow-landscape crowd-check helper
+       ================================================================== */
+    @media (max-height: 420px) and (orientation: landscape) {
+      :root { --timecontrol-height: 68px; }
+      .dev-panel { width: 180px; }
+    }
+
+    /* Reduce motion */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+
+<body data-backdrop="map-dark">
+
+  <!-- Backdrop scenes -->
+  <div class="backdrop"></div>
+  <svg class="landmass" viewBox="0 0 1000 700" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+    <!-- Stylised Finland/Baltic silhouette -->
+    <path d="M520 40 L560 80 L600 120 L640 180 L660 260 L690 340 L720 420 L700 500 L660 560 L600 600 L520 620 L460 600 L420 560 L410 480 L430 400 L460 320 L450 240 L440 160 L470 90 Z"
+      fill="rgba(255,255,255,0.10)" stroke="rgba(255,255,255,0.18)" stroke-width="1"/>
+    <path d="M240 380 L300 400 L340 430 L320 480 L270 490 L220 460 L210 420 Z"
+      fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)" stroke-width="1"/>
+  </svg>
+
+  <!-- Primary toolbar -->
+  <nav id="primaryToolbar" data-variant="pill" aria-label="Karttatasot">
+    <div class="pill" role="toolbar">
+      <button class="seg" aria-pressed="false" data-layer="sat" data-name="Satelliitti" data-has-variants="true">
+        <i class="material-icons" aria-hidden="true">satellite_alt</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+      <button class="seg" aria-pressed="true" data-layer="radar" data-name="Säätutka" data-has-variants="true">
+        <i class="material-icons" aria-hidden="true">radar</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+      <button class="seg" aria-pressed="false" data-layer="lightning" data-name="Salamat" data-has-variants="true">
+        <i class="material-icons" aria-hidden="true">bolt</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+      <button class="seg" aria-pressed="false" data-layer="obs" data-name="Havainto" data-has-variants="true">
+        <i class="material-icons" aria-hidden="true">thermostat</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+    </div>
+    <div class="fab-row">
+      <button class="fab-item" aria-pressed="false" data-layer="sat" data-name="Satelliitti">
+        <i class="material-icons" aria-hidden="true">satellite_alt</i>
+      </button>
+      <button class="fab-item" aria-pressed="true" data-layer="radar" data-name="Säätutka">
+        <i class="material-icons" aria-hidden="true">radar</i>
+      </button>
+      <button class="fab-item" aria-pressed="false" data-layer="lightning" data-name="Salamat">
+        <i class="material-icons" aria-hidden="true">bolt</i>
+      </button>
+      <button class="fab-item" aria-pressed="false" data-layer="obs" data-name="Havainto">
+        <i class="material-icons" aria-hidden="true">thermostat</i>
+      </button>
+    </div>
+    <button id="menuButton" class="glass-fab" aria-haspopup="menu" aria-expanded="false" aria-controls="overflowMenu" aria-label="Valikko">
+      <i class="material-icons" aria-hidden="true">more_horiz</i>
+    </button>
+  </nav>
+
+  <!-- Overflow menu -->
+  <div id="menuBackdrop" aria-hidden="true"></div>
+  <div id="overflowMenu" role="menu" hidden>
+    <div class="menu-header">Karttakohteet</div>
+    <div class="menu-row" role="menuitemcheckbox" aria-checked="true" data-poi="radars" tabindex="0">
+      <i class="material-icons" aria-hidden="true">cell_tower</i>
+      <span class="menu-label">Tutka-asemat</span>
+      <span class="switch" aria-hidden="true"></span>
+    </div>
+    <div class="menu-row" role="menuitemcheckbox" aria-checked="true" data-poi="airfields" tabindex="0">
+      <i class="material-icons" aria-hidden="true">flight</i>
+      <span class="menu-label">Lentokentät</span>
+      <span class="switch" aria-hidden="true"></span>
+    </div>
+    <div class="menu-row disabled" aria-disabled="true">
+      <i class="material-icons" aria-hidden="true">add_location_alt</i>
+      <span class="menu-label">Lisää kohteita tulossa…</span>
+    </div>
+    <div class="menu-divider"></div>
+    <div class="menu-header">Teema</div>
+    <div class="theme-chips" role="radiogroup" aria-label="Teema">
+      <button class="chip active" role="radio" aria-checked="true">Autom.</button>
+      <button class="chip" role="radio" aria-checked="false">Tumma</button>
+      <button class="chip" role="radio" aria-checked="false">Vaalea</button>
+    </div>
+  </div>
+
+  <!-- Bottom time control (shown for spatial context) -->
+  <div id="timecontrol" aria-label="Ajan hallinta">
+    <div class="playbar">
+      <button aria-label="Tasot"><i class="material-icons" aria-hidden="true">layers</i></button>
+      <button aria-label="Nopeus">1×</button>
+      <button aria-label="Edellinen"><i class="material-icons" aria-hidden="true">skip_previous</i></button>
+      <button class="primary" aria-label="Toista"><i class="material-icons" aria-hidden="true">play_arrow</i></button>
+      <button aria-label="Seuraava"><i class="material-icons" aria-hidden="true">skip_next</i></button>
+      <div class="time-block">
+        <div class="time-h">12:45</div>
+        <div class="time-d">Ke 23.4.</div>
+      </div>
+    </div>
+    <div class="timeline" id="timelineEl"></div>
+  </div>
+
+  <!-- GPS FAB -->
+  <button id="locationFab" data-state="off" aria-pressed="false" aria-label="Paikannus">
+    <i class="material-icons" aria-hidden="true">gps_not_fixed</i>
+  </button>
+
+  <!-- Coachmark toast -->
+  <div id="coachmark" hidden></div>
+
+  <!-- Annotation overlay -->
+  <div id="annotations" hidden>
+    <div class="anno" style="top: 14px; left: 50%; transform: translateX(-50%); margin-top: 76px;" data-side="top">
+      Segmenttipilleri — 52&nbsp;px korkea, glass-bg 0.62, blur 24&nbsp;px. Indikaattoriviiva aina näkyvissä: 8×2&nbsp;px harmaa → 16×2&nbsp;px syaani kun aktiivinen. Lisäksi aktiivinen saa pehmeän täytön ja värivaihdon.
+    </div>
+    <div class="anno" style="top: 14px; right: 12px; margin-top: 66px;" data-side="top">
+      Kolmipiste → "Karttakohteet" valikko (POI-kytkimet + teema)
+    </div>
+    <div class="anno" style="right: 80px; bottom: 120px;" data-side="right">
+      GPS-FAB 52&nbsp;px, kelluu aikapalkin yläpuolella; tilat off / following / tracking
+    </div>
+    <div class="anno" style="left: 50%; bottom: 104px; transform: translateX(-50%);" data-side="top">
+      Aikapalkki pysyy (hieman keveämpänä): pelkkä glass-kontti ilman hallitsevaa reunaa
+    </div>
+  </div>
+
+  <!-- Dev panel (mockup-only controls) -->
+  <aside class="dev-panel" id="devPanel">
+    <header>
+      <span>Mockup — toolbar</span>
+      <button id="devToggle" aria-label="Pienennä">−</button>
+    </header>
+    <div class="dev-body">
+      <label>Kartan tausta
+        <select id="backdropSelect">
+          <option value="map-dark">Tumma karttapohja</option>
+          <option value="sky-dark">Yötaivas (musta)</option>
+          <option value="radar-precip">Tutkakaiut (värikäs)</option>
+          <option value="sat-snow">Lumipilvet (HRV)</option>
+          <option value="sat-natural">Natural RGB</option>
+        </select>
+      </label>
+      <label>Yläpalkin tyyli
+        <select id="layoutSelect">
+          <option value="pill">Segmenttipilleri (suositus)</option>
+          <option value="fabs">Neljä erillistä nappia</option>
+        </select>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="menuCheckbox"> Valikko auki
+      </label>
+      <label class="check">
+        <input type="checkbox" id="annotationToggle"> Näytä merkinnät
+      </label>
+      <p class="dev-hint">Napsauta segmenttejä vaihtaaksesi aktiivista tasoa. Napsauta GPS-FAB:a kiertääksesi tiloja (off → following → tracking). Kaksoisnapsauta segmenttiä nähdäksesi coachmark-viestin.</p>
+    </div>
+  </aside>
+
+  <script>
+    (function () {
+      'use strict';
+
+      // ======================================================
+      // Timeline cells (13 slots, current = middle)
+      // ======================================================
+      (function buildTimeline() {
+        var el = document.getElementById('timelineEl');
+        for (var i = 0; i < 13; i++) {
+          var c = document.createElement('div');
+          if (i < 11) c.classList.add('loaded');
+          if (i === 9) c.classList.add('current');
+          el.appendChild(c);
+        }
+      })();
+
+      // ======================================================
+      // Backdrop switcher
+      // ======================================================
+      var backdropSelect = document.getElementById('backdropSelect');
+      backdropSelect.addEventListener('change', function (e) {
+        document.body.setAttribute('data-backdrop', e.target.value);
+      });
+
+      // ======================================================
+      // Layout variant switcher (pill vs four FABs)
+      // ======================================================
+      var layoutSelect = document.getElementById('layoutSelect');
+      var toolbar = document.getElementById('primaryToolbar');
+      layoutSelect.addEventListener('change', function (e) {
+        toolbar.setAttribute('data-variant', e.target.value);
+      });
+
+      // ======================================================
+      // Segment / FAB toggle behavior + coachmark
+      // Tap: toggles aria-pressed (mirrors the real tap-toggle semantic)
+      // ======================================================
+      var coachmark = document.getElementById('coachmark');
+      var coachTimer = null;
+      function showCoachmark(text) {
+        coachmark.textContent = text;
+        coachmark.hidden = false;
+        // force reflow for the transition
+        void coachmark.offsetWidth;
+        coachmark.classList.add('show');
+        clearTimeout(coachTimer);
+        coachTimer = setTimeout(function () {
+          coachmark.classList.remove('show');
+          setTimeout(function () { coachmark.hidden = true; }, 220);
+        }, 1400);
+      }
+
+      function bindLayerButton(btn) {
+        btn.addEventListener('click', function () {
+          var pressed = btn.getAttribute('aria-pressed') === 'true';
+          btn.setAttribute('aria-pressed', pressed ? 'false' : 'true');
+          // Show the Finnish name as onboarding toast the first time (and here on every tap for demo)
+          var name = btn.getAttribute('data-name');
+          if (name) showCoachmark(name);
+        });
+      }
+      document.querySelectorAll('.seg').forEach(bindLayerButton);
+      document.querySelectorAll('.fab-item').forEach(bindLayerButton);
+
+      // ======================================================
+      // Overflow menu open/close
+      // ======================================================
+      var menuButton = document.getElementById('menuButton');
+      var menu = document.getElementById('overflowMenu');
+      var menuBackdrop = document.getElementById('menuBackdrop');
+      var menuCheckbox = document.getElementById('menuCheckbox');
+
+      function openMenu() {
+        menu.hidden = false;
+        // force reflow for the transition
+        void menu.offsetWidth;
+        menu.classList.add('open');
+        menuBackdrop.classList.add('open');
+        menuButton.setAttribute('aria-expanded', 'true');
+        menuCheckbox.checked = true;
+      }
+      function closeMenu() {
+        menu.classList.remove('open');
+        menuBackdrop.classList.remove('open');
+        menuButton.setAttribute('aria-expanded', 'false');
+        menuCheckbox.checked = false;
+        setTimeout(function () { if (!menu.classList.contains('open')) menu.hidden = true; }, 200);
+      }
+
+      menuButton.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (menu.classList.contains('open')) closeMenu(); else openMenu();
+      });
+      menuBackdrop.addEventListener('click', closeMenu);
+      menuCheckbox.addEventListener('change', function (e) {
+        if (e.target.checked) openMenu(); else closeMenu();
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+          if (menu.classList.contains('open')) { closeMenu(); menuButton.focus(); }
+        }
+      });
+
+      // ======================================================
+      // POI toggle rows
+      // ======================================================
+      document.querySelectorAll('.menu-row[role="menuitemcheckbox"]').forEach(function (row) {
+        row.addEventListener('click', function () {
+          var checked = row.getAttribute('aria-checked') === 'true';
+          row.setAttribute('aria-checked', checked ? 'false' : 'true');
+        });
+        row.addEventListener('keydown', function (e) {
+          if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            row.click();
+          }
+        });
+      });
+
+      // Theme chips (radiogroup)
+      var chips = document.querySelectorAll('.theme-chips .chip');
+      chips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+          chips.forEach(function (c) {
+            c.classList.remove('active');
+            c.setAttribute('aria-checked', 'false');
+          });
+          chip.classList.add('active');
+          chip.setAttribute('aria-checked', 'true');
+        });
+      });
+
+      // ======================================================
+      // GPS FAB state cycle: off → following → tracking → off
+      // ======================================================
+      var fab = document.getElementById('locationFab');
+      var fabIcon = fab.querySelector('.material-icons');
+      var stateOrder = ['off', 'following', 'tracking'];
+      var iconMap = {
+        off: 'gps_not_fixed',
+        following: 'gps_fixed',
+        tracking: 'near_me'
+      };
+      fab.addEventListener('click', function () {
+        var cur = fab.getAttribute('data-state');
+        var next = stateOrder[(stateOrder.indexOf(cur) + 1) % stateOrder.length];
+        fab.setAttribute('data-state', next);
+        fab.setAttribute('aria-pressed', next === 'off' ? 'false' : 'true');
+        fabIcon.textContent = iconMap[next];
+      });
+
+      // ======================================================
+      // Dev panel collapse
+      // ======================================================
+      var devPanel = document.getElementById('devPanel');
+      var devToggle = document.getElementById('devToggle');
+      devToggle.addEventListener('click', function () {
+        var collapsed = devPanel.classList.toggle('collapsed');
+        devToggle.textContent = collapsed ? '+' : '−';
+      });
+
+      // Annotation overlay toggle
+      var annoToggle = document.getElementById('annotationToggle');
+      var annoLayer = document.getElementById('annotations');
+      annoToggle.addEventListener('change', function (e) {
+        annoLayer.hidden = !e.target.checked;
+      });
+
+      // ======================================================
+      // Keyboard shortcuts demo (1/2/3/4)
+      // ======================================================
+      document.addEventListener('keydown', function (e) {
+        if (e.target.matches('input, select, textarea')) return;
+        var map = { '1': 'sat', '2': 'radar', '3': 'lightning', '4': 'obs' };
+        var layer = map[e.key];
+        if (!layer) return;
+        // Toggle whichever variant is currently visible
+        var visible = toolbar.getAttribute('data-variant');
+        var selector = visible === 'pill' ? '.seg' : '.fab-item';
+        var btn = toolbar.querySelector(selector + '[data-layer="' + layer + '"]');
+        if (btn) btn.click();
+      });
+
+    })();
+  </script>
+</body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -63,16 +63,49 @@
 </head>
 
 <body>
-  <nav class="toolbar navbar noselect">
-    <button id="locationLayerButton" aria-label="Paikannus" aria-pressed="false"><i id="gpsStatus" class="material-icons">gps_not_fixed</i><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
-    <button id="mapLayerButton" aria-label="Karttapohja" aria-pressed="false"><i class="material-icons">brightness_2</i><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
-    <button id="satelliteLayerButton" aria-label="Satelliitti" aria-pressed="false" aria-haspopup="menu"><i class="material-icons">satellite</i><span class="btn-label">Satelliitti</span><span class="menu-indicator"><i class="material-icons">expand_more</i></span></button>
-    <button id="radarLayerButton" class="selectedButton" aria-pressed="true" aria-haspopup="menu"><i class="material-icons">filter_tilt_shift</i><span class="btn-label">Säätutka</span><span class="menu-indicator"><i class="material-icons">expand_more</i></span></button>
-    <button id="lightningLayerButton" aria-pressed="false"><i class="material-icons">flash_on</i><span class="btn-label">Salamat</span><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
-    <button id="observationLayerButton" aria-label="Havainto" aria-pressed="false" aria-haspopup="menu"><i class="material-icons">place</i><span class="btn-label">Havainto</span><span class="menu-indicator"><i class="material-icons">expand_more</i></span></button>
-    <button id="layersButton" aria-label="Lisää tasoja"><i class="material-icons">more_vert</i><span class="menu-spacer" aria-hidden="true"><i class="material-icons">expand_more</i></span></button>
+  <nav id="primaryToolbar" class="noselect" aria-label="Karttatasot">
+    <div class="pill" role="toolbar">
+      <button id="satelliteLayerButton" class="seg" aria-pressed="false" aria-label="Satelliitti" aria-haspopup="menu" data-name="Satelliitti">
+        <i class="material-icons" aria-hidden="true">satellite_alt</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+      <button id="radarLayerButton" class="seg selectedButton" aria-pressed="true" aria-label="Säätutka" aria-haspopup="menu" data-name="Säätutka">
+        <i class="material-icons" aria-hidden="true">radar</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+      <button id="lightningLayerButton" class="seg" aria-pressed="false" aria-label="Salamat" data-name="Salamat">
+        <i class="material-icons" aria-hidden="true">bolt</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+      <button id="observationLayerButton" class="seg" aria-pressed="false" aria-label="Havainto" aria-haspopup="menu" data-name="Havainto">
+        <i class="material-icons" aria-hidden="true">thermostat</i>
+        <span class="indicator" aria-hidden="true"></span>
+      </button>
+    </div>
+    <button id="menuButton" class="glass-fab" aria-haspopup="menu" aria-expanded="false" aria-controls="overflowMenu" aria-label="Valikko">
+      <i class="material-icons" aria-hidden="true">more_horiz</i>
+    </button>
   </nav>
-  
+
+  <div id="overflowMenuBackdrop"></div>
+  <div id="overflowMenu" role="menu" hidden>
+    <div class="menu-header">Karttakohteet</div>
+    <div id="poiList"></div>
+    <div class="menu-divider"></div>
+    <div class="menu-header">Teema</div>
+    <div class="theme-chips" role="radiogroup" aria-label="Teema">
+      <button class="chip" role="radio" aria-checked="false" data-theme="auto">Automaattinen</button>
+      <button class="chip" role="radio" aria-checked="false" data-theme="dark">Tumma</button>
+      <button class="chip" role="radio" aria-checked="false" data-theme="light">Vaalea</button>
+    </div>
+  </div>
+
+  <button id="locationLayerButton" class="location-fab noselect" aria-pressed="false" aria-label="Paikannus">
+    <i id="gpsStatus" class="material-icons" aria-hidden="true">gps_not_fixed</i>
+  </button>
+
+  <div id="coachmark" aria-live="polite" hidden></div>
+
   <div id="map"></div>
  
   <div id="infopanel" class="noselect">

--- a/src/radar.js
+++ b/src/radar.js
@@ -104,7 +104,6 @@ if (ACTIVE.has('suomi_dbz_eureffin')) {
 }
 // IS_DARK: null = auto (follow OS), true = user picked dark, false = user picked light
 let IS_DARK = safeParseJSON('IS_DARK', null);
-let currentMapTheme = 'dark';
 let IS_TRACKING = safeParseJSON('IS_TRACKING', false);
 let IS_FOLLOWING = safeParseJSON('IS_FOLLOWING', false);
 let IS_NAUTICAL = safeParseJSON('IS_NAUTICAL', false);
@@ -355,7 +354,7 @@ const icaoLayer = new VectorLayer({
     format: new GeoJSON(),
     url: 'airfields-finland.json',
   }),
-  visible: true,
+  visible: false,
   style(feature) {
     icaoStyle.getText().setText(feature.get('icao'));
     return icaoStyle;
@@ -734,10 +733,8 @@ function setMapLayer(maplayer) {
       darkGrayReferenceLayer.setVisible(false);
       lightGrayBaseLayer.setVisible(true);
       lightGrayReferenceLayer.setVisible(true);
-      currentMapTheme = 'light';
       darkBaseEl.classList.remove('selected');
       lightBaseEl.classList.add('selected');
-      setButtonState('mapLayerButton', false);
       track('theme-light');
       break;
     case 'dark':
@@ -745,10 +742,8 @@ function setMapLayer(maplayer) {
       darkGrayReferenceLayer.setVisible(true);
       lightGrayBaseLayer.setVisible(false);
       lightGrayReferenceLayer.setVisible(false);
-      currentMapTheme = 'dark';
       lightBaseEl.classList.remove('selected');
       darkBaseEl.classList.add('selected');
-      setButtonState('mapLayerButton', true);
       track('theme-dark');
       break;
     default:
@@ -756,10 +751,30 @@ function setMapLayer(maplayer) {
   }
 }
 
-function setUserTheme(maplayer) {
-  IS_DARK = maplayer === 'dark';
-  localStorage.setItem('IS_DARK', JSON.stringify(IS_DARK));
-  setMapLayer(maplayer);
+function getThemeMode() {
+  if (IS_DARK === null) return 'auto';
+  return IS_DARK ? 'dark' : 'light';
+}
+
+function updateThemeChipsState() {
+  const mode = getThemeMode();
+  document.querySelectorAll('#overflowMenu .chip[data-theme]').forEach((chip) => {
+    const match = chip.getAttribute('data-theme') === mode;
+    chip.setAttribute('aria-checked', String(match));
+  });
+}
+
+function setUserTheme(mode) {
+  if (mode === 'auto') {
+    IS_DARK = null;
+    localStorage.removeItem('IS_DARK');
+    setMapLayer(getEffectiveTheme());
+  } else {
+    IS_DARK = mode === 'dark';
+    localStorage.setItem('IS_DARK', JSON.stringify(IS_DARK));
+    setMapLayer(mode);
+  }
+  updateThemeChipsState();
 }
 
 document.getElementById('darkBase').addEventListener('mouseup', () => {
@@ -1047,6 +1062,10 @@ function onChangeVisible(event) {
       document.getElementById(wmslayer).classList.add('selected');
     }
     setButtonState(`${name}Button`, true);
+    const segEl = document.getElementById(`${name}Button`);
+    if (segEl && typeof showCoachmark === 'function') {
+      showCoachmark(segEl.getAttribute('data-name'));
+    }
     document.getElementById(`${name}Info`).classList.remove('playListDisabled');
     const toggleIcon = document.querySelector(`#${name}Info .card-visibility-toggle .material-icons`);
     if (toggleIcon) toggleIcon.textContent = 'visibility';
@@ -1156,15 +1175,6 @@ window.addEventListener('mouseup', (e) => {
     closePlaylist();
   }
 
-  // Layers
-  if (!document.getElementById('layers').contains(e.target)) {
-    if (document.getElementById('layersButton').contains(e.target)) return;
-    const elem = document.getElementById('layers');
-    // if (elem.style.display === 'block') {
-    elem.style.display = 'none';
-    // }
-  }
-
   // Close long-press menus when clicking/touching outside
   const longPressMenus = [
     { menuId: 'observationLongPressMenu', buttonId: 'observationLayerButton' },
@@ -1201,15 +1211,15 @@ function setButtonState(id, active) {
 
 function setButtonStates() {
   setButtonState('locationLayerButton', IS_TRACKING);
-  setButtonState('mapLayerButton', currentMapTheme === 'dark');
   setButtonState('satelliteLayerButton', VISIBLE.has('satelliteLayer'));
   setButtonState('radarLayerButton', VISIBLE.has('radarLayer'));
   setButtonState('lightningLayerButton', VISIBLE.has('lightningLayer'));
   setButtonState('observationLayerButton', VISIBLE.has('observationLayer'));
+  updateThemeChipsState();
 }
 
-// Press feedback for all navbar buttons
-document.querySelectorAll('.navbar > button').forEach((btn) => {
+// Press feedback for all floating controls
+document.querySelectorAll('.pill .seg, #menuButton, .location-fab').forEach((btn) => {
   function addPress() { btn.classList.add('pressing'); }
   function removePress() { btn.classList.remove('pressing'); }
   btn.addEventListener('mousedown', addPress);
@@ -1243,10 +1253,6 @@ document.getElementById('locationLayerButton').addEventListener('mouseup', () =>
 document.getElementById('cursorDistanceTxt').addEventListener('mouseup', () => {
   IS_NAUTICAL = !IS_NAUTICAL;
   localStorage.setItem('IS_NAUTICAL', JSON.stringify(IS_NAUTICAL));
-});
-
-document.getElementById('mapLayerButton').addEventListener('mouseup', () => {
-  setUserTheme(currentMapTheme === 'dark' ? 'light' : 'dark');
 });
 
 document.getElementById('radarLayerTitle').addEventListener('mouseup', () => {
@@ -1289,14 +1295,176 @@ const radarMenu = createLongPressHandler(
   () => radarLayer.getVisible(),
 );
 
-document.getElementById('layersButton').addEventListener('mouseup', () => {
-  const div = document.getElementById('layers');
-  if (div.style.display === 'none') {
-    div.style.display = 'grid';
-  } else {
-    div.style.display = 'none';
-  }
+// Overflow menu (three-dots) — open/close + theme chip wiring
+const overflowMenuEl = document.getElementById('overflowMenu');
+const overflowBackdropEl = document.getElementById('overflowMenuBackdrop');
+const menuButtonEl = document.getElementById('menuButton');
+
+function openOverflowMenu() {
+  overflowMenuEl.hidden = false;
+  // force reflow so the CSS transition runs from the initial state
+  overflowMenuEl.getBoundingClientRect();
+  overflowMenuEl.classList.add('open');
+  overflowBackdropEl.classList.add('open');
+  menuButtonEl.setAttribute('aria-expanded', 'true');
+  updateThemeChipsState();
+  updatePoiMenuState();
+}
+
+function closeOverflowMenu() {
+  overflowMenuEl.classList.remove('open');
+  overflowBackdropEl.classList.remove('open');
+  menuButtonEl.setAttribute('aria-expanded', 'false');
+  setTimeout(() => {
+    if (!overflowMenuEl.classList.contains('open')) overflowMenuEl.hidden = true;
+  }, 200);
+}
+
+menuButtonEl.addEventListener('mouseup', () => {
+  if (overflowMenuEl.classList.contains('open')) closeOverflowMenu();
+  else openOverflowMenu();
 });
+
+overflowBackdropEl.addEventListener('mouseup', closeOverflowMenu);
+
+window.addEventListener('mouseup', (e) => {
+  if (!overflowMenuEl.classList.contains('open')) return;
+  if (overflowMenuEl.contains(e.target)) return;
+  if (menuButtonEl.contains(e.target)) return;
+  closeOverflowMenu();
+});
+
+document.querySelectorAll('#overflowMenu .chip[data-theme]').forEach((chip) => {
+  chip.addEventListener('mouseup', () => {
+    setUserTheme(chip.getAttribute('data-theme'));
+  });
+});
+
+// POI layers — map features that users can toggle independently of data layers.
+// Adding a future POI = one entry in this registry; the overflow menu row and
+// localStorage persistence fall out automatically.
+const poiRegistry = [
+  {
+    id: 'radars',
+    label: 'Tutka-asemat',
+    icon: 'cell_tower',
+    defaultOn: true,
+    layerRef: () => radarSiteLayer,
+  },
+  {
+    id: 'airfields',
+    label: 'Lentokentät',
+    icon: 'flight',
+    defaultOn: false,
+    layerRef: () => icaoLayer,
+  },
+];
+
+// POI_STATE is reconciled against the current registry on every load: unknown
+// persisted keys are dropped, and new registry entries fall back to defaultOn.
+const POI_STATE = (() => {
+  const persisted = safeParseJSON('POI_STATE', null) || {};
+  const state = {};
+  poiRegistry.forEach((entry) => {
+    state[entry.id] = Object.prototype.hasOwnProperty.call(persisted, entry.id)
+      ? !!persisted[entry.id]
+      : entry.defaultOn;
+  });
+  return state;
+})();
+
+function persistPoiState() {
+  localStorage.setItem('POI_STATE', JSON.stringify(POI_STATE));
+}
+
+function applyPoiVisibility() {
+  poiRegistry.forEach((entry) => {
+    entry.layerRef().setVisible(!!POI_STATE[entry.id]);
+  });
+}
+
+function updatePoiMenuState() {
+  document.querySelectorAll('#poiList .menu-row[data-poi]').forEach((row) => {
+    const id = row.getAttribute('data-poi');
+    row.setAttribute('aria-checked', String(!!POI_STATE[id]));
+  });
+}
+
+function togglePoi(id) {
+  POI_STATE[id] = !POI_STATE[id];
+  applyPoiVisibility();
+  persistPoiState();
+  updatePoiMenuState();
+  track('poi-toggle', { id, visible: POI_STATE[id] });
+}
+
+function buildPoiMenuRows() {
+  const container = document.getElementById('poiList');
+  if (!container) return;
+  container.textContent = '';
+  poiRegistry.forEach((entry) => {
+    const row = document.createElement('div');
+    row.className = 'menu-row';
+    row.setAttribute('role', 'menuitemcheckbox');
+    row.setAttribute('aria-checked', String(!!POI_STATE[entry.id]));
+    row.setAttribute('data-poi', entry.id);
+    row.setAttribute('tabindex', '0');
+
+    const iconEl = document.createElement('i');
+    iconEl.className = 'material-icons';
+    iconEl.setAttribute('aria-hidden', 'true');
+    iconEl.textContent = entry.icon;
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'menu-label';
+    labelEl.textContent = entry.label;
+
+    const switchEl = document.createElement('span');
+    switchEl.className = 'switch';
+    switchEl.setAttribute('aria-hidden', 'true');
+
+    row.appendChild(iconEl);
+    row.appendChild(labelEl);
+    row.appendChild(switchEl);
+
+    row.addEventListener('mouseup', () => togglePoi(entry.id));
+    row.addEventListener('keydown', (e) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        togglePoi(entry.id);
+      }
+    });
+
+    container.appendChild(row);
+  });
+}
+
+// Reconcile persisted state against layer visibility (handles the case where
+// persisted state diverges from the layer's declared default), then render the
+// menu rows once. Also re-persists cleaned state so stale keys drop from
+// localStorage the first time a user opens the page after a registry change.
+applyPoiVisibility();
+persistPoiState();
+buildPoiMenuRows();
+
+// Coachmark: briefly surfaces the Finnish layer name after it becomes visible,
+// so icon-only segments stay learnable.
+const coachmarkEl = document.getElementById('coachmark');
+let coachmarkTimer = null;
+function showCoachmark(text) {
+  if (!text) return;
+  coachmarkEl.textContent = text;
+  coachmarkEl.hidden = false;
+  coachmarkEl.getBoundingClientRect();
+  coachmarkEl.classList.add('show');
+  if (coachmarkTimer) clearTimeout(coachmarkTimer);
+  coachmarkTimer = setTimeout(() => {
+    coachmarkEl.classList.remove('show');
+    setTimeout(() => {
+      if (!coachmarkEl.classList.contains('show')) coachmarkEl.hidden = true;
+    }, 220);
+  }, 1400);
+}
 
 document.addEventListener('keyup', (event) => {
   if (event.defaultPrevented) {
@@ -1325,6 +1493,9 @@ document.addEventListener('keyup', (event) => {
     toggleLayerVisibility(lightningLayer);
   } else if (key === '4' || key === 'Digit4') {
     toggleLayerVisibility(observationLayer);
+  } else if (event.key === 'Escape') {
+    if (overflowMenuEl.classList.contains('open')) closeOverflowMenu();
+    else handled = false;
   } else if (event.key === 'Control') {
     document.getElementById('help').style.display = 'none';
   } else if (event.key === 'Home') {

--- a/src/radar.js
+++ b/src/radar.js
@@ -1062,10 +1062,6 @@ function onChangeVisible(event) {
       document.getElementById(wmslayer).classList.add('selected');
     }
     setButtonState(`${name}Button`, true);
-    const segEl = document.getElementById(`${name}Button`);
-    if (segEl && typeof showCoachmark === 'function') {
-      showCoachmark(segEl.getAttribute('data-name'));
-    }
     document.getElementById(`${name}Info`).classList.remove('playListDisabled');
     const toggleIcon = document.querySelector(`#${name}Info .card-visibility-toggle .material-icons`);
     if (toggleIcon) toggleIcon.textContent = 'visibility';
@@ -1092,6 +1088,20 @@ function onChangeVisible(event) {
  */
 function toggleLayerVisibility(layer) {
   layer.setVisible(!layer.getVisible());
+}
+
+// Toggle wrapper for segment-originated actions (button taps + keyboard
+// shortcuts). Announces the Finnish layer name via coachmark only when the
+// toggle turned the layer on. Deliberately not used by the playlist eye icon
+// or long-press variant selection so those paths stay quiet.
+function toggleAndAnnounce(layer, segId) {
+  toggleLayerVisibility(layer);
+  if (layer.getVisible()) {
+    const seg = document.getElementById(segId);
+    if (seg && typeof showCoachmark === 'function') {
+      showCoachmark(seg.getAttribute('data-name'));
+    }
+  }
 }
 
 //
@@ -1260,7 +1270,7 @@ document.getElementById('radarLayerTitle').addEventListener('mouseup', () => {
 });
 
 document.getElementById('lightningLayerButton').addEventListener('mouseup', () => {
-  toggleLayerVisibility(lightningLayer);
+  toggleAndAnnounce(lightningLayer, 'lightningLayerButton');
 });
 
 document.getElementById('lightningLayerTitle').addEventListener('mouseup', () => {
@@ -1271,7 +1281,7 @@ document.getElementById('lightningLayerTitle').addEventListener('mouseup', () =>
 const observationMenu = createLongPressHandler(
   'observationLayerButton',
   'observationLongPressMenu',
-  () => { toggleLayerVisibility(observationLayer); },
+  () => { toggleAndAnnounce(observationLayer, 'observationLayerButton'); },
   (id) => { updateLayer(observationLayer, id); observationMenu.hide(); },
   () => observationLayer.getSource().getParams().LAYERS,
   () => observationLayer.getVisible(),
@@ -1280,7 +1290,7 @@ const observationMenu = createLongPressHandler(
 const satelliteMenu = createLongPressHandler(
   'satelliteLayerButton',
   'satelliteLongPressMenu',
-  () => { toggleLayerVisibility(satelliteLayer); },
+  () => { toggleAndAnnounce(satelliteLayer, 'satelliteLayerButton'); },
   (id) => { updateLayer(satelliteLayer, id); satelliteMenu.hide(); },
   () => satelliteLayer.getSource().getParams().LAYERS,
   () => satelliteLayer.getVisible(),
@@ -1289,7 +1299,7 @@ const satelliteMenu = createLongPressHandler(
 const radarMenu = createLongPressHandler(
   'radarLayerButton',
   'radarLongPressMenu',
-  () => { toggleLayerVisibility(radarLayer); },
+  () => { toggleAndAnnounce(radarLayer, 'radarLayerButton'); },
   (id) => { updateLayer(radarLayer, id); radarMenu.hide(); },
   () => radarLayer.getSource().getParams().LAYERS,
   () => radarLayer.getVisible(),
@@ -1327,12 +1337,16 @@ menuButtonEl.addEventListener('mouseup', () => {
 
 overflowBackdropEl.addEventListener('mouseup', closeOverflowMenu);
 
-window.addEventListener('mouseup', (e) => {
+function closeOverflowIfOutside(e) {
   if (!overflowMenuEl.classList.contains('open')) return;
   if (overflowMenuEl.contains(e.target)) return;
   if (menuButtonEl.contains(e.target)) return;
   closeOverflowMenu();
-});
+}
+window.addEventListener('mouseup', closeOverflowIfOutside);
+// Mirror on touchend for touch-only devices where upstream preventDefault
+// can swallow the synthesized mouseup (same pattern the long-press menus use).
+window.addEventListener('touchend', closeOverflowIfOutside);
 
 document.querySelectorAll('#overflowMenu .chip[data-theme]').forEach((chip) => {
   chip.addEventListener('mouseup', () => {
@@ -1486,13 +1500,13 @@ document.addEventListener('keyup', (event) => {
   } else if (key === 'l' || key === 'KeyL') {
     skipNext();
   } else if (key === '1' || key === 'Digit1') {
-    toggleLayerVisibility(satelliteLayer);
+    toggleAndAnnounce(satelliteLayer, 'satelliteLayerButton');
   } else if (key === '2' || key === 'Digit2') {
-    toggleLayerVisibility(radarLayer);
+    toggleAndAnnounce(radarLayer, 'radarLayerButton');
   } else if (key === '3' || key === 'Digit3') {
-    toggleLayerVisibility(lightningLayer);
+    toggleAndAnnounce(lightningLayer, 'lightningLayerButton');
   } else if (key === '4' || key === 'Digit4') {
-    toggleLayerVisibility(observationLayer);
+    toggleAndAnnounce(observationLayer, 'observationLayerButton');
   } else if (event.key === 'Escape') {
     if (overflowMenuEl.classList.contains('open')) closeOverflowMenu();
     else handled = false;


### PR DESCRIPTION
## Summary
- Top toolbar becomes a floating segmented pill (satellite / radar / lightning / observation) plus a detached three-dot menu button; 7 side-by-side buttons collapse to 4 icon-only segments with always-visible indicator bars that grow + recolor cyan on activation.
- GPS moves to a 52px floating FAB in the bottom-right, anchored above the time-control pill via a new `--timecontrol-height` token.
- Dark/light toggle leaves the top bar and becomes an auto/dark/light chip row inside a new overflow menu. **Auto is now the default** (follows OS).
- New Karttakohteet (map features) section with iOS-style switches toggles Tutka-asemat and Lentokentät POI layers. Driven by a small `poiRegistry` — future POIs are one-line additions.
- Persisted POI state (`POI_STATE` in `localStorage`) reconciles against the current registry on every load: unknown keys are dropped, new entries fall back to their declared `defaultOn`, user's explicit choice always wins.
- Finnish text labels dropped from segments in favor of a brief coachmark toast that flashes the layer name when it becomes visible (tap, keyboard, or long-press menu select). Long-press variant menus and 1/2/3/4 shortcuts unchanged. Esc closes the overflow menu.
- Icon refresh: `satellite_alt`, `radar` (literal match for Säätutka), `bolt`, `thermostat`; `cell_tower` for the Tutka-asemat POI to keep it visually distinct from the radar segment.
- Dead code removed: `#mapLayerButton` top-bar toggle, hidden `#layersButton` grid handler, and their CSS.

## Design process
Built with a 4-person team review cycle (UX specialist, visual designer, architect, devil's advocate with a second round critiquing the other three plans). Interactive mockup at [`design/toolbar-mockup.html`](design/toolbar-mockup.html) documents the visual direction — open in any browser to toggle simulated map backdrops (dark sky / bright radar echoes / HRV snow cloud tops / natural RGB) and stress-test contrast.

Key design decisions landed from the team review:
- Segmented pill over four separate FABs — single on-map silhouette, one hit-test region.
- Three-cue active state (fill + icon recolor + indicator bar grows) so activation reads against any map content.
- `POI_STATE` object (not Set) so we can distinguish "user turned off" from "never seen" — required for safe registry evolution.
- Coachmark bundled into the same PR as the label drop — never drop learnability cues without onboarding.
- GPS relocation bundled here (not phased) — mismatched intermediate state would look unfinished.

## Defaults
| POI | Default |
|---|---|
| Tutka-asemat (radar stations) | on |
| Lentokentät (airfields) | off |

## Test plan
- [ ] Fresh load (incognito or `localStorage.clear()`): radar segment active, radar stations visible, airfields hidden. Theme chip "Automaattinen" active; tiles match OS preference.
- [ ] Tap each segment — active state (cyan bar grows, soft fill, icon recolor) reads clearly; coachmark flashes the Finnish name; tap-off hides layer and coachmark is not shown.
- [ ] Long-press radar/satellite/observation segment → variant menu still opens at the segment's screen position.
- [ ] Overflow menu: tap ⋯ → opens; tap chip → theme updates without reload; tap POI row → layer toggles instantly; tap-outside or Esc → closes.
- [ ] GPS FAB: tap → tracking on, cyan ring; tap again → off. Stays clear of the time-control pill on portrait iPhone and narrow landscape iPad.
- [ ] Persisted POI state: toggle airfields on, reload → still on. Toggle radars off, reload → still off.
- [ ] Registry reconciliation: `localStorage.setItem('POI_STATE', JSON.stringify({radars: true, ghost: true}))`, reload → `ghost` dropped, localStorage cleaned to `{"radars":true,"airfields":false}`.
- [ ] Keyboard shortcuts 1/2/3/4 toggle segments; `k`/`l`/`j`/space still drive playback; Esc closes overflow menu when open.
- [ ] Backdrop stress: check the pill and FAB stay legible over bright radar returns (layer off → precipitation visible) and over EUMETSAT HRV cloud tops.
- [ ] Safe-area: check iOS PWA standalone mode on iPhone (top notch clears the pill; bottom home-indicator clears the FAB and time-control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)