### PR TITLE
Radar animation interpolation (optical flow, WebGL2)

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -455,9 +455,19 @@ html, body {
     
   }
 
-  /* Default: frame loaded for the current view — neutral dark gray. */
+  /* Default: frame loaded AND flow ready for the current view —
+     neutral dark gray. Interpolation will animate through this
+     timestep smoothly. */
   #timeline > div {
     background-color: #3C3D3E;
+  }
+  /* Loaded but interpolator flow isn't ready yet — the bitmap is on
+     screen but playback through this timestep will "jump" instead
+     of warping. Green so the user can see which cells are holding
+     up smooth animation. Below timeline-loading in specificity so
+     a still-loading cell stays amber. */
+  #timeline > div.timeline-flow-pending {
+    background-color: #3a8a4a;
   }
   /* Loading for the current view — warm amber, clearly contrasting. */
   #timeline > div.timeline-loading {

--- a/docs/animation-interpolation-plan.md
+++ b/docs/animation-interpolation-plan.md
@@ -1,0 +1,487 @@
+# Radar Animation: Optical Flow Frame Interpolation
+
+Handoff plan for Claude Code. Target repo: `website-tutka-meteo-fi`.
+
+## Problem
+
+Radar animation at 5-minute cadence feels jumpy. Crossfade between consecutive frames is rejected because it produces a "pumping" visual — reflectivity appears to grow/shrink rather than move. We need true motion-compensated interpolation.
+
+## Constraints
+
+- **No backend changes.** Only existing WMS endpoints may be used.
+- **Full-size images, not tiles.** App already fetches single WMS images per timestep.
+- **Mobile must work or degrade gracefully.** iPhones and mid-range Androids.
+- **Caching stays.** `src/animation/framePool.js` + `src/animation/stickyImageWMS.js` already implement a 13-slot pool with sliding windows and stale-while-loading. Interpolation layers on top, doesn't replace.
+- **Vanilla JS + OpenLayers**, airbnb-base ESLint, no framework churn.
+
+## Existing cache — verified read of the codebase
+
+Before writing any new code, understand what's already there. The `FramePool` is well-designed and dictates the integration shape.
+
+**Topology.** Pool of N=13 invisible `ImageLayer`s, each with its own `StickyImageWMS` source pinned to one `TIME`. The primary (visible) layer doesn't hold frames itself — on each tick `showTime(t)` calls `primary.setSource(slot.source)` to point the primary at whichever slot matches. Instant swap, no refetch. This is exactly the right shape for interpolation too.
+
+**Cache identity per slot.** Slots are keyed by TIME, but the pool tracks these WMS params as the "slot identity" via `SYNC_PARAM_KEYS`:
+
+```js
+const SYNC_PARAM_KEYS = ['LAYERS', 'STYLES', 'FORMAT', 'ELEVATION'];
+```
+
+When the primary's source changes any of these, `_watchPrimarySource` → `_resyncAllParams` updates every slot's params and calls `invalidateSticky()` on each. Consequence: **every STYLES switch triggers a full 13-frame refetch.**
+
+**View coverage.** Extent/resolution are not in the slot key explicitly — instead, each slot holds one image at one world extent, and `StickyImageWMS.hasLoadedImageForView(extent, resolution, pixelRatio, projection)` checks at `moveend` whether the cached image still covers the view. If not, `slot.loaded` flips false and the slot re-fetches for the new view on next prefetch. So pan/zoom invalidates per-slot, not by rebuilding keys.
+
+**Window sliding.** `setWindow(newTimes)` preserves slots whose TIME is still in the new window and reassigns only the slots whose TIME dropped out. Typical window slide keeps 12 of 13 slots.
+
+**Prefetch strategy.** `_prefetchAroundCurrent()` kicks off current + next + next+1. `_advanceFrontier()` fires on each `imageloadend` to trigger the next couple of upcoming frames — forward-biased because playback is almost always forward. Cap of 2 new requests per completion.
+
+**No BBOX cache key needed.** The combination of per-slot sticky-with-view-check + slot reassignment on window slide gives us an implicit cache that survives view changes cleanly. Our flow cache should follow the same per-slot pattern rather than inventing a hash key.
+
+**Pool instances.** Four separate pools, one per category: `satelliteLayer`, `radarLayer`, `lightningLayer`, `observationLayer` (see `radar.js` around L1572–1585). Interpolation applies to `satelliteLayer` and `radarLayer` only.
+
+## STYLES independence — the important insight
+
+The user correctly observed: **flow fields represent physical motion and should be invariant under STYLES change.** A DBZ vs rain-rate colormap swap shouldn't invalidate motion estimates.
+
+What this means for the design:
+
+- **Frame bitmap cache** is STYLES-dependent (already is — rendered RGB pixels). Existing FramePool behavior unchanged.
+- **Flow cache** is STYLES-independent. Key by `{LAYERS, ELEVATION, URL, slotTime_A, slotTime_B, viewEpoch}` — explicitly exclude STYLES and FORMAT.
+- Flow computed from style-A pixels gets reused when displaying style-B pixels. Not mathematically identical (different RGB → slightly different gradients → slightly different flow) but physically correct: motion is a property of the atmosphere, not the colormap. The reuse is a pragmatic win; the alternative — recomputing flow on every style switch — wastes real CPU/GPU time for negligible visual gain.
+- On style switch: frame bitmaps invalidate (existing behavior kicks in, pool refetches). Flow cache is **preserved**. When new bitmaps land, warp with existing flow — no interpolation gap.
+- ELEVATION must stay in the flow key because it selects a different physical field (different altitude slice), not a different rendering of the same field.
+
+Only one caveat: if a style has a stepped colormap with large flat regions (classical radar palettes do this at low dBZ), the flow computed from it will be noisy in those regions. Compute flow from the highest-contrast style available when a choice exists. For the v1 implementation: compute from whatever style is active when the frame pair first becomes loadable. Good enough.
+
+**View change invalidation.** Flow is computed from pixels in a specific world extent. When a pan/zoom causes slot-level sticky invalidation, any flow pair involving that slot must also invalidate. Hook into the same `moveend` path `FramePool` already uses — when a slot transitions `loaded: true → false` due to view change, drop flow fields referencing that slot.
+
+## Decision
+
+**Client-side pyramidal Lucas–Kanade optical flow in WebGL2**, pre-computed per pair on prefetch, with a motion-compensated warp shader during playback.
+
+Rejected alternatives:
+- Crossfade — pumping, user rejected.
+- OpenCV.js Farnebäck — 8 MB WASM, inconsistent mobile SIMD, slower on phones than GPU.
+- Server-side pysteps — violates "no backend changes" constraint.
+
+## Architecture
+
+Two decoupled stages:
+
+1. **Flow computation** — expensive, runs once per consecutive frame pair during prefetch. Produces a flow field texture (RG16F, ~256×256) stored in memory keyed by `(timeA, timeB)`.
+2. **Warp rendering** — cheap, runs every animation frame. Fragment shader samples frame A and frame B with displaced UVs and blends.
+
+This split is what makes it smooth — no flow recomputation during playback.
+
+## New module layout
+
+Co-located with the existing animation code — they're tightly coupled:
+
+```
+src/
+  animation/
+    framePool.js            (existing, ~3 small edits)
+    stickyImageWMS.js       (existing, unchanged)
+    interpolation/
+      index.js              public API: RadarInterpolator, canInterpolate
+      capabilities.js       runtime feature probe, benchmark, gating
+      flowCache.js          keyed flow storage, STYLES-invariant
+      flowLK.js             pyramidal Lucas–Kanade in WebGL2
+      warp.js               motion-compensated warp shader + renderer
+      canvasSource.js       ol/source wrapper that exposes the warp canvas
+      shaders/
+        lkGradient.frag     Sobel gradients
+        lkSolve.frag        2x2 system solve per pixel
+        warp.frag           final display warp
+        common.vert         fullscreen triangle
+      glUtils.js            FBO, texture, program helpers
+```
+
+## Public API
+
+```js
+import { RadarInterpolator, canInterpolate } from './interpolation/index.js';
+
+const interp = new RadarInterpolator({
+  gl: offscreenGL,              // shared WebGL2 context
+  flowResolution: 256,          // compute flow at this size
+  pyramidLevels: 3,
+  iterations: 5,                // LK iterations per level
+  // No `subframes` param: playback `t` is driven continuously by the RAF
+  // loop (see §Playback loop refactor), so perceived smoothness is bounded
+  // by display refresh rate, not a configured count.
+});
+
+// Called by the existing cache as frames arrive
+interp.registerFrame(timeISO, imageBitmap);
+
+// Called when a new pair becomes available (frame N and N+1 both cached)
+await interp.computeFlow(timeA, timeB);   // ~30-80ms @ 256²
+
+// Called by the existing animation loop at any t
+const canvas = interp.renderAt(timeA, timeB, t);  // t ∈ [0,1]
+// Blit canvas into the existing OpenLayers ImageLayer source
+```
+
+The interpolator does **not** know about OpenLayers, WMS, or the cache. It takes ImageBitmaps and timestamps, returns a canvas. This keeps it testable and replaceable.
+
+## Integration points — concrete, based on actual code
+
+Three places, and only three. Keep the diff to `radar.js` minimal by doing the work inside `src/animation/`.
+
+**1. `src/animation/framePool.js` — frame registration hook.**
+After each successful load in the `imageloadend` handler (around L74–96), the slot's source has a LOADED `HTMLImageElement` (`event.image.getImage()`). That's our bitmap. Pass it to the interpolator:
+
+```js
+source.on('imageloadend', (event) => {
+  if (event.image !== slot.source.image) return;
+  slot.loaded = true;
+  slot.source.setSticky(event.image);
+  this._notifyLoadChange(slot);
+  if (this.primary.getSource() === slot.source) this.primary.changed();
+  this.map.render();
+  this._advanceFrontier();
+  // NEW: feed the interpolator
+  if (this.interpolator) {
+    this.interpolator.onSlotLoaded(slot, event.image);
+  }
+});
+```
+
+Inject the interpolator via constructor option, default null. Pools that don't interpolate (lightning, observation) pass nothing.
+
+**2. `src/animation/framePool.js` — showTime becomes interpolatable.**
+Today `showTime(time)` does a discrete source swap. For interpolation, introduce a second method:
+
+```js
+showInterpolated(timeA, timeB, t) {
+  // If t === 0 → same as showTime(timeA)
+  // If t === 1 → same as showTime(timeB)
+  // Otherwise: swap primary to a canvas-backed source that the
+  // interpolator paints each frame.
+}
+```
+
+The interpolated path uses a custom `ol.source.ImageCanvas` (or a thin subclass of `ImageWMS` that hijacks `getImage` to return our warped canvas). The canvas lives in the interpolator; the source just hands OL a reference. On each playback RAF, interpolator draws frame(A, B, t), canvas updates, `source.changed()`, OL redraws.
+
+The existing `showTime` stays for discrete stepping (`j`/`l`/space keys) and for scrubber drags.
+
+**3. `src/animation/framePool.js` — STYLES switch preserves flow.**
+In `_resyncAllParams` (L175–191), after `invalidateSticky()`, notify the interpolator which param actually changed. If only STYLES or FORMAT changed, the interpolator keeps its flow cache; if LAYERS/ELEVATION/URL changed, drop it.
+
+```js
+_resyncAllParams() {
+  // ... existing resync ...
+  if (this.interpolator) {
+    const prev = this._primaryParamsSnap;   // old snap
+    const now = this._snapPrimary();         // new snap (or take before update)
+    const flowInvariant = (prev.layers === now.layers
+                        && prev.elevation === now.elevation
+                        && prev.url === now.url);
+    this.interpolator.onParamsChanged({ flowInvariant });
+  }
+}
+```
+
+(Small refactor needed: capture the previous snap before overwriting, currently `this._primaryParamsSnap = snap` runs inside `_watchPrimarySource` before `_resyncAllParams` is called. Reorder or pass prev in as an arg.)
+
+**4. `src/radar.js` — wire it up and refactor the playback loop.**
+
+Two parts. The wire-up is small; the playback refactor is a prerequisite that
+has to land first.
+
+**4a. Pool wire-up** (L1757–1770 today, where the four pools are constructed).
+`main` is currently `const main = () => {…}` (not async) and invokes a chain
+of sync setup that depends on pool existence (`setTime('last')` at L1826
+calls `pool.setWindow`/`pool.showTime`). Either make `main` async
+explicitly, or run the capability probe at module load and expose it as a
+Promise so pool construction can proceed without blocking boot:
+
+```js
+import { RadarInterpolator, canInterpolate } from './animation/interpolation';
+
+// module-scope; resolves before the user can press play
+let interpEnabled = false;
+const interpReady = canInterpolate().then((ok) => { interpEnabled = ok; });
+
+// inside main():
+for (const [name, layer] of pairs) {
+  const opts = { primaryLayer: layer, map };
+  if (interpEnabled && (name === 'radarLayer' || name === 'satelliteLayer')) {
+    opts.interpolator = new RadarInterpolator({ gl: sharedGL, /* ... */ });
+  }
+  const pool = new FramePool(opts);
+  // ...
+}
+```
+
+Create `sharedGL` once outside the loop — both radar and satellite
+interpolators share a single offscreen WebGL2 context so that GPU memory
+and state are coherent. Nothing else in the app needs GL.
+
+**4b. Playback loop refactor** (touches `play` / `stop` / `setTime` around
+L556–715). Today `play()` is `setInterval(setTime, 1000 / frameRate)` and
+each tick advances the timestep by a full 5-minute frame. That is the only
+animation loop; it fires at 2 Hz. Interpolation needs a continuous
+`t ∈ [0, 1]` between consecutive timesteps, which today does not exist —
+without this refactor, `renderAt(A, B, t)` has no caller and Phase 2+ is
+dead on arrival.
+
+Split playback into two cadences:
+
+- **Advance cadence** (slow): when `performance.now() - lastAdvance ≥
+  stepDuration`, run the existing `setTime` advance logic to pick the next
+  (A, B) pair, reset `lastAdvance`. `stepDuration = 1000 / frameRate`
+  (today 500 ms at frameRate=2). Existing speed control still works.
+- **Render cadence** (fast): a single `requestAnimationFrame` loop computes
+  `t = Math.min(1, (performance.now() - lastAdvance) / stepDuration)` and
+  asks each visible pool to render at `(A, B, t)`. If the pool has no
+  interpolator — or the interpolator has no flow for (A, B) yet — it falls
+  back to `showTime(A)`, visually identical to today. Non-interpolating
+  pools (lightning, observation) always ignore `t`.
+
+Keyboard shortcuts (`j`/`k`/`l`/space) and scrubber drags stay discrete:
+they set `startDate` directly, call `showTime`, and reset `lastAdvance` so
+the next continuous-play tick picks up from a clean state. Only continuous
+playback via `play()` goes through the RAF-interpolated path.
+
+The existing `isInteracting` gate (L667, L678) stays — skip both advance
+and render while the user is panning/zooming, same as today.
+
+## View-change invalidation wiring
+
+The existing `moveend` handler (L106–129) is already the right place. Extend it:
+
+```js
+map.on('moveend', () => {
+  const ctx = this._getViewContext();
+  if (ctx) {
+    for (const slot of this.slots) {
+      if (!slot.time) continue;
+      const fresh = slot.source.hasLoadedImageForView(/*...*/);
+      if (slot.loaded !== fresh) {
+        slot.loaded = fresh;
+        this._notifyLoadChange(slot);
+        // NEW: if slot became stale, invalidate flow pairs referencing it
+        if (!fresh && this.interpolator) {
+          this.interpolator.invalidateSlot(slot.time);
+        }
+      }
+    }
+  }
+  this._prefetchAroundCurrent();
+});
+```
+
+**Window-slide invalidation** (distinct from moveend). When
+`setWindow(newTimes)` reassigns a slot (framePool.js:281–295), the slot's
+`time` attribute is overwritten in place. Capture the *old* time BEFORE
+reassignment so `interpolator.invalidateSlot(oldTime)` has something to
+work with — any flow pair referencing the dropped time is dropped.
+Symmetrically, as new TIMEs arrive and their `imageloadend` fires,
+`onSlotLoaded` should check both neighboring pairs (prev, this) and
+(this, next) for eligibility and trigger flow computation when both
+endpoints are loaded. Typical window slide drops 1 slot and invalidates
+at most 2 pairs.
+
+## Feature gating
+
+In `capabilities.js`:
+
+```js
+export async function canInterpolate() {
+  const canvas = document.createElement('canvas');
+  const gl = canvas.getContext('webgl2');
+  if (!gl) return false;
+  // iOS 15.4+ stopped exposing EXT_color_buffer_float and switched to
+  // EXT_color_buffer_half_float. Either enables RG16F render targets,
+  // which is all we need for flow fields. Accept either, then probe a
+  // 1×1 RG16F FBO for completeness before trusting the extension —
+  // presence of the extension does not guarantee FBO-completeness in
+  // every mobile driver.
+  const hasHalf = !!gl.getExtension('EXT_color_buffer_half_float');
+  const hasFull = !!gl.getExtension('EXT_color_buffer_float');
+  if (!hasHalf && !hasFull) return false;
+  if (!probeRg16fFboComplete(gl)) return false;
+
+  // Memory hint (undefined on Safari — don't fail there, let benchmark decide)
+  if (navigator.deviceMemory !== undefined && navigator.deviceMemory < 3) {
+    return false;
+  }
+
+  // Micro-benchmark: run one flow computation on a 256² synthetic pair.
+  // If it takes >150ms, device is too slow — fall back.
+  const ms = await benchmarkFlowOnce(gl, 256);
+  return ms < 150;
+}
+```
+
+Cache the result in localStorage with a 7-day TTL so we don't re-benchmark every page load.
+
+Also expose a manual override via query string (`?interp=off` / `?interp=on`)
+for debugging and for users who want to force a behavior. Do **not** use the
+URL hash — `ol-hashed` (imported at `radar.js:12`, called at L1843) owns the
+hash and will strip anything it doesn't recognize on the next map update.
+
+## Mobile specifics
+
+- **Flow at 256×256, warp at display resolution.** Flow fields are smooth; downsampling costs almost nothing visually and drops compute 16×.
+- **Memory budget (redone with real numbers).** WMS images are
+  viewport-size × `imageRatio` (1.5 per `radar.js:47,295,309,322,335`). On a
+  1920×1080 desktop window each frame is ~2880×1620 × RGBA ≈ 18 MB; 13 slots
+  × 2 interpolating pools ≈ 486 MB of frame texture memory if we duplicate
+  them onto the GPU. On a typical phone (~390×844) it's ~3 MB × 26 ≈ 78 MB.
+  Desktop, not mobile, is the pressure case.
+  - Mitigations: do **not** keep a second GPU copy of every slot bitmap —
+    upload to GL only when a pair is about to be warped, and release when
+    the pair leaves the current ± 1 window. Two live pairs per pool (A→B
+    current, B→C next) × 2 pools × 2 textures ≈ 8 frame textures resident.
+  - Flow at 256² × RG16F is cheap (~0.5 MB per pair × 12 pairs × 2 pools
+    ≈ 12 MB). Warp upsamples bilinearly to display resolution; that's
+    acceptable for meteorological data and keeps the flow cache trivial.
+  - Evict oldest flow fields first on pressure; they recompute in 30–80 ms.
+- **Handle `webglcontextlost`** on the shared GL context. On restore, invalidate all cached flow textures and recompute lazily. Do **not** crash playback — fall back to discrete-switch until context is back.
+- **Background tab**: iOS Safari evicts WebGL contexts aggressively. Pause playback on `visibilitychange` to `hidden`, flag everything as dirty on return.
+
+## Pyramidal Lucas–Kanade implementation notes
+
+Standard coarse-to-fine LK. Pseudocode for `flow-lk.js`:
+
+```
+build_pyramid(frameA) -> [A0, A1, A2]   // downsample 2x each level
+build_pyramid(frameB) -> [B0, B1, B2]
+flow = zeros(coarsest_size)
+for level in reversed(range(levels)):
+  flow = upsample(flow) * 2              // carry estimate from coarser level
+  for iter in range(iterations):
+    warped_B = warp(B[level], flow)
+    Ix, Iy = sobel(A[level])
+    It = warped_B - A[level]
+    # Solve 2x2 normal equations per pixel in a fragment shader:
+    # [ΣIx²  ΣIxIy] [u]   [-ΣIxIt]
+    # [ΣIxIy ΣIy² ] [v] = [-ΣIyIt]
+    # Use a 5x5 or 7x7 window (separable box blur on the products).
+    du, dv = solve_per_pixel()
+    flow += (du, dv)
+return flow
+```
+
+All of this runs in fragment shaders with ping-pong FBOs. No CPU readbacks during computation — that would kill mobile performance. The only readback is optionally for debugging.
+
+Use `RG16F` texture format for flow (supported by `EXT_color_buffer_float`). Half precision is plenty for pixel displacements of up to ~50 px.
+
+## Warp shader (the cheap part)
+
+```glsl
+#version 300 es
+precision highp float;
+
+uniform sampler2D uFrameA;
+uniform sampler2D uFrameB;
+uniform sampler2D uFlow;     // RG = displacement in normalized uv
+uniform float uT;            // 0..1
+
+in vec2 vUv;
+out vec4 fragColor;
+
+void main() {
+  vec2 flow = texture(uFlow, vUv).rg;
+
+  // Forward warp A by t*flow, backward warp B by (1-t)*flow, blend.
+  vec4 a = texture(uFrameA, vUv - uT * flow);
+  vec4 b = texture(uFrameB, vUv + (1.0 - uT) * flow);
+  fragColor = mix(a, b, uT);
+}
+```
+
+Nodata handling: if either sampled pixel has alpha 0, fall back to the other sample. Prevents smearing across coastlines / radar range edges.
+
+## Gotchas specific to this codebase
+
+- **Cache identity is already correct.** Confirmed: `FramePool` syncs on `LAYERS`/`STYLES`/`FORMAT`/`ELEVATION` and handles view changes via sticky + `hasLoadedImageForView`. No refactor of the existing cache needed before starting.
+- **WMS frames are styled RGB, not raw dBZ.** Flow on styled images is fine for visual interpolation, but low-reflectivity areas with flat color ramps produce weak gradients → noisy flow. A continuous viridis-like ramp is much better than a stepped classical radar palette here. If the active style uses a stepped palette, consider computing flow on the luminance channel only and boosting contrast.
+- **Lightning and observation layers must NOT be interpolated.** They are point/vector data, not fields. The four pools are separate; only pass an interpolator to `satelliteLayer` and `radarLayer` pool constructors. Lightning and observation pools are constructed without one.
+- **Keyboard shortcuts** (`j`, `k`, `l`, space — per README): these already work on discrete timesteps via `showTime`. Keep them on discrete steps. Interpolation is only for continuous playback via `k`.
+- **Timeline UI** (`src/timeline.js`, ~40 lines): the scrubber currently snaps to discrete frames. Decide whether scrubbing shows interpolated frames (nicer) or snaps (cheaper). Recommend: snaps while dragging, interpolates during play.
+- **Canvas output: use a custom `ol/layer/Layer` with `options.render`, not
+  `ImageCanvas`.** `ol/source/ImageCanvas` caches the returned canvas by
+  extent/resolution/revision and only re-invokes `canvasFunction` when
+  someone calls `source.changed()`. Workable, but it reallocates the canvas
+  on every pan (`scaleFromCenter(extent, ratio)`), which is wasteful for
+  per-RAF updates. Cleaner: `new Layer({ render: (frameState) => warpCanvas })`
+  hands OL the interpolator's canvas directly. Drive repaints with
+  `layer.changed()` or `map.render()` each RAF. The interpolator owns the
+  canvas; OL just blits it.
+  - Keep the existing `ImageLayer` + `StickyImageWMS` path for
+    non-interpolating pools (lightning, observation) and for
+    interpolating pools whenever interpolation is paused/disabled.
+  - When starting interpolated playback, swap the primary pool's visible
+    layer in the map from the `ImageLayer` to the custom `Layer`; swap
+    back on pause/disable. A layer swap is cleaner than a source swap and
+    avoids the `StickyImageWMS` invalidation semantics question entirely.
+- **A and B may have different pixel dimensions.** Each slot's sticky
+  bitmap was fetched at whatever extent/resolution was current when its
+  `triggerLoad` ran, so after any pan between slot-A's load and slot-B's
+  load the two `HTMLImageElement`s can have different WIDTH/HEIGHT.
+  `StickyImageWMS.hasLoadedImageForView` is a "good enough" check (L117–120)
+  and accepts both. Before flow computation, resample A and B onto a
+  fixed analysis grid (e.g., 512² in the pool's current view extent) — the
+  LK shader then has a shared UV space. Warp reads from the same resampled
+  textures and upsamples to display resolution for final display.
+- **Source swap vs canvas swap.** When starting interpolated playback, we swap primary to the canvas-backed source; when pausing or stepping discretely, swap back to the slot's `StickyImageWMS`. Make sure `invalidateSticky` semantics still hold on these transitions.
+- **umami telemetry** is present (`track()` at L121–123). Add a `track('interp-fallback', { reason })` when `canInterpolate()` returns false, so we can see real-world gating distributions across devices.
+
+## Implementation phases
+
+Do this incrementally. Each phase is independently shippable behind a flag.
+
+**Phase 1 — Skeleton + capability gating + playback loop refactor.** This
+phase is larger than it looks because the playback refactor is a
+prerequisite for everything after it.
+
+- (a) Empty `RadarInterpolator` class (no-op `renderAt`), `canInterpolate()`
+  probe with the iOS-aware extension check and FBO completeness probe,
+  feature flag wired through `radar.js` via `interpReady` Promise.
+- (b) Refactor `play()` / `setTime()` into the two-cadence structure
+  described in §Integration point 4b. While interpolation is disabled,
+  the RAF loop just calls `showTime(A)` and ignores `t` — behavior is
+  identical to today's `setInterval`. Keyboard shortcuts, scrubber drags,
+  speed control, and `IS_FOLLOWING` all keep working.
+- (c) Add a `showInterpolated(A, B, t)` stub on `FramePool` that today
+  delegates to `showTime(A)`; later phases fill it in.
+
+Ship, verify no visual or timing regressions against the current app.
+
+**Phase 2 — Warp renderer only, with zero flow.** Implement the warp shader with a flow field of all zeros. Visually equivalent to crossfade. Purpose: shake out the GL context plumbing, OL integration, timing, mobile perf of just the display path. Ship behind flag, test on phones.
+
+**Phase 3 — Pyramidal LK flow computation.** Implement `flow-lk.js`. Validate on synthetic pairs (translation-only cases should recover exact flow). Wire into prefetch. Now interpolation is real.
+
+**Phase 4 — Polish.** Nodata masking, `webglcontextlost` recovery, memory budget enforcement, localStorage benchmark caching, URL hash override, telemetry for flow computation times per device.
+
+**Phase 5 — Enable by default** after a week of dogfooding.
+
+## Validation checklist
+
+- [ ] Identical visual output to current app when interpolation is disabled
+- [ ] No new WMS requests — verify in DevTools Network tab
+- [ ] Flow computation <80 ms on M1 MacBook, <150 ms on iPhone 12, at 256²
+- [ ] RAF render loop sustains device refresh rate during playback (60 fps
+      on standard displays, 120 fps on ProMotion). Flow computation is
+      off the RAF path — it runs during prefetch — so it doesn't affect
+      per-frame latency as long as it completes before the pair is needed.
+- [ ] No memory growth over 1-hour animation loop (check with perf profiler)
+- [ ] Graceful fallback on WebGL1-only devices, old Androids, iOS < 15
+- [ ] Lightning/observation layers unaffected
+- [ ] Keyboard shortcuts still hit discrete timesteps
+- [ ] Timeline scrubber UX decided and implemented
+
+## Out of scope for this PR
+
+- Nowcasting / extrapolation past the last observed frame (can extend later using the same flow fields, semi-Lagrangian scheme).
+- Replacing pysteps for forecasting — that's a server-side concern.
+- Changing the WMS layer list or data sources.
+
+## References
+
+- Bouguet, J-Y. (2001). *Pyramidal Implementation of the Lucas Kanade Feature Tracker.* Intel Corporation. The canonical reference for pyramidal LK.
+- pysteps documentation — `pysteps.motion.lucaskanade` and `pysteps.extrapolation.semilagrangian` are the semantic model, even though we're reimplementing in WebGL2.
+- WebGL2 `EXT_color_buffer_float` — required for RG16F render targets.

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -524,15 +524,38 @@ export default class FramePool {
   // the next in windowTimes (B). Toggles primary's opacity: zeroed
   // while warp has real content (so the user sees only the
   // interpolated frame), restored to _userOpacity otherwise.
+  //
+  // Loop end: the last window frame has no meaningful next frame
+  // (wrapping back to the first would be a 60-minute temporal
+  // discontinuity). Instead of falling through to primary on that
+  // one tick — which caused a visible brightness pop because primary
+  // renders sharper than warp — hold at t=1 on the previous pair.
+  // Warp at t=1 equals B = current time, so the content matches the
+  // adjacent warp frames and the whole loop stays on a consistent
+  // rendering path.
   showInterpolated(t) {
     if (!this.interpolator || !this.interpActive) return;
     if (!this.windowTimes || !this.currentTime) return;
     if (!this.warpLayer) return;
     const curIdx = this.windowTimes.indexOf(this.currentTime);
     if (curIdx < 0) return;
-    const nextIdx = (curIdx + 1) % this.size;
-    const timeB = this.windowTimes[nextIdx];
-    if (!timeB) return;
+
+    let timeA;
+    let timeB;
+    let effectiveT;
+    if (curIdx < this.size - 1) {
+      timeA = this.currentTime;
+      timeB = this.windowTimes[curIdx + 1];
+      effectiveT = t;
+    } else if (curIdx > 0) {
+      // Last frame: reuse the previous pair held at its end.
+      timeA = this.windowTimes[curIdx - 1];
+      timeB = this.currentTime;
+      effectiveT = 1;
+    } else {
+      return;
+    }
+    if (!timeA || !timeB) return;
 
     // Pass the 1× view extent — hasFlow checks whether the stored
     // frames cover the visible area, not the 1.5× fetch buffer, so
@@ -540,7 +563,7 @@ export default class FramePool {
     // the view moves out of the buffer, hasFlow falls back to false
     // and primary's stale-while-loading sticky covers the gap.
     const viewExtent = this._viewExtent();
-    const hasFlow = this.interpolator.hasFlow(this.currentTime, timeB, viewExtent);
+    const hasFlow = this.interpolator.hasFlow(timeA, timeB, viewExtent);
     this._setPrimaryTransparent(hasFlow);
 
     if (!hasFlow) {
@@ -554,9 +577,9 @@ export default class FramePool {
       return;
     }
 
-    this._warpState.timeA = this.currentTime;
+    this._warpState.timeA = timeA;
     this._warpState.timeB = timeB;
-    this._warpState.t = t;
+    this._warpState.t = effectiveT;
 
     this.warpLayer.getSource().changed();
   }

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -150,6 +150,19 @@ export default class FramePool {
       // which cells need to be re-fetched for the current view.
       const ctx = this._getViewContext();
       if (ctx) {
+        // First, drop each source's cached ImageWMS wrapper. OL's own
+        // render pipeline calls getImage on the primary layer's source
+        // during a pan, and the cache locks in a wrapper whose extent
+        // reflects the intermediate view. Without this reset, loads
+        // completing on those wrappers would store mid-pan extents
+        // that fail extentApproxEqual against neighbouring slots
+        // (which didn't get render-hit during the pan), and the
+        // interpolator would skip computeFlow for any pair involving
+        // the current slot — visible as two permanently-green cells
+        // on the timeline.
+        for (const slot of this.slots) {
+          slot.source.resetImageCache();
+        }
         for (const slot of this.slots) {
           if (!slot.time) {
             continue; // eslint-disable-line no-continue

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -28,13 +28,17 @@ function pickSyncParams(params) {
 // refetch the one slot whose TIME left the window.
 export default class FramePool {
   constructor({
-    primaryLayer, map, size = 13, ratio = 1.5,
+    primaryLayer, map, size = 13, ratio = 1.5, interpolator = null,
   }) {
     this.primary = primaryLayer;
     this.map = map;
     this.size = size;
     this.slots = [];
     this.ratio = ratio;
+    // Optional RadarInterpolator instance. When present, later phases
+    // dispatch per-RAF warp requests through it; Phase 1 just stores
+    // the reference and keeps showInterpolated as a no-op.
+    this.interpolator = interpolator;
 
     this.onLoadStateChange = null;
     this.windowTimes = null;
@@ -322,6 +326,19 @@ export default class FramePool {
     }
     this._prefetchAroundCurrent();
     return true;
+  }
+
+  // Render the slot at a fractional position `t` in [0, 1] between
+  // the current frame (A) and the next frame in windowTimes (B).
+  // Phase 1 stub: the discrete frame is already on screen because
+  // setTime → showTime(A) ran at the most recent advance; there is
+  // nothing to do per-RAF without an active interpolator. Later
+  // phases will dispatch into this.interpolator.renderAt(A, B, t)
+  // when the pair has computed flow and swap the primary layer to
+  // the warp canvas.
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  showInterpolated(t) {
+    // phase 1: no-op
   }
 
   // Is this time's slot's current-view image loaded?

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -12,6 +12,18 @@ function pickSyncParams(params) {
   return out;
 }
 
+// Given a padded canvas extent and the padding ratio (e.g., 1.5),
+// return the inner 1× view extent (canvas minus buffer) with the
+// same center.
+function deriveViewExtent(paddedExtent, ratio) {
+  if (!paddedExtent || !ratio) return paddedExtent;
+  const cx = (paddedExtent[0] + paddedExtent[2]) / 2;
+  const cy = (paddedExtent[1] + paddedExtent[3]) / 2;
+  const hw = ((paddedExtent[2] - paddedExtent[0]) * 0.5) / ratio;
+  const hh = ((paddedExtent[3] - paddedExtent[1]) * 0.5) / ratio;
+  return [cx - hw, cy - hh, cx + hw, cy + hh];
+}
+
 // Pool of N invisible ImageLayers, each with its own ImageWMS source
 // pinned to a specific TIME. All 13 sources preload in parallel (the
 // layers are hidden, so we drive loads manually via source.getImage +
@@ -416,11 +428,15 @@ export default class FramePool {
       if (!this.interpActive) return this._emptyCanvas;
       const { timeA, timeB, t } = this._warpState;
       if (!timeA || !timeB) return this._emptyCanvas;
-      // Pass extent to hasFlow so we bail when the view has moved
-      // past what A and B were loaded for — OL would otherwise blit
-      // our old-extent canvas at the new extent.
-      if (!interpolator.hasFlow(timeA, timeB, extent)) return this._emptyCanvas;
-      return interpolator.renderAt(timeA, timeB, t, size[0], size[1]);
+      // Derive the 1× view extent from OL's requested 1.5× canvas
+      // extent. hasFlow checks whether the stored frames cover the
+      // 1× view (not the 1.5× buffer area) so small pans within the
+      // buffer keep flow active.
+      const viewExtent = deriveViewExtent(extent, this.ratio);
+      if (!interpolator.hasFlow(timeA, timeB, viewExtent)) return this._emptyCanvas;
+      // Pass the canvas extent so renderAt can compute the UV
+      // transform that places content at the correct world position.
+      return interpolator.renderAt(timeA, timeB, t, size[0], size[1], extent);
     };
 
     this.warpLayer = new ImageLayer({
@@ -518,13 +534,12 @@ export default class FramePool {
     const timeB = this.windowTimes[nextIdx];
     if (!timeB) return;
 
-    // Use the current view extent scaled by this.ratio to match
-    // what ImageCanvasSource will pass to canvasFunction. If the
-    // view has moved past what A and B were loaded for, hasFlow
-    // returns false — primary becomes visible again (at user
-    // opacity) so its stale-while-loading sticky can bridge the
-    // gap until new frames arrive for the new extent.
-    const viewExtent = this._viewExtentScaled();
+    // Pass the 1× view extent — hasFlow checks whether the stored
+    // frames cover the visible area, not the 1.5× fetch buffer, so
+    // a small pan still within the buffer keeps flow engaged. When
+    // the view moves out of the buffer, hasFlow falls back to false
+    // and primary's stale-while-loading sticky covers the gap.
+    const viewExtent = this._viewExtent();
     const hasFlow = this.interpolator.hasFlow(this.currentTime, timeB, viewExtent);
     this._setPrimaryTransparent(hasFlow);
 
@@ -591,21 +606,14 @@ export default class FramePool {
     }
   }
 
-  // Current view extent padded by this.ratio, mirroring how
-  // ImageCanvasSource scales the requested extent before handing
-  // it to canvasFunction. Used for hasFlow's extent check so the
-  // view extent we compare against matches what frames were loaded
-  // for (StickyImageWMS uses the same ratio when fetching).
-  _viewExtentScaled() {
-    const view = this.map.getView();
+  // Current map view extent in world coords (EPSG:3857 meters).
+  // Returned as the 1× viewport area, not padded by this.ratio —
+  // hasFlow checks whether the stored frame's extent (which does
+  // include the 1.5× fetch buffer) contains this 1× view.
+  _viewExtent() {
     const size = this.map.getSize();
     if (!size) return null;
-    const e = view.calculateExtent(size);
-    const cx = (e[0] + e[2]) / 2;
-    const cy = (e[1] + e[3]) / 2;
-    const hw = (e[2] - e[0]) * 0.5 * this.ratio;
-    const hh = (e[3] - e[1]) * 0.5 * this.ratio;
-    return [cx - hw, cy - hh, cx + hw, cy + hh];
+    return this.map.getView().calculateExtent(size);
   }
 
   // Flip primary's opacity between 0 (warp is rendering content) and

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -510,9 +510,12 @@ export default class FramePool {
       this.primary.setOpacity(this._userOpacity);
       this._settingOpacityInternally = false;
     }
-    // Clear the custom property so the playlist falls back to
-    // layer.opacity again (which is now the user's value).
+    // Clear the custom properties so the playlist falls back to
+    // layer.opacity again (which is now the user's value), and so
+    // any later _interpHiding check from a stale path sees a clean
+    // state.
     this.primary.set('_userOpacity', undefined, true);
+    this.primary.set('_interpHiding', undefined, true);
     if (this._primaryVisListener) {
       this.primary.un('change:visible', this._primaryVisListener);
       this._primaryVisListener = null;
@@ -523,6 +526,8 @@ export default class FramePool {
     }
     this.map.removeLayer(this.warpLayer);
     this.warpLayer = null;
+    this._emptyCanvas = null;
+    this._userOpacity = undefined;
   }
 
   // Toggle interpolated display on/off. radar.js calls this from
@@ -616,21 +621,16 @@ export default class FramePool {
     if (idx < 0) return;
     if (idx > 0) {
       const prevTime = this.windowTimes[idx - 1];
-      if (this._isLoaded(prevTime)) {
+      if (this.isTimeLoaded(prevTime)) {
         this.interpolator.computeFlow(prevTime, time);
       }
     }
     if (idx < this.windowTimes.length - 1) {
       const nextTime = this.windowTimes[idx + 1];
-      if (this._isLoaded(nextTime)) {
+      if (this.isTimeLoaded(nextTime)) {
         this.interpolator.computeFlow(time, nextTime);
       }
     }
-  }
-
-  _isLoaded(time) {
-    const slot = this.slots.find((s) => s.time === time);
-    return !!(slot && slot.loaded);
   }
 
   // Re-compute flow for every pair in the current window whose
@@ -643,7 +643,7 @@ export default class FramePool {
     for (let i = 0; i < this.windowTimes.length - 1; i++) {
       const tA = this.windowTimes[i];
       const tB = this.windowTimes[i + 1];
-      if (this._isLoaded(tA) && this._isLoaded(tB)) {
+      if (this.isTimeLoaded(tA) && this.isTimeLoaded(tB)) {
         this.interpolator.computeFlow(tA, tB);
       }
     }
@@ -669,10 +669,15 @@ export default class FramePool {
   //     would get overridden back to 0 on the next RAF).
   _setPrimaryTransparent(transparent) {
     if (!this.warpLayer) return;
+    // Write _interpHiding BEFORE the opacity-equal early return.
+    // If opacity already matches the desired value but _interpHiding
+    // still holds a stale truthy value from an earlier transparent
+    // swap, the playlist's change:opacity filter will keep rejecting
+    // the user's slider drags.
+    this.primary.set('_interpHiding', transparent, true);
     const desired = transparent ? 0 : this._userOpacity;
     if (this.primary.getOpacity() === desired) return;
     this._settingOpacityInternally = true;
-    this.primary.set('_interpHiding', transparent, true);
     this.primary.setOpacity(desired);
     this._settingOpacityInternally = false;
   }

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -144,50 +144,25 @@ export default class FramePool {
       map.addLayer(layer);
     }
 
+    // Debounce moveend-driven invalidate+prefetch. OL fires a
+    // moveend at the end of every view animation, and a scroll-wheel
+    // zoom decomposes into many short animations as the wheel ticks
+    // — so a fast scroll burst fires several moveends in quick
+    // succession and would trigger several rounds of prefetch
+    // (3-6 fetches per visible pool each). The aborted requests
+    // still leave the browser before our AbortController catches
+    // them, hammering the WMS server. Wait for ~200ms of quiet
+    // before doing the work; sticky-while-loading covers the user
+    // during the debounce window.
+    this._moveendTimer = null;
     map.on('moveend', () => {
-      // Probe each slot: if its cached image doesn't cover the new
-      // view, its `loaded` flag is stale. Reset so the timeline reflects
-      // which cells need to be re-fetched for the current view.
-      const ctx = this._getViewContext();
-      if (ctx) {
-        // First, drop each source's cached ImageWMS wrapper. OL's own
-        // render pipeline calls getImage on the primary layer's source
-        // during a pan, and the cache locks in a wrapper whose extent
-        // reflects the intermediate view. Without this reset, loads
-        // completing on those wrappers would store mid-pan extents
-        // that fail extentApproxEqual against neighbouring slots
-        // (which didn't get render-hit during the pan), and the
-        // interpolator would skip computeFlow for any pair involving
-        // the current slot — visible as two permanently-green cells
-        // on the timeline.
-        for (const slot of this.slots) {
-          slot.source.resetImageCache();
-        }
-        for (const slot of this.slots) {
-          if (!slot.time) {
-            continue; // eslint-disable-line no-continue
-          }
-          const fresh = slot.source.hasLoadedImageForView(
-            ctx.extent,
-            ctx.resolution,
-            1,
-            ctx.projection,
-          );
-          if (slot.loaded !== fresh) {
-            slot.loaded = fresh;
-            this._notifyLoadChange(slot);
-            // Slot's sticky no longer covers the view — any flow pair
-            // built from the now-stale bitmap is suspect. Drop the
-            // frame texture and pair entries; onSlotLoaded will repopulate
-            // when the slot refetches.
-            if (!fresh && this.interpolator && slot.time) {
-              this.interpolator.invalidateSlot(slot.time);
-            }
-          }
-        }
+      if (this._moveendTimer) {
+        clearTimeout(this._moveendTimer);
       }
-      this._prefetchAroundCurrent();
-      this._notifyAllFlowState();
+      this._moveendTimer = setTimeout(() => {
+        this._moveendTimer = null;
+        this._handleMoveend();
+      }, 200);
     });
 
     // When the layer becomes visible after being hidden, catch up on
@@ -637,6 +612,52 @@ export default class FramePool {
     this._warpState.t = effectiveT;
 
     this.warpLayer.getSource().changed();
+  }
+
+  // Run once per debounced moveend. Drops OL's cached image wrapper
+  // on every slot source (so OL re-creates a fresh wrapper at the
+  // current view), checks each slot's loaded state against the new
+  // view, invalidates interpolator frames whose stickies no longer
+  // cover, then triggers prefetch around the current frame.
+  _handleMoveend() {
+    const ctx = this._getViewContext();
+    if (ctx) {
+      // First, drop each source's cached ImageWMS wrapper. OL's own
+      // render pipeline calls getImage on the primary layer's source
+      // during a pan, and the cache locks in a wrapper whose extent
+      // reflects the intermediate view. Without this reset, loads
+      // completing on those wrappers would store mid-pan extents
+      // that fail extentApproxEqual against neighbouring slots
+      // (which didn't get render-hit during the pan), and the
+      // interpolator would skip computeFlow for any pair involving
+      // the current slot — visible as two permanently-green cells
+      // on the timeline.
+      for (const slot of this.slots) {
+        slot.source.resetImageCache();
+      }
+      for (const slot of this.slots) {
+        if (!slot.time) continue; // eslint-disable-line no-continue
+        const fresh = slot.source.hasLoadedImageForView(
+          ctx.extent,
+          ctx.resolution,
+          1,
+          ctx.projection,
+        );
+        if (slot.loaded !== fresh) {
+          slot.loaded = fresh;
+          this._notifyLoadChange(slot);
+          // Slot's sticky no longer covers the view — any flow pair
+          // built from the now-stale bitmap is suspect. Drop the
+          // frame texture and pair entries; onSlotLoaded will repopulate
+          // when the slot refetches.
+          if (!fresh && this.interpolator && slot.time) {
+            this.interpolator.invalidateSlot(slot.time);
+          }
+        }
+      }
+    }
+    this._prefetchAroundCurrent();
+    this._notifyAllFlowState();
   }
 
   // Called from imageloadend after a slot's bitmap is uploaded to

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -386,6 +386,16 @@ export default class FramePool {
     this._userOpacity = this.primary.getOpacity();
     this._settingOpacityInternally = false;
 
+    // 1×1 transparent canvas we return from canvasFunction when the
+    // warp has nothing to show. Returning null from canvasFunction
+    // causes ol/source/ImageCanvas to keep its last cached canvas
+    // visible — which means old warp content stays displayed after
+    // stop + step. Returning a new empty canvas forces the layer to
+    // display a transparent pixel instead, so primary shows through.
+    this._emptyCanvas = document.createElement('canvas');
+    this._emptyCanvas.width = 1;
+    this._emptyCanvas.height = 1;
+
     // canvasFunction is given the size OL wants rendered, in device
     // pixels. That's usually viewSize × ratio × devicePixelRatio —
     // larger than A's native bitmap on retina because the slot's
@@ -393,10 +403,10 @@ export default class FramePool {
     // canvas covers the requested extent; the shader upscales from
     // A's bitmap with bilinear filtering.
     const canvasFunction = (extent, resolution, pixelRatio, size) => {
-      if (!this.interpActive) return null;
+      if (!this.interpActive) return this._emptyCanvas;
       const { timeA, timeB, t } = this._warpState;
-      if (!timeA || !timeB) return null;
-      if (!interpolator.hasFlow(timeA, timeB)) return null;
+      if (!timeA || !timeB) return this._emptyCanvas;
+      if (!interpolator.hasFlow(timeA, timeB)) return this._emptyCanvas;
       return interpolator.renderAt(timeA, timeB, t, size[0], size[1]);
     };
 

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -369,19 +369,22 @@ export default class FramePool {
     return true;
   }
 
-  // Attach an interpolator and build the warp layer. Warp is an
-  // overlay on top of the primary — it mirrors primary's visible
-  // and opacity. canvasFunction returns null while flow isn't ready
-  // (warp renders nothing; primary shows through). When ready, warp
-  // renders interpolated content; since warp is also at the user's
-  // opacity, the result is a mild double-exposure over primary — a
-  // known Phase 2 artifact that Phase 4 polishes out by making the
-  // swap cleaner. For now it validates the whole GL pipeline.
+  // Attach an interpolator and build the warp layer. Warp overlays
+  // the primary. Visibility mirrors primary's so the user's
+  // layer-toggle button keeps working against the primary. Opacity
+  // is handled as a clean swap: while warp is rendering content,
+  // primary's opacity drops to 0; when warp has nothing to show,
+  // primary is restored to the user's chosen opacity. This avoids
+  // both the button-revert bug from the earlier visibility-swap
+  // attempt and the double-exposure artifact of naive overlay.
   setInterpolator(interpolator) {
     if (this.interpolator === interpolator) return;
     this._teardownWarpLayer();
     this.interpolator = interpolator;
     if (!interpolator) return;
+
+    this._userOpacity = this.primary.getOpacity();
+    this._settingOpacityInternally = false;
 
     // canvasFunction is given the size OL wants rendered, in device
     // pixels. That's usually viewSize × ratio × devicePixelRatio —
@@ -400,20 +403,22 @@ export default class FramePool {
     this.warpLayer = new ImageLayer({
       name: `${this.primary.get('name')}__warp`,
       visible: this.primary.getVisible(),
-      opacity: this.primary.getOpacity(),
+      opacity: this._userOpacity,
       // Match the primary's WMS ratio (1.5 by default in radar.js)
       // so OL asks canvasFunction for the same extent-and-size the
-      // primary's slot images were fetched at. Ratio=1 asked OL to
-      // interpret the 1.5× canvas as a 1× canvas — that's what was
-      // shrinking content to the middle of the viewport.
+      // primary's slot images were fetched at.
       source: new ImageCanvasSource({ canvasFunction, ratio: this.ratio }),
     });
 
     this._primaryVisListener = () => {
       this.warpLayer.setVisible(this.primary.getVisible());
     };
+    // Opacity listener is guarded so our own transparent/restore
+    // writes don't get captured as "the user's chosen opacity".
     this._primaryOpacityListener = () => {
-      this.warpLayer.setOpacity(this.primary.getOpacity());
+      if (this._settingOpacityInternally) return;
+      this._userOpacity = this.primary.getOpacity();
+      this.warpLayer.setOpacity(this._userOpacity);
     };
     this.primary.on('change:visible', this._primaryVisListener);
     this.primary.on('change:opacity', this._primaryOpacityListener);
@@ -436,6 +441,15 @@ export default class FramePool {
 
   _teardownWarpLayer() {
     if (!this.warpLayer) return;
+    // If we'd zeroed primary's opacity for warp display, restore it
+    // before dropping the warp layer so the user isn't left with an
+    // invisible radar.
+    if (this._userOpacity !== undefined
+        && this.primary.getOpacity() === 0) {
+      this._settingOpacityInternally = true;
+      this.primary.setOpacity(this._userOpacity);
+      this._settingOpacityInternally = false;
+    }
     if (this._primaryVisListener) {
       this.primary.un('change:visible', this._primaryVisListener);
       this._primaryVisListener = null;
@@ -449,19 +463,19 @@ export default class FramePool {
   }
 
   // Toggle interpolated display on/off. radar.js calls this from
-  // play() / stop(). Forces the warp source to re-run canvasFunction
-  // so the next render reflects the new state (active → render
-  // content; inactive → return null, layer renders nothing and
-  // primary shows through).
+  // play() / stop(). On stop, restore primary's opacity so the user
+  // sees the discrete frame at their chosen opacity again.
   setInterpActive(active) {
     if (this.interpActive === active) return;
     this.interpActive = active;
+    if (!active) this._setPrimaryTransparent(false);
     if (this.warpLayer) this.warpLayer.getSource().changed();
   }
 
   // Render the warp at fractional t between current frame (A) and
-  // the next in windowTimes (B). No-op unless the interpolator is
-  // attached and has a valid window.
+  // the next in windowTimes (B). Toggles primary's opacity: zeroed
+  // while warp has real content (so the user sees only the
+  // interpolated frame), restored to _userOpacity otherwise.
   showInterpolated(t) {
     if (!this.interpolator || !this.interpActive) return;
     if (!this.windowTimes || !this.currentTime) return;
@@ -472,11 +486,27 @@ export default class FramePool {
     const timeB = this.windowTimes[nextIdx];
     if (!timeB) return;
 
+    const hasFlow = this.interpolator.hasFlow(this.currentTime, timeB);
+    this._setPrimaryTransparent(hasFlow);
+    if (!hasFlow) return;
+
     this._warpState.timeA = this.currentTime;
     this._warpState.timeB = timeB;
     this._warpState.t = t;
 
     this.warpLayer.getSource().changed();
+  }
+
+  // Flip primary's opacity between 0 (warp is rendering content) and
+  // the user's chosen opacity. Guarded so our own writes don't get
+  // captured by the change:opacity listener as a new "user opacity".
+  _setPrimaryTransparent(transparent) {
+    if (!this.warpLayer) return;
+    const desired = transparent ? 0 : this._userOpacity;
+    if (this.primary.getOpacity() === desired) return;
+    this._settingOpacityInternally = true;
+    this.primary.setOpacity(desired);
+    this._settingOpacityInternally = false;
   }
 
   // Is this time's slot's current-view image loaded?

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -106,6 +106,10 @@ export default class FramePool {
         // pending refetch).
         if (this.interpolator) {
           this.interpolator.onSlotLoaded(slot, event.image.getImage(), event.image.getExtent());
+          // Compute flow for pairs neighbouring this time that now
+          // have both endpoints loaded. The interpolator decides
+          // whether to run LK or zero-fill based on its useFlow flag.
+          this._checkFlowCompute(slot.time);
         }
         // Fan out: as the current ring of frames finishes loading,
         // trigger the next ring outward. Throttles total wire traffic
@@ -381,6 +385,11 @@ export default class FramePool {
   setInterpolator(interpolator) {
     if (this.interpolator === interpolator) return;
     this._teardownWarpLayer();
+    // Release the old interpolator's GPU resources before dropping
+    // the reference, otherwise textures / programs / FBOs leak.
+    if (this.interpolator && this.interpolator !== interpolator) {
+      this.interpolator.dispose();
+    }
     this.interpolator = interpolator;
     if (!interpolator) return;
 
@@ -524,6 +533,51 @@ export default class FramePool {
     this._warpState.t = t;
 
     this.warpLayer.getSource().changed();
+  }
+
+  // Called from imageloadend after a slot's bitmap is uploaded to
+  // the interpolator. Triggers computeFlow for the (prev, this) and
+  // (this, next) pairs when both endpoints are loaded. No-op if the
+  // interpolator isn't attached or the time isn't in the current
+  // window. Non-wrapping: the last window slot doesn't pair with
+  // the first.
+  _checkFlowCompute(time) {
+    if (!this.interpolator || !this.windowTimes) return;
+    const idx = this.windowTimes.indexOf(time);
+    if (idx < 0) return;
+    if (idx > 0) {
+      const prevTime = this.windowTimes[idx - 1];
+      if (this._isLoaded(prevTime)) {
+        this.interpolator.computeFlow(prevTime, time);
+      }
+    }
+    if (idx < this.windowTimes.length - 1) {
+      const nextTime = this.windowTimes[idx + 1];
+      if (this._isLoaded(nextTime)) {
+        this.interpolator.computeFlow(time, nextTime);
+      }
+    }
+  }
+
+  _isLoaded(time) {
+    const slot = this.slots.find((s) => s.time === time);
+    return !!(slot && slot.loaded);
+  }
+
+  // Re-compute flow for every pair in the current window whose
+  // both endpoints are loaded. Called from radar.js after a mode
+  // switch (crossfade ↔ flow) — the interpolator cleared its flow
+  // cache, so without this the warp layer would stay blank until
+  // the next frame arrived via prefetch.
+  refreshFlows() {
+    if (!this.interpolator || !this.windowTimes) return;
+    for (let i = 0; i < this.windowTimes.length - 1; i++) {
+      const tA = this.windowTimes[i];
+      const tB = this.windowTimes[i + 1];
+      if (this._isLoaded(tA) && this._isLoaded(tB)) {
+        this.interpolator.computeFlow(tA, tB);
+      }
+    }
   }
 
   // Current view extent padded by this.ratio, mirroring how

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -453,14 +453,15 @@ export default class FramePool {
     // Retroactively upload already-loaded slot bitmaps so hasFlow
     // returns true on the first showInterpolated call after a delayed
     // attach (canInterpolate is async; some slots may already be
-    // loaded by the time we get here).
+    // loaded by the time we get here). Pass extent along so hasFlow's
+    // extent check isn't permanently stuck on a null stored extent.
     for (const slot of this.slots) {
       if (!slot.loaded || !slot.time) continue; // eslint-disable-line no-continue
       const wrapper = slot.source._sticky;
       if (!wrapper) continue; // eslint-disable-line no-continue
       const img = wrapper.getImage();
       if (img && img.complete && img.naturalWidth) {
-        interpolator.onSlotLoaded(slot, img);
+        interpolator.onSlotLoaded(slot, img, wrapper.getExtent());
       }
     }
   }
@@ -526,7 +527,17 @@ export default class FramePool {
     const viewExtent = this._viewExtentScaled();
     const hasFlow = this.interpolator.hasFlow(this.currentTime, timeB, viewExtent);
     this._setPrimaryTransparent(hasFlow);
-    if (!hasFlow) return;
+
+    if (!hasFlow) {
+      // Force canvasFunction to re-run (returning our empty 1×1
+      // canvas) so the warp layer drops any stale content that was
+      // last drawn for a previous (A, B). Otherwise after pan/zoom
+      // invalidates the frames, the warp keeps displaying its last
+      // interpolated image over the primary — looks like "a frame
+      // stuck" until the window slides around to it again.
+      this.warpLayer.getSource().changed();
+      return;
+    }
 
     this._warpState.timeA = this.currentTime;
     this._warpState.timeB = timeB;

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -369,22 +369,20 @@ export default class FramePool {
     return true;
   }
 
-  // Attach an interpolator and build the warp layer it will render
-  // into. Called once from radar.js after canInterpolate resolves.
-  // Idempotent — a second call with the same interpolator is a no-op;
-  // with a different one, the old warp layer is torn down first.
+  // Attach an interpolator and build the warp layer. Warp is an
+  // overlay on top of the primary — it mirrors primary's visible
+  // and opacity. canvasFunction returns null while flow isn't ready
+  // (warp renders nothing; primary shows through). When ready, warp
+  // renders interpolated content; since warp is also at the user's
+  // opacity, the result is a mild double-exposure over primary — a
+  // known Phase 2 artifact that Phase 4 polishes out by making the
+  // swap cleaner. For now it validates the whole GL pipeline.
   setInterpolator(interpolator) {
     if (this.interpolator === interpolator) return;
     this._teardownWarpLayer();
     this.interpolator = interpolator;
     if (!interpolator) return;
 
-    this._userVisible = this.primary.getVisible();
-    this._settingVisInternally = false;
-
-    // canvasFunction reads _warpState populated by showInterpolated.
-    // Returning null leaves the layer blank — used when interp isn't
-    // active yet, or when flow isn't ready for the current pair.
     const canvasFunction = () => {
       if (!this.interpActive) return null;
       const { timeA, timeB, t } = this._warpState;
@@ -395,19 +393,18 @@ export default class FramePool {
 
     this.warpLayer = new ImageLayer({
       name: `${this.primary.get('name')}__warp`,
-      visible: false,
+      visible: this.primary.getVisible(),
       opacity: this.primary.getOpacity(),
-      source: new ImageCanvasSource({ canvasFunction, ratio: 1 }),
+      // Match the primary's WMS ratio (1.5 by default in radar.js)
+      // so OL asks canvasFunction for the same extent-and-size the
+      // primary's slot images were fetched at. Ratio=1 asked OL to
+      // interpret the 1.5× canvas as a 1× canvas — that's what was
+      // shrinking content to the middle of the viewport.
+      source: new ImageCanvasSource({ canvasFunction, ratio: this.ratio }),
     });
 
-    // Track user's visibility and opacity choices on the primary
-    // layer and mirror them onto warp. Internal visibility swaps
-    // (triggered by setInterpActive / showInterpolated) are filtered
-    // via _settingVisInternally so they don't re-write _userVisible.
     this._primaryVisListener = () => {
-      if (this._settingVisInternally) return;
-      this._userVisible = this.primary.getVisible();
-      this._syncVisibility();
+      this.warpLayer.setVisible(this.primary.getVisible());
     };
     this._primaryOpacityListener = () => {
       this.warpLayer.setOpacity(this.primary.getOpacity());
@@ -446,57 +443,34 @@ export default class FramePool {
   }
 
   // Toggle interpolated display on/off. radar.js calls this from
-  // play() / stop(). Actual layer swap happens inside _setWarpShowing,
-  // which only flips layers once we actually have content to show —
-  // avoids a blank frame at the start of play before flow is ready.
+  // play() / stop(). Forces the warp source to re-run canvasFunction
+  // so the next render reflects the new state (active → render
+  // content; inactive → return null, layer renders nothing and
+  // primary shows through).
   setInterpActive(active) {
     if (this.interpActive === active) return;
     this.interpActive = active;
-    if (!active) this._setWarpShowing(false);
     if (this.warpLayer) this.warpLayer.getSource().changed();
   }
 
-  // Render the warp at fractional t between current frame (A) and the
-  // next in windowTimes (B). No-op unless we've been put into interp
-  // mode AND the pool has a valid window AND the interpolator has
-  // what it needs to produce output. On first successful render,
-  // swaps layer visibility from primary to warp.
+  // Render the warp at fractional t between current frame (A) and
+  // the next in windowTimes (B). No-op unless the interpolator is
+  // attached and has a valid window.
   showInterpolated(t) {
     if (!this.interpolator || !this.interpActive) return;
     if (!this.windowTimes || !this.currentTime) return;
+    if (!this.warpLayer) return;
     const curIdx = this.windowTimes.indexOf(this.currentTime);
     if (curIdx < 0) return;
     const nextIdx = (curIdx + 1) % this.size;
     const timeB = this.windowTimes[nextIdx];
     if (!timeB) return;
-    if (!this.interpolator.hasFlow(this.currentTime, timeB)) return;
 
     this._warpState.timeA = this.currentTime;
     this._warpState.timeB = timeB;
     this._warpState.t = t;
 
     this.warpLayer.getSource().changed();
-    this._setWarpShowing(true);
-  }
-
-  // Internal: flip primary ↔ warp visibility without disturbing the
-  // user's layer-toggle state.
-  _setWarpShowing(showing) {
-    if (!this.warpLayer) return;
-    const desiredWarp = showing && this._userVisible;
-    const desiredPrimary = !showing && this._userVisible;
-    if (this.warpLayer.getVisible() === desiredWarp
-        && this.primary.getVisible() === desiredPrimary) return;
-    this._settingVisInternally = true;
-    this.warpLayer.setVisible(desiredWarp);
-    this.primary.setVisible(desiredPrimary);
-    this._settingVisInternally = false;
-  }
-
-  _syncVisibility() {
-    if (!this.warpLayer) return;
-    const warpShowing = this.warpLayer.getVisible();
-    this._setWarpShowing(warpShowing);
   }
 
   // Is this time's slot's current-view image loaded?

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -60,6 +60,12 @@ export default class FramePool {
     this._warpState = { timeA: null, timeB: null, t: 0 };
 
     this.onLoadStateChange = null;
+    // Per-index callback fired when the pair starting at that index
+    // may have changed flow-ready status — both endpoints loaded
+    // AND the interpolator has a flow pair for (windowTimes[i],
+    // windowTimes[i+1]). Radar.js uses it to paint a "loaded but
+    // no-flow" indicator on the timeline.
+    this.onFlowStateChange = null;
     this.windowTimes = null;
     this.currentTime = null;
 
@@ -168,6 +174,7 @@ export default class FramePool {
         }
       }
       this._prefetchAroundCurrent();
+      this._notifyAllFlowState();
     });
 
     // When the layer becomes visible after being hidden, catch up on
@@ -241,6 +248,7 @@ export default class FramePool {
         && prev.elevation === now.elevation
       );
       this.interpolator.onParamsChanged({ flowInvariant });
+      this._notifyAllFlowState();
     }
     this._prefetchAroundCurrent();
   }
@@ -368,6 +376,7 @@ export default class FramePool {
         this.onLoadStateChange(i, this.isPositionLoaded(i));
       }
     }
+    this._notifyAllFlowState();
   }
 
   // Point the primary at the slot matching `time`. The swap is
@@ -528,6 +537,9 @@ export default class FramePool {
     this.warpLayer = null;
     this._emptyCanvas = null;
     this._userOpacity = undefined;
+    // Interp is gone → no pair can be flow-ready. Refresh the
+    // timeline so the indicator drops any pending highlights.
+    this._notifyAllFlowState();
   }
 
   // Toggle interpolated display on/off. radar.js calls this from
@@ -636,6 +648,7 @@ export default class FramePool {
         this.interpolator.computeFlow(time, nextTime);
       }
     }
+    this._notifyAllFlowState();
   }
 
   // Re-compute flow for every pair in the current window whose
@@ -652,6 +665,7 @@ export default class FramePool {
         this.interpolator.computeFlow(tA, tB);
       }
     }
+    this._notifyAllFlowState();
   }
 
   // Current map view extent in world coords (EPSG:3857 meters).
@@ -691,6 +705,26 @@ export default class FramePool {
   isTimeLoaded(time) {
     const slot = this.slots.find((s) => s.time === time);
     return !!(slot && slot.loaded);
+  }
+
+  // Does the pair starting at `index` in the current window have a
+  // flow computed? Used by the timeline UI to mark cells that are
+  // loaded but will still "jump" during playback because the warp
+  // has no interpolation to render.
+  isPairFlowReady(index) {
+    if (!this.interpolator || !this.windowTimes) return false;
+    if (index < 0 || index >= this.windowTimes.length - 1) return false;
+    const tA = this.windowTimes[index];
+    const tB = this.windowTimes[index + 1];
+    if (!tA || !tB) return false;
+    return this.interpolator.hasFlow(tA, tB);
+  }
+
+  _notifyAllFlowState() {
+    if (!this.onFlowStateChange || !this.windowTimes) return;
+    for (let i = 0; i < this.size; i++) {
+      this.onFlowStateChange(i, this.isPairFlowReady(i));
+    }
   }
 
   // Load state at timeline position (0..size-1).

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -407,6 +407,11 @@ export default class FramePool {
 
     this._userOpacity = this.primary.getOpacity();
     this._settingOpacityInternally = false;
+    // Publish _userOpacity as a custom property on the primary layer
+    // so the playlist UI can show the user's chosen opacity even
+    // when our transparent swap has the actual layer.opacity at 0.
+    // Silent set — no propertychange event fires.
+    this.primary.set('_userOpacity', this._userOpacity, true);
 
     // 1×1 transparent canvas we return from canvasFunction when the
     // warp has nothing to show. Returning null from canvasFunction
@@ -460,6 +465,7 @@ export default class FramePool {
     this._primaryOpacityListener = () => {
       if (this._settingOpacityInternally) return;
       this._userOpacity = this.primary.getOpacity();
+      this.primary.set('_userOpacity', this._userOpacity, true);
       this.warpLayer.setOpacity(this._userOpacity);
     };
     this.primary.on('change:visible', this._primaryVisListener);
@@ -504,6 +510,9 @@ export default class FramePool {
       this.primary.setOpacity(this._userOpacity);
       this._settingOpacityInternally = false;
     }
+    // Clear the custom property so the playlist falls back to
+    // layer.opacity again (which is now the user's value).
+    this.primary.set('_userOpacity', undefined, true);
     if (this._primaryVisListener) {
       this.primary.un('change:visible', this._primaryVisListener);
       this._primaryVisListener = null;

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -416,7 +416,10 @@ export default class FramePool {
 
     this.warpLayer = new ImageLayer({
       name: `${this.primary.get('name')}__warp`,
-      visible: this.primary.getVisible(),
+      // Hidden until interp becomes active — OL skips the layer
+      // entirely (no canvasFunction calls, no compositor work) while
+      // playback is paused, which lets the GPU process actually idle.
+      visible: false,
       opacity: this._userOpacity,
       // Match the primary's WMS ratio (1.5 by default in radar.js)
       // so OL asks canvasFunction for the same extent-and-size the
@@ -425,7 +428,7 @@ export default class FramePool {
     });
 
     this._primaryVisListener = () => {
-      this.warpLayer.setVisible(this.primary.getVisible());
+      this.warpLayer.setVisible(this.interpActive && this.primary.getVisible());
     };
     // Opacity listener is guarded so our own transparent/restore
     // writes don't get captured as "the user's chosen opacity".
@@ -477,13 +480,18 @@ export default class FramePool {
   }
 
   // Toggle interpolated display on/off. radar.js calls this from
-  // play() / stop(). On stop, restore primary's opacity so the user
-  // sees the discrete frame at their chosen opacity again.
+  // play() / stop(). Show/hide the warp layer accordingly — while
+  // hidden, OL skips it during render so the GPU process can idle.
+  // On stop, also restore primary's opacity so the user sees the
+  // discrete frame at their chosen opacity again.
   setInterpActive(active) {
     if (this.interpActive === active) return;
     this.interpActive = active;
     if (!active) this._setPrimaryTransparent(false);
-    if (this.warpLayer) this.warpLayer.getSource().changed();
+    if (this.warpLayer) {
+      this.warpLayer.setVisible(active && this.primary.getVisible());
+      this.warpLayer.getSource().changed();
+    }
   }
 
   // Render the warp at fractional t between current frame (A) and

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -100,11 +100,12 @@ export default class FramePool {
         }
         this.map.render();
         // Hand the fresh bitmap to the interpolator so it can upload
-        // a GL texture keyed by the slot's TIME. Safe for interp=null
-        // pools (lightning, observation) — the method is only called
-        // when an interpolator has been attached.
+        // a GL texture keyed by the slot's TIME. Pass the extent the
+        // image was loaded at too, so hasFlow can detect when the
+        // view has since moved to a different extent (zoom/pan
+        // pending refetch).
         if (this.interpolator) {
-          this.interpolator.onSlotLoaded(slot, event.image.getImage());
+          this.interpolator.onSlotLoaded(slot, event.image.getImage(), event.image.getExtent());
         }
         // Fan out: as the current ring of frames finishes loading,
         // trigger the next ring outward. Throttles total wire traffic
@@ -406,7 +407,10 @@ export default class FramePool {
       if (!this.interpActive) return this._emptyCanvas;
       const { timeA, timeB, t } = this._warpState;
       if (!timeA || !timeB) return this._emptyCanvas;
-      if (!interpolator.hasFlow(timeA, timeB)) return this._emptyCanvas;
+      // Pass extent to hasFlow so we bail when the view has moved
+      // past what A and B were loaded for — OL would otherwise blit
+      // our old-extent canvas at the new extent.
+      if (!interpolator.hasFlow(timeA, timeB, extent)) return this._emptyCanvas;
       return interpolator.renderAt(timeA, timeB, t, size[0], size[1]);
     };
 
@@ -496,7 +500,14 @@ export default class FramePool {
     const timeB = this.windowTimes[nextIdx];
     if (!timeB) return;
 
-    const hasFlow = this.interpolator.hasFlow(this.currentTime, timeB);
+    // Use the current view extent scaled by this.ratio to match
+    // what ImageCanvasSource will pass to canvasFunction. If the
+    // view has moved past what A and B were loaded for, hasFlow
+    // returns false — primary becomes visible again (at user
+    // opacity) so its stale-while-loading sticky can bridge the
+    // gap until new frames arrive for the new extent.
+    const viewExtent = this._viewExtentScaled();
+    const hasFlow = this.interpolator.hasFlow(this.currentTime, timeB, viewExtent);
     this._setPrimaryTransparent(hasFlow);
     if (!hasFlow) return;
 
@@ -505,6 +516,23 @@ export default class FramePool {
     this._warpState.t = t;
 
     this.warpLayer.getSource().changed();
+  }
+
+  // Current view extent padded by this.ratio, mirroring how
+  // ImageCanvasSource scales the requested extent before handing
+  // it to canvasFunction. Used for hasFlow's extent check so the
+  // view extent we compare against matches what frames were loaded
+  // for (StickyImageWMS uses the same ratio when fetching).
+  _viewExtentScaled() {
+    const view = this.map.getView();
+    const size = this.map.getSize();
+    if (!size) return null;
+    const e = view.calculateExtent(size);
+    const cx = (e[0] + e[2]) / 2;
+    const cy = (e[1] + e[3]) / 2;
+    const hw = (e[2] - e[0]) * 0.5 * this.ratio;
+    const hh = (e[3] - e[1]) * 0.5 * this.ratio;
+    return [cx - hw, cy - hh, cx + hw, cy + hh];
   }
 
   // Flip primary's opacity between 0 (warp is rendering content) and

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -1,4 +1,5 @@
 import ImageLayer from 'ol/layer/Image';
+import ImageCanvasSource from 'ol/source/ImageCanvas';
 import StickyImageWMS from './stickyImageWMS';
 
 const SYNC_PARAM_KEYS = ['LAYERS', 'STYLES', 'FORMAT', 'ELEVATION'];
@@ -35,10 +36,16 @@ export default class FramePool {
     this.size = size;
     this.slots = [];
     this.ratio = ratio;
-    // Optional RadarInterpolator instance. When present, later phases
-    // dispatch per-RAF warp requests through it; Phase 1 just stores
-    // the reference and keeps showInterpolated as a no-op.
+    // Optional RadarInterpolator instance. When present, showInterpolated
+    // drives the interpolator's warp shader and a separate warp layer
+    // displays the interpolated canvas.
     this.interpolator = interpolator;
+    this.warpLayer = null;
+    this.interpActive = false;
+    // Updated each RAF so the warp source's canvasFunction can read
+    // the current (A, B, t) it should render. Kept as an object
+    // reference so closures in setInterpolator can read through it.
+    this._warpState = { timeA: null, timeB: null, t: 0 };
 
     this.onLoadStateChange = null;
     this.windowTimes = null;
@@ -92,6 +99,13 @@ export default class FramePool {
           this.primary.changed();
         }
         this.map.render();
+        // Hand the fresh bitmap to the interpolator so it can upload
+        // a GL texture keyed by the slot's TIME. Safe for interp=null
+        // pools (lightning, observation) — the method is only called
+        // when an interpolator has been attached.
+        if (this.interpolator) {
+          this.interpolator.onSlotLoaded(slot, event.image.getImage());
+        }
         // Fan out: as the current ring of frames finishes loading,
         // trigger the next ring outward. Throttles total wire traffic
         // (never more than 2 new requests per ring) while eventually
@@ -126,6 +140,13 @@ export default class FramePool {
           if (slot.loaded !== fresh) {
             slot.loaded = fresh;
             this._notifyLoadChange(slot);
+            // Slot's sticky no longer covers the view — any flow pair
+            // built from the now-stale bitmap is suspect. Drop the
+            // frame texture and pair entries; onSlotLoaded will repopulate
+            // when the slot refetches.
+            if (!fresh && this.interpolator && slot.time) {
+              this.interpolator.invalidateSlot(slot.time);
+            }
           }
         }
       }
@@ -169,14 +190,14 @@ export default class FramePool {
         || snap.elevation !== prev.elevation
       ) {
         this._primaryParamsSnap = snap;
-        this._resyncAllParams();
+        this._resyncAllParams(prev, snap);
       }
     };
     p.on('change', fn);
     this._psListener = { target: p, fn };
   }
 
-  _resyncAllParams() {
+  _resyncAllParams(prev, now) {
     const p = this.primary.getSource();
     const pParams = pickSyncParams(p.getParams());
     for (const slot of this.slots) {
@@ -190,6 +211,19 @@ export default class FramePool {
       // Product/style/URL changed — any stale sticky is now for a
       // different layer and would bleed through on the next pan/zoom.
       slot.source.invalidateSticky();
+    }
+    // Flow is STYLES- and FORMAT-invariant: a colormap swap doesn't
+    // change the underlying motion field, so the interpolator can
+    // keep its flow cache and reuse it with the re-styled bitmaps
+    // once they land. URL / LAYERS / ELEVATION changes cross physical
+    // fields and must drop the cache.
+    if (this.interpolator && prev && now) {
+      const flowInvariant = (
+        prev.url === now.url
+        && prev.layers === now.layers
+        && prev.elevation === now.elevation
+      );
+      this.interpolator.onParamsChanged({ flowInvariant });
     }
     this._prefetchAroundCurrent();
   }
@@ -286,6 +320,10 @@ export default class FramePool {
       const slot = needAssign[j];
       const newTime = unassigned[j];
       if (!newTime) break;
+      // Capture old time BEFORE overwriting so the interpolator can
+      // drop flow pairs referencing the dropped TIME. Doing this
+      // after `slot.time = newTime` would lose the identity we need.
+      const oldTime = slot.time;
       slot.time = newTime;
       slot.loaded = false;
       slot.source.updateParams({
@@ -296,6 +334,9 @@ export default class FramePool {
       // for the old TIME and would render the wrong frame until the
       // new TIME's image lands.
       slot.source.invalidateSticky();
+      if (this.interpolator && oldTime) {
+        this.interpolator.invalidateSlot(oldTime);
+      }
     }
     // Prefetch is driven by showTime / moveend (current ± neighbors),
     // not from setWindow. Reassigned slots outside the current ± 1
@@ -328,17 +369,134 @@ export default class FramePool {
     return true;
   }
 
-  // Render the slot at a fractional position `t` in [0, 1] between
-  // the current frame (A) and the next frame in windowTimes (B).
-  // Phase 1 stub: the discrete frame is already on screen because
-  // setTime → showTime(A) ran at the most recent advance; there is
-  // nothing to do per-RAF without an active interpolator. Later
-  // phases will dispatch into this.interpolator.renderAt(A, B, t)
-  // when the pair has computed flow and swap the primary layer to
-  // the warp canvas.
-  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  // Attach an interpolator and build the warp layer it will render
+  // into. Called once from radar.js after canInterpolate resolves.
+  // Idempotent — a second call with the same interpolator is a no-op;
+  // with a different one, the old warp layer is torn down first.
+  setInterpolator(interpolator) {
+    if (this.interpolator === interpolator) return;
+    this._teardownWarpLayer();
+    this.interpolator = interpolator;
+    if (!interpolator) return;
+
+    this._userVisible = this.primary.getVisible();
+    this._settingVisInternally = false;
+
+    // canvasFunction reads _warpState populated by showInterpolated.
+    // Returning null leaves the layer blank — used when interp isn't
+    // active yet, or when flow isn't ready for the current pair.
+    const canvasFunction = () => {
+      if (!this.interpActive) return null;
+      const { timeA, timeB, t } = this._warpState;
+      if (!timeA || !timeB) return null;
+      if (!interpolator.hasFlow(timeA, timeB)) return null;
+      return interpolator.renderAt(timeA, timeB, t);
+    };
+
+    this.warpLayer = new ImageLayer({
+      name: `${this.primary.get('name')}__warp`,
+      visible: false,
+      opacity: this.primary.getOpacity(),
+      source: new ImageCanvasSource({ canvasFunction, ratio: 1 }),
+    });
+
+    // Track user's visibility and opacity choices on the primary
+    // layer and mirror them onto warp. Internal visibility swaps
+    // (triggered by setInterpActive / showInterpolated) are filtered
+    // via _settingVisInternally so they don't re-write _userVisible.
+    this._primaryVisListener = () => {
+      if (this._settingVisInternally) return;
+      this._userVisible = this.primary.getVisible();
+      this._syncVisibility();
+    };
+    this._primaryOpacityListener = () => {
+      this.warpLayer.setOpacity(this.primary.getOpacity());
+    };
+    this.primary.on('change:visible', this._primaryVisListener);
+    this.primary.on('change:opacity', this._primaryOpacityListener);
+    this.map.addLayer(this.warpLayer);
+
+    // Retroactively upload already-loaded slot bitmaps so hasFlow
+    // returns true on the first showInterpolated call after a delayed
+    // attach (canInterpolate is async; some slots may already be
+    // loaded by the time we get here).
+    for (const slot of this.slots) {
+      if (!slot.loaded || !slot.time) continue; // eslint-disable-line no-continue
+      const wrapper = slot.source._sticky;
+      if (!wrapper) continue; // eslint-disable-line no-continue
+      const img = wrapper.getImage();
+      if (img && img.complete && img.naturalWidth) {
+        interpolator.onSlotLoaded(slot, img);
+      }
+    }
+  }
+
+  _teardownWarpLayer() {
+    if (!this.warpLayer) return;
+    if (this._primaryVisListener) {
+      this.primary.un('change:visible', this._primaryVisListener);
+      this._primaryVisListener = null;
+    }
+    if (this._primaryOpacityListener) {
+      this.primary.un('change:opacity', this._primaryOpacityListener);
+      this._primaryOpacityListener = null;
+    }
+    this.map.removeLayer(this.warpLayer);
+    this.warpLayer = null;
+  }
+
+  // Toggle interpolated display on/off. radar.js calls this from
+  // play() / stop(). Actual layer swap happens inside _setWarpShowing,
+  // which only flips layers once we actually have content to show —
+  // avoids a blank frame at the start of play before flow is ready.
+  setInterpActive(active) {
+    if (this.interpActive === active) return;
+    this.interpActive = active;
+    if (!active) this._setWarpShowing(false);
+    if (this.warpLayer) this.warpLayer.getSource().changed();
+  }
+
+  // Render the warp at fractional t between current frame (A) and the
+  // next in windowTimes (B). No-op unless we've been put into interp
+  // mode AND the pool has a valid window AND the interpolator has
+  // what it needs to produce output. On first successful render,
+  // swaps layer visibility from primary to warp.
   showInterpolated(t) {
-    // phase 1: no-op
+    if (!this.interpolator || !this.interpActive) return;
+    if (!this.windowTimes || !this.currentTime) return;
+    const curIdx = this.windowTimes.indexOf(this.currentTime);
+    if (curIdx < 0) return;
+    const nextIdx = (curIdx + 1) % this.size;
+    const timeB = this.windowTimes[nextIdx];
+    if (!timeB) return;
+    if (!this.interpolator.hasFlow(this.currentTime, timeB)) return;
+
+    this._warpState.timeA = this.currentTime;
+    this._warpState.timeB = timeB;
+    this._warpState.t = t;
+
+    this.warpLayer.getSource().changed();
+    this._setWarpShowing(true);
+  }
+
+  // Internal: flip primary ↔ warp visibility without disturbing the
+  // user's layer-toggle state.
+  _setWarpShowing(showing) {
+    if (!this.warpLayer) return;
+    const desiredWarp = showing && this._userVisible;
+    const desiredPrimary = !showing && this._userVisible;
+    if (this.warpLayer.getVisible() === desiredWarp
+        && this.primary.getVisible() === desiredPrimary) return;
+    this._settingVisInternally = true;
+    this.warpLayer.setVisible(desiredWarp);
+    this.primary.setVisible(desiredPrimary);
+    this._settingVisInternally = false;
+  }
+
+  _syncVisibility() {
+    if (!this.warpLayer) return;
+    const warpShowing = this.warpLayer.getVisible();
+    this._setWarpShowing(warpShowing);
   }
 
   // Is this time's slot's current-view image loaded?

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -383,12 +383,18 @@ export default class FramePool {
     this.interpolator = interpolator;
     if (!interpolator) return;
 
-    const canvasFunction = () => {
+    // canvasFunction is given the size OL wants rendered, in device
+    // pixels. That's usually viewSize × ratio × devicePixelRatio —
+    // larger than A's native bitmap on retina because the slot's
+    // StickyImageWMS uses hidpi:false. Render at that size so the
+    // canvas covers the requested extent; the shader upscales from
+    // A's bitmap with bilinear filtering.
+    const canvasFunction = (extent, resolution, pixelRatio, size) => {
       if (!this.interpActive) return null;
       const { timeA, timeB, t } = this._warpState;
       if (!timeA || !timeB) return null;
       if (!interpolator.hasFlow(timeA, timeB)) return null;
-      return interpolator.renderAt(timeA, timeB, t);
+      return interpolator.renderAt(timeA, timeB, t, size[0], size[1]);
     };
 
     this.warpLayer = new ImageLayer({

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -544,13 +544,19 @@ export default class FramePool {
   }
 
   // Flip primary's opacity between 0 (warp is rendering content) and
-  // the user's chosen opacity. Guarded so our own writes don't get
-  // captured by the change:opacity listener as a new "user opacity".
+  // the user's chosen opacity. Guarded on two fronts:
+  //   - our change:opacity listener filters on _settingOpacityInternally
+  //     so it doesn't capture our writes as a new "user opacity".
+  //   - we mark the layer with `_interpHiding` before the opacity write
+  //     so radar.js's layerInfoPlaylist can skip the slider-UI update —
+  //     otherwise the slider would jump to 0 (and the user's drag
+  //     would get overridden back to 0 on the next RAF).
   _setPrimaryTransparent(transparent) {
     if (!this.warpLayer) return;
     const desired = transparent ? 0 : this._userOpacity;
     if (this.primary.getOpacity() === desired) return;
     this._settingOpacityInternally = true;
+    this.primary.set('_interpHiding', transparent, true);
     this.primary.setOpacity(desired);
     this._settingOpacityInternally = false;
   }

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -144,26 +144,35 @@ export default class FramePool {
       map.addLayer(layer);
     }
 
-    // Debounce moveend-driven invalidate+prefetch. OL fires a
-    // moveend at the end of every view animation, and a scroll-wheel
-    // zoom decomposes into many short animations as the wheel ticks
-    // — so a fast scroll burst fires several moveends in quick
-    // succession and would trigger several rounds of prefetch
-    // (3-6 fetches per visible pool each). The aborted requests
-    // still leave the browser before our AbortController catches
-    // them, hammering the WMS server. Wait for ~200ms of quiet
-    // before doing the work; sticky-while-loading covers the user
-    // during the debounce window.
+    // Debounce moveend-driven invalidate+prefetch AND coalesce across
+    // a whole wheel-zoom gesture. OL fires a moveend at the end of
+    // every view-animation tween, and a scroll-wheel zoom is a train
+    // of such tweens. A moveend-only debounce expires in the gap
+    // between tweens during a slow scroll, so each wheel tick ends
+    // up firing its own prefetch burst. We also listen to raw DOM
+    // `wheel` events and restart the timer on each one — the
+    // gesture only "ends" after QUIET_MS of no wheel AND no moveend.
+    // While the timer is pending we treat the pool as mid-gesture:
+    // prefetch, frontier-advance and playback-advance are all
+    // suppressed. Sticky-while-loading covers the user until the
+    // flush runs.
+    const QUIET_MS = 300;
     this._moveendTimer = null;
-    map.on('moveend', () => {
-      if (this._moveendTimer) {
-        clearTimeout(this._moveendTimer);
-      }
+    this._gestureEndAt = 0;
+    const scheduleFlush = () => {
+      if (this._moveendTimer) clearTimeout(this._moveendTimer);
+      this._gestureEndAt = performance.now() + QUIET_MS;
       this._moveendTimer = setTimeout(() => {
         this._moveendTimer = null;
+        this._gestureEndAt = 0;
         this._handleMoveend();
-      }, 200);
-    });
+      }, QUIET_MS);
+    };
+    map.on('moveend', scheduleFlush);
+    const viewport = map.getViewport && map.getViewport();
+    if (viewport) {
+      viewport.addEventListener('wheel', scheduleFlush, { passive: true });
+    }
 
     // When the layer becomes visible after being hidden, catch up on
     // any view changes that happened while hidden.
@@ -259,12 +268,17 @@ export default class FramePool {
     return this.slots.find((s) => s.time === time) || null;
   }
 
+  isZoomGestureActive() {
+    return this._gestureEndAt > 0 && performance.now() < this._gestureEndAt;
+  }
+
   // Prefetch the initial ring: current, +1, +2 (wrapping). Animation
   // plays forward the vast majority of the time, so we bias the
   // initial fetch toward upcoming frames instead of the symmetric
   // previous+next ring.
   _prefetchAroundCurrent() {
     if (!this.primary.getVisible()) return;
+    if (this.isZoomGestureActive()) return;
     if (!this.currentTime || !this.windowTimes) return;
     const curIdx = this.windowTimes.indexOf(this.currentTime);
     if (curIdx < 0) return;
@@ -286,6 +300,7 @@ export default class FramePool {
   // around, which matches typical playback behavior (rarely reverse).
   _advanceFrontier() {
     if (!this.primary.getVisible()) return;
+    if (this.isZoomGestureActive()) return;
     if (!this.currentTime || !this.windowTimes) return;
     const curIdx = this.windowTimes.indexOf(this.currentTime);
     if (curIdx < 0) return;

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -464,7 +464,18 @@ export default class FramePool {
     };
     this.primary.on('change:visible', this._primaryVisListener);
     this.primary.on('change:opacity', this._primaryOpacityListener);
-    this.map.addLayer(this.warpLayer);
+    // Insert the warp layer right after the primary so it takes
+    // over the primary's z-slot. addLayer would append to the end,
+    // which puts the warp above POIs, range rings and the
+    // observation layer — wrong z-order. If the primary isn't in
+    // the collection for some reason, fall back to appending.
+    const mapLayers = this.map.getLayers();
+    const primaryIdx = mapLayers.getArray().indexOf(this.primary);
+    if (primaryIdx >= 0) {
+      mapLayers.insertAt(primaryIdx + 1, this.warpLayer);
+    } else {
+      mapLayers.push(this.warpLayer);
+    }
 
     // Retroactively upload already-loaded slot bitmaps so hasFlow
     // returns true on the first showInterpolated call after a delayed

--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -592,12 +592,17 @@ export default class FramePool {
     this._setPrimaryTransparent(hasFlow);
 
     if (!hasFlow) {
-      // Force canvasFunction to re-run (returning our empty 1×1
-      // canvas) so the warp layer drops any stale content that was
-      // last drawn for a previous (A, B). Otherwise after pan/zoom
-      // invalidates the frames, the warp keeps displaying its last
-      // interpolated image over the primary — looks like "a frame
-      // stuck" until the window slides around to it again.
+      // Clear _warpState so canvasFunction's own hasFlow check sees
+      // a null pair and returns _emptyCanvas. Without this the
+      // closure in canvasFunction reads the PREVIOUS pair's
+      // (timeA, timeB) — and if that pair still has valid flow +
+      // extent for the current view, renderAt runs and the warp
+      // keeps showing the previous pair's interpolation on top of
+      // the primary layer. That's the "stuck frame plus next
+      // frames visible" ghost: previous pair warp over current pair
+      // primary, both at user opacity.
+      this._warpState.timeA = null;
+      this._warpState.timeB = null;
       this.warpLayer.getSource().changed();
       return;
     }

--- a/src/animation/interpolation/capabilities.js
+++ b/src/animation/interpolation/capabilities.js
@@ -1,0 +1,64 @@
+// Capability probe for optical-flow interpolation. Returns a Promise
+// resolving to true iff the device can run the interpolator.
+//
+// Order of checks (fail fast): URL override → WebGL2 → RG16F render
+// extension → 1x1 FBO completeness → low-memory bail-out. Extension
+// presence alone does not guarantee FBO-completeness on every mobile
+// driver, so the completeness probe stays.
+//
+// iOS 15.4+ stopped exposing EXT_color_buffer_float (it had falsely
+// advertised FP32 renderability before) and switched to
+// EXT_color_buffer_half_float. Either extension enables RG16F render
+// targets, which is all the LK flow pass needs.
+//
+// Phase 1 stops here. Phase 4 adds the LK micro-benchmark and a
+// localStorage-cached verdict with a 7-day TTL.
+
+function readOverride() {
+  const params = new URLSearchParams(window.location.search);
+  const v = params.get('interp');
+  if (v === 'on') return true;
+  if (v === 'off') return false;
+  return null;
+}
+
+function probeRg16fFboComplete(gl) {
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG16F, 1, 1, 0, gl.RG, gl.HALF_FLOAT, null);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  const fbo = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+  const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.deleteFramebuffer(fbo);
+  gl.deleteTexture(tex);
+  return status === gl.FRAMEBUFFER_COMPLETE;
+}
+
+export default async function canInterpolate() {
+  const override = readOverride();
+  if (override !== null) return override;
+
+  const canvas = document.createElement('canvas');
+  const gl = canvas.getContext('webgl2');
+  if (!gl) return false;
+
+  const hasHalf = !!gl.getExtension('EXT_color_buffer_half_float');
+  const hasFull = !!gl.getExtension('EXT_color_buffer_float');
+  if (!hasHalf && !hasFull) return false;
+
+  if (!probeRg16fFboComplete(gl)) return false;
+
+  // navigator.deviceMemory is undefined on Safari; only fail when we
+  // have a concrete low-memory reading.
+  if (navigator.deviceMemory !== undefined && navigator.deviceMemory < 3) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/animation/interpolation/flowLK.js
+++ b/src/animation/interpolation/flowLK.js
@@ -42,9 +42,11 @@ in vec2 vUv;
 out vec4 fragColor;
 
 void main() {
-  // 7×7 window centered on vUv. radius can be tuned — bigger window
-  // is more robust to noise but smooths out motion boundaries.
-  const int RADIUS = 3;
+  // 11×11 window. Bigger windows are more robust for our inputs
+  // (stepped palettes, bilinear-resampled radar) and the extra
+  // smoothing across motion boundaries is acceptable at this
+  // analysis resolution.
+  const int RADIUS = 5;
 
   // Accumulate the 5 LK moments across all three RGB channels.
   // Stepped radar palettes (e.g. FMI classical green/yellow/red
@@ -88,8 +90,10 @@ void main() {
   float det = sumIx2 * sumIy2 - sumIxIy * sumIxIy;
   vec2 flow = vec2(0.0);
   // Threshold guards pixels with no structure (flat regions) — the
-  // matrix is singular there and the "flow" is noise.
-  if (det > 1e-6) {
+  // matrix is singular there and the "flow" is noise. The RGB-summed
+  // moments span roughly [0, 100] for cell edges, so a floor well
+  // above floating-point noise keeps the output clean.
+  if (det > 1e-3) {
     float invDet = 1.0 / det;
     // Note the signs: the RHS is (-ΣIxIt, -ΣIyIt) so we multiply
     // through with negatives here.

--- a/src/animation/interpolation/flowLK.js
+++ b/src/animation/interpolation/flowLK.js
@@ -119,9 +119,11 @@ export default class FlowLK {
   // Compute flow from A to B. Returns a fresh RG16F texture of
   // resolution² holding UV displacements. The caller owns the
   // returned texture and must gl.deleteTexture it when done.
-  compute(texA, texB) {
+  // `filter` lets the caller downgrade to NEAREST when the device
+  // lacks OES_texture_half_float_linear.
+  compute(texA, texB, filter) {
     const { gl } = this;
-    const flowTex = createRg16fTexture(gl, this.resolution, this.resolution, null);
+    const flowTex = createRg16fTexture(gl, this.resolution, this.resolution, null, filter);
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, flowTex, 0);

--- a/src/animation/interpolation/flowLK.js
+++ b/src/animation/interpolation/flowLK.js
@@ -41,22 +41,19 @@ uniform vec2 uStep;   // 1 / resolution, in UV
 in vec2 vUv;
 out vec4 fragColor;
 
-void main() {
-  // 11×11 window. Bigger windows are more robust for our inputs
-  // (stepped palettes, bilinear-resampled radar) and the extra
-  // smoothing across motion boundaries is acceptable at this
-  // analysis resolution.
-  const int RADIUS = 5;
+float lum(vec4 c) {
+  return dot(c.rgb, vec3(0.2126, 0.7152, 0.0722));
+}
 
-  // Accumulate the 5 LK moments across all three RGB channels.
-  // Stepped radar palettes (e.g. FMI classical green/yellow/red
-  // bands) have near-zero luminance gradient inside each band — LK
-  // on luminance alone produces a singular 2×2 and clamps flow to
-  // zero. Hue changes between bands though, so summing per-channel
-  // gradients recovers the motion signal. With a continuous
-  // colormap (e.g. Bookbinder viridis-like), all three channels
-  // produce similar signal and the sum is roughly 3× luminance —
-  // no harm.
+void main() {
+  // 7×7 window centered on vUv. The bigger 11×11 window caused
+  // per-timestep jumps in the output — averaging motion across too
+  // wide an area smooths out cell-boundary flow differences, so
+  // cells that are supposed to move one way get their flow diluted
+  // by neighbours moving slightly differently, and each recomputed
+  // pair lands on a visibly different estimate.
+  const int RADIUS = 3;
+
   float sumIx2  = 0.0;
   float sumIy2  = 0.0;
   float sumIxIy = 0.0;
@@ -67,21 +64,21 @@ void main() {
     for (int dx = -RADIUS; dx <= RADIUS; dx++) {
       vec2 pt = vUv + vec2(float(dx), float(dy)) * uStep;
 
-      vec3 aL = texture(uA, pt + vec2(-uStep.x, 0.0)).rgb;
-      vec3 aR = texture(uA, pt + vec2( uStep.x, 0.0)).rgb;
-      vec3 aT = texture(uA, pt + vec2(0.0, -uStep.y)).rgb;
-      vec3 aB = texture(uA, pt + vec2(0.0,  uStep.y)).rgb;
+      float aL = lum(texture(uA, pt + vec2(-uStep.x, 0.0)));
+      float aR = lum(texture(uA, pt + vec2( uStep.x, 0.0)));
+      float aT = lum(texture(uA, pt + vec2(0.0, -uStep.y)));
+      float aB = lum(texture(uA, pt + vec2(0.0,  uStep.y)));
 
-      vec3 Ix = (aR - aL) * 0.5;
-      vec3 Iy = (aB - aT) * 0.5;
+      float Ix = (aR - aL) * 0.5;
+      float Iy = (aB - aT) * 0.5;
 
-      vec3 It = texture(uB, pt).rgb - texture(uA, pt).rgb;
+      float It = lum(texture(uB, pt)) - lum(texture(uA, pt));
 
-      sumIx2  += dot(Ix, Ix);
-      sumIy2  += dot(Iy, Iy);
-      sumIxIy += dot(Ix, Iy);
-      sumIxIt += dot(Ix, It);
-      sumIyIt += dot(Iy, It);
+      sumIx2  += Ix * Ix;
+      sumIy2  += Iy * Iy;
+      sumIxIy += Ix * Iy;
+      sumIxIt += Ix * It;
+      sumIyIt += Iy * It;
     }
   }
 
@@ -89,11 +86,7 @@ void main() {
   //       [ΣIxIy ΣIy² ] [v] = [-ΣIyIt]
   float det = sumIx2 * sumIy2 - sumIxIy * sumIxIy;
   vec2 flow = vec2(0.0);
-  // Threshold guards pixels with no structure (flat regions) — the
-  // matrix is singular there and the "flow" is noise. The RGB-summed
-  // moments span roughly [0, 100] for cell edges, so a floor well
-  // above floating-point noise keeps the output clean.
-  if (det > 1e-3) {
+  if (det > 1e-6) {
     float invDet = 1.0 / det;
     // Note the signs: the RHS is (-ΣIxIt, -ΣIyIt) so we multiply
     // through with negatives here.

--- a/src/animation/interpolation/flowLK.js
+++ b/src/animation/interpolation/flowLK.js
@@ -41,15 +41,20 @@ uniform vec2 uStep;   // 1 / resolution, in UV
 in vec2 vUv;
 out vec4 fragColor;
 
-float lum(vec4 c) {
-  return dot(c.rgb, vec3(0.2126, 0.7152, 0.0722));
-}
-
 void main() {
   // 7×7 window centered on vUv. radius can be tuned — bigger window
   // is more robust to noise but smooths out motion boundaries.
   const int RADIUS = 3;
 
+  // Accumulate the 5 LK moments across all three RGB channels.
+  // Stepped radar palettes (e.g. FMI classical green/yellow/red
+  // bands) have near-zero luminance gradient inside each band — LK
+  // on luminance alone produces a singular 2×2 and clamps flow to
+  // zero. Hue changes between bands though, so summing per-channel
+  // gradients recovers the motion signal. With a continuous
+  // colormap (e.g. Bookbinder viridis-like), all three channels
+  // produce similar signal and the sum is roughly 3× luminance —
+  // no harm.
   float sumIx2  = 0.0;
   float sumIy2  = 0.0;
   float sumIxIy = 0.0;
@@ -60,22 +65,21 @@ void main() {
     for (int dx = -RADIUS; dx <= RADIUS; dx++) {
       vec2 pt = vUv + vec2(float(dx), float(dy)) * uStep;
 
-      // Central difference on A: Sobel-lite (3-tap).
-      float aL = lum(texture(uA, pt + vec2(-uStep.x, 0.0)));
-      float aR = lum(texture(uA, pt + vec2( uStep.x, 0.0)));
-      float aT = lum(texture(uA, pt + vec2(0.0, -uStep.y)));
-      float aB = lum(texture(uA, pt + vec2(0.0,  uStep.y)));
+      vec3 aL = texture(uA, pt + vec2(-uStep.x, 0.0)).rgb;
+      vec3 aR = texture(uA, pt + vec2( uStep.x, 0.0)).rgb;
+      vec3 aT = texture(uA, pt + vec2(0.0, -uStep.y)).rgb;
+      vec3 aB = texture(uA, pt + vec2(0.0,  uStep.y)).rgb;
 
-      float Ix = (aR - aL) * 0.5;
-      float Iy = (aB - aT) * 0.5;
+      vec3 Ix = (aR - aL) * 0.5;
+      vec3 Iy = (aB - aT) * 0.5;
 
-      float It = lum(texture(uB, pt)) - lum(texture(uA, pt));
+      vec3 It = texture(uB, pt).rgb - texture(uA, pt).rgb;
 
-      sumIx2  += Ix * Ix;
-      sumIy2  += Iy * Iy;
-      sumIxIy += Ix * Iy;
-      sumIxIt += Ix * It;
-      sumIyIt += Iy * It;
+      sumIx2  += dot(Ix, Ix);
+      sumIy2  += dot(Iy, Iy);
+      sumIxIy += dot(Ix, Iy);
+      sumIxIt += dot(Ix, It);
+      sumIyIt += dot(Iy, It);
     }
   }
 

--- a/src/animation/interpolation/flowLK.js
+++ b/src/animation/interpolation/flowLK.js
@@ -1,0 +1,154 @@
+// Single-level Lucas-Kanade optical flow in a single fragment-shader
+// pass. Output is an RG16F texture of flowResolution² holding
+// normalized UV displacements (flow.x in [-1,1] = fraction of texture
+// width, flow.y ditto for height).
+//
+// For each output pixel we evaluate a (2*radius+1)² window centered
+// on the pixel, compute Sobel gradients of A and the temporal
+// difference (B - A) at each window sample, accumulate the 5 moments
+// ΣIx², ΣIy², ΣIxIy, ΣIxIt, ΣIyIt, and solve the 2×2 normal
+// equations. Luminance (Rec.709) is computed inline from the RGBA
+// source textures — no separate grayscale upload needed.
+//
+// No pyramidal coarse-to-fine pass yet. For typical radar motion
+// viewed at Finland-scale zoom the displacement at 256² analysis
+// resolution is under a pixel, so a single level with a 7×7 window
+// recovers it. Very large displacements (extreme zoom-out or fast
+// synoptic systems) will fail silently — the solve clamps to zero
+// and the interpolation degrades to the Phase 2 crossfade. Pyramid
+// support is a Phase 3b enhancement if we see this in practice.
+
+import {
+  createProgram, createRg16fTexture, createFullscreenTriangle, drawFullscreen,
+} from './glUtils';
+
+const VERT = `#version 300 es
+in vec2 aPos;
+out vec2 vUv;
+void main() {
+  vUv = aPos * 0.5 + 0.5;
+  gl_Position = vec4(aPos, 0.0, 1.0);
+}
+`;
+
+const FRAG = `#version 300 es
+precision highp float;
+
+uniform sampler2D uA;
+uniform sampler2D uB;
+uniform vec2 uStep;   // 1 / resolution, in UV
+
+in vec2 vUv;
+out vec4 fragColor;
+
+float lum(vec4 c) {
+  return dot(c.rgb, vec3(0.2126, 0.7152, 0.0722));
+}
+
+void main() {
+  // 7×7 window centered on vUv. radius can be tuned — bigger window
+  // is more robust to noise but smooths out motion boundaries.
+  const int RADIUS = 3;
+
+  float sumIx2  = 0.0;
+  float sumIy2  = 0.0;
+  float sumIxIy = 0.0;
+  float sumIxIt = 0.0;
+  float sumIyIt = 0.0;
+
+  for (int dy = -RADIUS; dy <= RADIUS; dy++) {
+    for (int dx = -RADIUS; dx <= RADIUS; dx++) {
+      vec2 pt = vUv + vec2(float(dx), float(dy)) * uStep;
+
+      // Central difference on A: Sobel-lite (3-tap).
+      float aL = lum(texture(uA, pt + vec2(-uStep.x, 0.0)));
+      float aR = lum(texture(uA, pt + vec2( uStep.x, 0.0)));
+      float aT = lum(texture(uA, pt + vec2(0.0, -uStep.y)));
+      float aB = lum(texture(uA, pt + vec2(0.0,  uStep.y)));
+
+      float Ix = (aR - aL) * 0.5;
+      float Iy = (aB - aT) * 0.5;
+
+      float It = lum(texture(uB, pt)) - lum(texture(uA, pt));
+
+      sumIx2  += Ix * Ix;
+      sumIy2  += Iy * Iy;
+      sumIxIy += Ix * Iy;
+      sumIxIt += Ix * It;
+      sumIyIt += Iy * It;
+    }
+  }
+
+  // Solve [ΣIx²  ΣIxIy] [u]   [-ΣIxIt]
+  //       [ΣIxIy ΣIy² ] [v] = [-ΣIyIt]
+  float det = sumIx2 * sumIy2 - sumIxIy * sumIxIy;
+  vec2 flow = vec2(0.0);
+  // Threshold guards pixels with no structure (flat regions) — the
+  // matrix is singular there and the "flow" is noise.
+  if (det > 1e-6) {
+    float invDet = 1.0 / det;
+    // Note the signs: the RHS is (-ΣIxIt, -ΣIyIt) so we multiply
+    // through with negatives here.
+    flow.x = (-sumIy2  * sumIxIt + sumIxIy * sumIyIt) * invDet;
+    flow.y = ( sumIxIy * sumIxIt - sumIx2  * sumIyIt) * invDet;
+  }
+
+  // flow is in pixel units at this analysis resolution; convert to
+  // UV displacement so the warp shader can use it directly.
+  flow *= uStep;
+
+  fragColor = vec4(flow, 0.0, 1.0);
+}
+`;
+
+export default class FlowLK {
+  constructor(gl, resolution = 256) {
+    this.gl = gl;
+    this.resolution = resolution;
+    this.program = createProgram(gl, VERT, FRAG);
+    this.vbo = createFullscreenTriangle(gl);
+    this.fbo = gl.createFramebuffer();
+
+    this.aPos = gl.getAttribLocation(this.program, 'aPos');
+    this.uA = gl.getUniformLocation(this.program, 'uA');
+    this.uB = gl.getUniformLocation(this.program, 'uB');
+    this.uStep = gl.getUniformLocation(this.program, 'uStep');
+  }
+
+  // Compute flow from A to B. Returns a fresh RG16F texture of
+  // resolution² holding UV displacements. The caller owns the
+  // returned texture and must gl.deleteTexture it when done.
+  compute(texA, texB) {
+    const { gl } = this;
+    const flowTex = createRg16fTexture(gl, this.resolution, this.resolution, null);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, flowTex, 0);
+
+    gl.viewport(0, 0, this.resolution, this.resolution);
+    gl.disable(gl.BLEND);
+    gl.useProgram(this.program);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texA);
+    gl.uniform1i(this.uA, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, texB);
+    gl.uniform1i(this.uB, 1);
+
+    const step = 1 / this.resolution;
+    gl.uniform2f(this.uStep, step, step);
+
+    drawFullscreen(gl, this.vbo, this.aPos);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    return flowTex;
+  }
+
+  dispose() {
+    this.gl.deleteProgram(this.program);
+    this.gl.deleteBuffer(this.vbo);
+    this.gl.deleteFramebuffer(this.fbo);
+  }
+}

--- a/src/animation/interpolation/glUtils.js
+++ b/src/animation/interpolation/glUtils.js
@@ -50,13 +50,19 @@ export function createRgbaTexture(gl, width, height, source = null) {
 }
 
 // RG16F render-target storage for flow fields. `data` must be either
-// null (zero-filled, Phase 2) or a Uint16Array of half-floats.
-export function createRg16fTexture(gl, width, height, data = null) {
+// null (zero-filled, Phase 2) or a Uint16Array of half-floats. `filter`
+// controls min/mag filter — LINEAR is desirable for smooth flow
+// across the 256²→display upscale but requires
+// OES_texture_half_float_linear; callers on devices without that
+// extension should pass gl.NEAREST to avoid silent black/blocky
+// sampling.
+export function createRg16fTexture(gl, width, height, data, filter) {
   const tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG16F, width, height, 0, gl.RG, gl.HALF_FLOAT, data);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  const f = filter === undefined ? gl.LINEAR : filter;
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, f);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, f);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
   return tex;

--- a/src/animation/interpolation/glUtils.js
+++ b/src/animation/interpolation/glUtils.js
@@ -1,0 +1,79 @@
+// Minimal WebGL2 helpers for the interpolation pipeline. Just enough
+// to compile shaders, upload textures, and draw a fullscreen triangle —
+// no full rendergraph framework here.
+
+export function createProgram(gl, vertSrc, fragSrc) {
+  const compile = (type, src) => {
+    const s = gl.createShader(type);
+    gl.shaderSource(s, src);
+    gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+      const info = gl.getShaderInfoLog(s);
+      gl.deleteShader(s);
+      throw new Error(`Shader compile error:\n${info}\n---\n${src}`);
+    }
+    return s;
+  };
+  const vs = compile(gl.VERTEX_SHADER, vertSrc);
+  const fs = compile(gl.FRAGMENT_SHADER, fragSrc);
+  const prog = gl.createProgram();
+  gl.attachShader(prog, vs);
+  gl.attachShader(prog, fs);
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(prog);
+    gl.deleteProgram(prog);
+    throw new Error(`Program link error: ${info}`);
+  }
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  return prog;
+}
+
+// Upload from an HTMLImageElement or empty texture of given size.
+// Returns a texture with LINEAR filtering and CLAMP_TO_EDGE wrap.
+export function createRgbaTexture(gl, width, height, source = null) {
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+  if (source) {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
+  } else {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  }
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  return tex;
+}
+
+// RG16F render-target storage for flow fields. `data` must be either
+// null (zero-filled, Phase 2) or a Uint16Array of half-floats.
+export function createRg16fTexture(gl, width, height, data = null) {
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG16F, width, height, 0, gl.RG, gl.HALF_FLOAT, data);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  return tex;
+}
+
+// Fullscreen triangle — (-1,-1), (3,-1), (-1,3) covers NDC in one tri.
+// Reused by every fullscreen pass.
+export function createFullscreenTriangle(gl) {
+  const vbo = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+  return vbo;
+}
+
+export function drawFullscreen(gl, vbo, attribLocation) {
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  gl.enableVertexAttribArray(attribLocation);
+  gl.vertexAttribPointer(attribLocation, 2, gl.FLOAT, false, 0, 0);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
+}

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -16,6 +16,7 @@
 
 import canInterpolate from './capabilities';
 import WarpRenderer from './warp';
+import FlowLK from './flowLK';
 import { createRgbaTexture, createRg16fTexture } from './glUtils';
 
 export { canInterpolate };
@@ -38,8 +39,12 @@ function extentMatches(stored, current) {
 }
 
 export class RadarInterpolator {
-  constructor({ flowResolution = 256 } = {}) {
+  constructor({ flowResolution = 256, useFlow = false } = {}) {
     this.flowResolution = flowResolution;
+    // When true, flows are computed via Lucas-Kanade; when false,
+    // flows are zero-filled (interpolation degenerates to crossfade).
+    // Swapped at runtime via setUseFlow.
+    this.useFlow = useFlow;
 
     this.canvas = document.createElement('canvas');
     this.canvas.width = 1;
@@ -68,11 +73,25 @@ export class RadarInterpolator {
     this.gl.getExtension('EXT_color_buffer_float');
 
     this.warp = new WarpRenderer(this.gl);
+    this.flowLK = new FlowLK(this.gl, flowResolution);
 
-    // Keyed by time ISO string. Values: { texture, width, height }.
+    // Keyed by time ISO string. Values: { texture, width, height, extent }.
     this.frames = new Map();
-    // Keyed by `${timeA}|${timeB}`. Values: { texture }.
+    // Keyed by `${timeA}|${timeB}`. Values: { texture }. Populated
+    // lazily by computeFlow; hasFlow returns false for pairs not yet
+    // populated, so the caller sees "not ready" until the flow (zero
+    // or LK, depending on useFlow) has actually been created.
     this.flows = new Map();
+  }
+
+  // Flip between zero-flow (crossfade) and LK flow. Clears any
+  // computed flows; callers should refresh them for currently-loaded
+  // pairs so the next render has the new flow type ready.
+  setUseFlow(useFlow) {
+    if (this.useFlow === useFlow) return;
+    this.useFlow = useFlow;
+    for (const f of this.flows.values()) this.gl.deleteTexture(f.texture);
+    this.flows.clear();
   }
 
   // Called from FramePool on imageloadend once a slot's bitmap is
@@ -92,6 +111,15 @@ export class RadarInterpolator {
     this.frames.set(slot.time, {
       texture, width: w, height: h, extent: extent ? extent.slice() : null,
     });
+    // The new bitmap invalidates any flow pairs that referenced the
+    // previous bitmap for this time — drop them so the next
+    // computeFlow call produces fresh flow from the new texture.
+    for (const [key, flow] of this.flows) {
+      if (key.startsWith(`${slot.time}|`) || key.endsWith(`|${slot.time}`)) {
+        this.gl.deleteTexture(flow.texture);
+        this.flows.delete(key);
+      }
+    }
   }
 
   // Called from FramePool._resyncAllParams. If the change wasn't
@@ -129,17 +157,38 @@ export class RadarInterpolator {
   }
 
   // Is there enough data to render (A, B, t) for the given extent?
-  // In Phase 2, "flow ready" means both bitmaps are uploaded AND,
-  // if the caller passes a view extent, both frames' stored extents
-  // are close enough to it that blitting the warp output at the
-  // requested extent will look correct. Without the extent check,
-  // zooming keeps rendering old-extent pixels at the new view.
+  // Requires: both frame textures uploaded, a flow texture computed
+  // for the pair (via computeFlow), and — if a view extent is
+  // passed — both frames' stored extents close enough to it that the
+  // warp output will align when OL blits it at the current view.
   hasFlow(timeA, timeB, extent = null) {
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     if (!a || !b) return false;
+    if (!this.flows.has(`${timeA}|${timeB}`)) return false;
     if (!extent) return true;
     return extentMatches(a.extent, extent) && extentMatches(b.extent, extent);
+  }
+
+  // Produce the flow texture for (A, B) — LK-computed if useFlow is
+  // true, zero-filled otherwise. Framepool calls this from
+  // imageloadend when both frames of a pair become available. No-op
+  // if the pair already has a flow (the frames themselves are
+  // replaced in onSlotLoaded; a new compute is triggered then by
+  // having that call invalidate the flow first).
+  computeFlow(timeA, timeB) {
+    const key = `${timeA}|${timeB}`;
+    if (this.flows.has(key)) return;
+    const a = this.frames.get(timeA);
+    const b = this.frames.get(timeB);
+    if (!a || !b) return;
+    let texture;
+    if (this.useFlow) {
+      texture = this.flowLK.compute(a.texture, b.texture);
+    } else {
+      texture = createRg16fTexture(this.gl, this.flowResolution, this.flowResolution, null);
+    }
+    this.flows.set(key, { texture });
   }
 
   // Draw the warped image for (A, B, t) into this.canvas. Returns
@@ -153,12 +202,12 @@ export class RadarInterpolator {
   renderAt(timeA, timeB, t, targetW = 0, targetH = 0) {
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
-    if (!a || !b) return null;
+    const flow = this.flows.get(`${timeA}|${timeB}`);
+    if (!a || !b || !flow) return null;
 
     // A and B can disagree on pixel dimensions if the user panned
     // between their loads. The shader samples both via UV so
-    // dimensions only matter for output. Phase 3 will resample A
-    // and B onto a shared analysis grid before LK runs.
+    // dimensions only matter for output.
     const w = targetW || a.width;
     const h = targetH || a.height;
 
@@ -167,29 +216,13 @@ export class RadarInterpolator {
       this.canvas.height = h;
     }
 
-    const flowTex = this._getOrCreateFlow(timeA, timeB);
-
     const { gl } = this;
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    this.warp.render(a.texture, b.texture, flowTex, t, w, h);
+    this.warp.render(a.texture, b.texture, flow.texture, t, w, h);
 
     return this.canvas;
-  }
-
-  _getOrCreateFlow(timeA, timeB) {
-    const key = `${timeA}|${timeB}`;
-    let flow = this.flows.get(key);
-    if (!flow) {
-      // Phase 2: zero-filled flow. Phase 3 will populate this via
-      // pyramidal LK before any render call that needs it.
-      const r = this.flowResolution;
-      const texture = createRg16fTexture(this.gl, r, r, null);
-      flow = { texture };
-      this.flows.set(key, flow);
-    }
-    return flow.texture;
   }
 
   dispose() {
@@ -198,5 +231,6 @@ export class RadarInterpolator {
     this.frames.clear();
     this.flows.clear();
     this.warp.dispose();
+    this.flowLK.dispose();
   }
 }

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -1,0 +1,52 @@
+// Public API for optical-flow interpolation. Phase 1 skeleton: the
+// class compiles, plugs into the call sites FramePool will use in
+// later phases, and never actually warps a pixel. Every method is a
+// no-op or returns a sentinel that makes the caller fall back to
+// discrete frame display.
+//
+// Phase 2 will add the warp renderer (with zero flow, visually a
+// crossfade) to validate GL context plumbing and OL integration.
+// Phase 3 adds pyramidal Lucas–Kanade flow computation. Phase 4
+// handles nodata masking, webglcontextlost recovery, and memory
+// budget enforcement.
+
+import canInterpolate from './capabilities';
+
+export { canInterpolate };
+
+// Phase 1 skeleton methods don't read `this`. Later phases will hold GPU
+// state (textures, programs, flow cache) and access it through `this`.
+/* eslint-disable class-methods-use-this */
+export class RadarInterpolator {
+  constructor(opts = {}) {
+    this.gl = opts.gl || null;
+    this.flowResolution = opts.flowResolution || 256;
+    this.pyramidLevels = opts.pyramidLevels || 3;
+    this.iterations = opts.iterations || 5;
+  }
+
+  // Called from FramePool.imageloadend once a slot's bitmap finishes
+  // loading. Phase 3 will upload to GPU and kick off flow computation
+  // for any newly-completable pair.
+  onSlotLoaded(/* slot, image */) {}
+
+  // Called from FramePool._resyncAllParams after a WMS-param change.
+  // `flowInvariant` is true when only STYLES / FORMAT changed — flow
+  // can be kept and reused with the re-styled bitmaps once they land.
+  // Phase 3 will conditionally clear the flow cache.
+  onParamsChanged(/* { flowInvariant } */) {}
+
+  // Called when a slot's view-cached image is no longer valid (pan /
+  // zoom pushed the sticky out of the requested extent) OR when the
+  // slot's TIME is reassigned during a window slide. Phase 3 will
+  // drop any flow pair that references the invalidated time.
+  invalidateSlot(/* time */) {}
+
+  // Is there a usable flow field for (A, B)? Phase 1 always returns
+  // false so FramePool.showInterpolated falls back to the discrete
+  // display path.
+  hasFlow(/* timeA, timeB */) { return false; }
+
+  // Render the warped frame for (A, B, t). Phase 1 returns null.
+  renderAt(/* timeA, timeB, t */) { return null; }
+}

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -21,16 +21,20 @@ import { createRgbaTexture, createRg16fTexture } from './glUtils';
 
 export { canInterpolate };
 
-// Approximate equality (0.5% of size). Used to confirm A and B were
-// fetched at the same extent — if they weren't, sampling them at a
-// shared UV would hit different world coordinates and the flow would
-// be nonsense.
+// Approximate equality for two extents that are supposed to be bit-
+// identical (A and B fetched at the same view+resolution). The only
+// reason for a tolerance at all is floating-point rounding in the
+// OL extent math. 1e-6 of the extent size is well below any view
+// displacement we could see and still well above float noise.
+// Previously this was 0.5%, which at Finland scale is ~10 km — that
+// let systematically-mismatched pairs through and LK's flow came
+// out with a constant bias riding on top of real motion.
 function extentApproxEqual(a, b) {
   if (!a || !b) return false;
   const w = Math.abs(a[2] - a[0]);
   const h = Math.abs(a[3] - a[1]);
-  const tolW = w * 0.005;
-  const tolH = h * 0.005;
+  const tolW = Math.max(w * 1e-6, 1e-3);
+  const tolH = Math.max(h * 1e-6, 1e-3);
   return Math.abs(a[0] - b[0]) <= tolW
     && Math.abs(a[2] - b[2]) <= tolW
     && Math.abs(a[1] - b[1]) <= tolH
@@ -86,6 +90,15 @@ export class RadarInterpolator {
     // RG16F flow texture to be renderable later.
     this.gl.getExtension('EXT_color_buffer_half_float');
     this.gl.getExtension('EXT_color_buffer_float');
+    // Linear filtering of half-float textures needs a separate
+    // extension. Without it, sampling RG16F with LINEAR returns
+    // either NEAREST (blocky) or black/NaN on various drivers
+    // (Android Mali, some iOS Safari versions). If the extension is
+    // unavailable, fall back to NEAREST sampling on flow textures —
+    // warp gets a blockier motion field but stays correct.
+    this.flowFilter = this.gl.getExtension('OES_texture_half_float_linear')
+      ? this.gl.LINEAR
+      : this.gl.NEAREST;
 
     this.warp = new WarpRenderer(this.gl);
     this.flowLK = new FlowLK(this.gl, flowResolution);
@@ -97,6 +110,25 @@ export class RadarInterpolator {
     // populated, so the caller sees "not ready" until the flow (zero
     // or LK, depending on useFlow) has actually been created.
     this.flows = new Map();
+
+    // iOS Safari can evict WebGL2 contexts when the tab goes
+    // background or under memory pressure. When it happens all GPU
+    // handles we're holding are invalid — we can't even dispose
+    // them cleanly — and any subsequent draw silently fails. Mark
+    // ourselves unusable on loss; hasFlow returns false afterwards
+    // so the pool keeps the primary layer visible and the warp
+    // stays blank. preventDefault allows the restore event, but we
+    // don't attempt a live rebuild — the cheapest path back is for
+    // the user to toggle interp off and on via the menu, which
+    // constructs a fresh interpolator.
+    this.contextLost = false;
+    this._onContextLost = (e) => {
+      e.preventDefault();
+      this.contextLost = true;
+      this.frames.clear();
+      this.flows.clear();
+    };
+    this.canvas.addEventListener('webglcontextlost', this._onContextLost);
   }
 
   // Flip between zero-flow (crossfade) and LK flow. Clears any
@@ -116,6 +148,7 @@ export class RadarInterpolator {
   // (happens during zoom/pan before the new bitmaps land — without
   // this the warp draws old-extent pixels at the new extent).
   onSlotLoaded(slot, image, extent) {
+    if (this.contextLost) return;
     if (!slot || !slot.time || !image) return;
     const w = image.naturalWidth || image.width;
     const h = image.naturalHeight || image.height;
@@ -183,6 +216,7 @@ export class RadarInterpolator {
   // returns true and renderAt builds a UV offset to place content
   // at the correct world position in the output canvas.
   hasFlow(timeA, timeB, extent = null) {
+    if (this.contextLost) return false;
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     if (!a || !b) return false;
@@ -199,16 +233,24 @@ export class RadarInterpolator {
   // replaced in onSlotLoaded; a new compute is triggered then by
   // having that call invalidate the flow first).
   computeFlow(timeA, timeB) {
+    if (this.contextLost) return;
     const key = `${timeA}|${timeB}`;
     if (this.flows.has(key)) return;
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     if (!a || !b) return;
+    // A and B must share a stored extent for LK's result to be
+    // meaningful — sampling at a common UV would otherwise hit
+    // different world coordinates. Skipping here avoids burning GPU
+    // cycles on garbage flow during rapid pan/zoom when slots load
+    // at different extents; hasFlow's extent check would reject
+    // this pair at display time anyway.
+    if (this.useFlow && !extentApproxEqual(a.extent, b.extent)) return;
     let texture;
     if (this.useFlow) {
-      texture = this.flowLK.compute(a.texture, b.texture);
+      texture = this.flowLK.compute(a.texture, b.texture, this.flowFilter);
     } else {
-      texture = createRg16fTexture(this.gl, this.flowResolution, this.flowResolution, null);
+      texture = createRg16fTexture(this.gl, this.flowResolution, this.flowResolution, null, this.flowFilter);
     }
     this.flows.set(key, { texture });
   }
@@ -222,6 +264,7 @@ export class RadarInterpolator {
   // retina (source images are fetched with hidpi:false, so A's
   // native size is half of what OL wants on 2× displays).
   renderAt(timeA, timeB, t, targetW = 0, targetH = 0, canvasExtent = null) {
+    if (this.contextLost) return null;
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     const flow = this.flows.get(`${timeA}|${timeB}`);
@@ -276,11 +319,21 @@ export class RadarInterpolator {
       offsetX,
       offsetY,
     );
+    // Flush pending draw commands so the compositor reads fully-
+    // drawn pixels when it pulls the canvas — iOS Safari otherwise
+    // occasionally presents a half-drawn buffer during fast playback.
+    gl.flush();
 
     return this.canvas;
   }
 
   dispose() {
+    if (this._onContextLost) {
+      this.canvas.removeEventListener('webglcontextlost', this._onContextLost);
+      this._onContextLost = null;
+    }
+    // If the context is already lost, deleteTexture calls are no-ops
+    // — safe to run either way.
     for (const f of this.frames.values()) this.gl.deleteTexture(f.texture);
     for (const f of this.flows.values()) this.gl.deleteTexture(f.texture);
     this.frames.clear();

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -20,6 +20,23 @@ import { createRgbaTexture, createRg16fTexture } from './glUtils';
 
 export { canInterpolate };
 
+// Loose extent equality: two bounding boxes are considered the same
+// view when each corner agrees within 0.5% of the stored extent's
+// width/height. That tolerates floating-point drift from view
+// animations while still catching real pan/zoom deltas.
+function extentMatches(stored, current) {
+  if (!stored || !current) return false;
+  const w = stored[2] - stored[0];
+  const h = stored[3] - stored[1];
+  if (!w || !h) return false;
+  const tolW = Math.abs(w) * 0.005;
+  const tolH = Math.abs(h) * 0.005;
+  return Math.abs(stored[0] - current[0]) <= tolW
+    && Math.abs(stored[2] - current[2]) <= tolW
+    && Math.abs(stored[1] - current[1]) <= tolH
+    && Math.abs(stored[3] - current[3]) <= tolH;
+}
+
 export class RadarInterpolator {
   constructor({ flowResolution = 256 } = {}) {
     this.flowResolution = flowResolution;
@@ -60,9 +77,11 @@ export class RadarInterpolator {
 
   // Called from FramePool on imageloadend once a slot's bitmap is
   // usable. Uploads the image to a GL texture keyed by the slot's
-  // TIME. If a previous texture existed for that TIME (e.g., after a
-  // STYLES change invalidated it), it's replaced.
-  onSlotLoaded(slot, image) {
+  // TIME. The caller-provided `extent` is stored so hasFlow can
+  // later detect a stale pair whose content is for a different view
+  // (happens during zoom/pan before the new bitmaps land — without
+  // this the warp draws old-extent pixels at the new extent).
+  onSlotLoaded(slot, image, extent) {
     if (!slot || !slot.time || !image) return;
     const w = image.naturalWidth || image.width;
     const h = image.naturalHeight || image.height;
@@ -70,7 +89,9 @@ export class RadarInterpolator {
     const existing = this.frames.get(slot.time);
     if (existing) this.gl.deleteTexture(existing.texture);
     const texture = createRgbaTexture(this.gl, w, h, image);
-    this.frames.set(slot.time, { texture, width: w, height: h });
+    this.frames.set(slot.time, {
+      texture, width: w, height: h, extent: extent ? extent.slice() : null,
+    });
   }
 
   // Called from FramePool._resyncAllParams. If the change wasn't
@@ -107,11 +128,18 @@ export class RadarInterpolator {
     }
   }
 
-  // Is there enough data to render (A, B, t)? In Phase 2, "flow
-  // ready" really just means "both bitmaps uploaded" — the zero flow
-  // texture is created on demand.
-  hasFlow(timeA, timeB) {
-    return this.frames.has(timeA) && this.frames.has(timeB);
+  // Is there enough data to render (A, B, t) for the given extent?
+  // In Phase 2, "flow ready" means both bitmaps are uploaded AND,
+  // if the caller passes a view extent, both frames' stored extents
+  // are close enough to it that blitting the warp output at the
+  // requested extent will look correct. Without the extent check,
+  // zooming keeps rendering old-extent pixels at the new view.
+  hasFlow(timeA, timeB, extent = null) {
+    const a = this.frames.get(timeA);
+    const b = this.frames.get(timeB);
+    if (!a || !b) return false;
+    if (!extent) return true;
+    return extentMatches(a.extent, extent) && extentMatches(b.extent, extent);
   }
 
   // Draw the warped image for (A, B, t) into this.canvas. Returns

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -107,20 +107,24 @@ export class RadarInterpolator {
   }
 
   // Draw the warped image for (A, B, t) into this.canvas. Returns
-  // the canvas, or null if we don't have both frames yet.
-  renderAt(timeA, timeB, t) {
+  // the canvas, or null if we don't have both frames yet. If the
+  // caller passes targetW/H, the canvas is sized and the viewport
+  // rendered at that resolution; otherwise A's native bitmap size
+  // is used. Callers that go through ol/source/ImageCanvas pass
+  // the pixelRatio-adjusted size OL requested, which matters on
+  // retina (source images are fetched with hidpi:false, so A's
+  // native size is half of what OL wants on 2× displays).
+  renderAt(timeA, timeB, t, targetW = 0, targetH = 0) {
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     if (!a || !b) return null;
 
     // A and B can disagree on pixel dimensions if the user panned
-    // between their loads. Phase 2 picks A's dimensions as the
-    // analysis grid; the warp shader samples B using the same UVs
-    // regardless, which smears B at the edges when dimensions
-    // differ. Acceptable for the shake-out phase; Phase 3 will
-    // resample both onto a common analysis grid before LK runs.
-    const w = a.width;
-    const h = a.height;
+    // between their loads. The shader samples both via UV so
+    // dimensions only matter for output. Phase 3 will resample A
+    // and B onto a shared analysis grid before LK runs.
+    const w = targetW || a.width;
+    const h = targetH || a.height;
 
     if (this.canvas.width !== w || this.canvas.height !== h) {
       this.canvas.width = w;

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -21,21 +21,36 @@ import { createRgbaTexture, createRg16fTexture } from './glUtils';
 
 export { canInterpolate };
 
-// Loose extent equality: two bounding boxes are considered the same
-// view when each corner agrees within 0.5% of the stored extent's
-// width/height. That tolerates floating-point drift from view
-// animations while still catching real pan/zoom deltas.
-function extentMatches(stored, current) {
-  if (!stored || !current) return false;
-  const w = stored[2] - stored[0];
-  const h = stored[3] - stored[1];
-  if (!w || !h) return false;
-  const tolW = Math.abs(w) * 0.005;
-  const tolH = Math.abs(h) * 0.005;
-  return Math.abs(stored[0] - current[0]) <= tolW
-    && Math.abs(stored[2] - current[2]) <= tolW
-    && Math.abs(stored[1] - current[1]) <= tolH
-    && Math.abs(stored[3] - current[3]) <= tolH;
+// Approximate equality (0.5% of size). Used to confirm A and B were
+// fetched at the same extent — if they weren't, sampling them at a
+// shared UV would hit different world coordinates and the flow would
+// be nonsense.
+function extentApproxEqual(a, b) {
+  if (!a || !b) return false;
+  const w = Math.abs(a[2] - a[0]);
+  const h = Math.abs(a[3] - a[1]);
+  const tolW = w * 0.005;
+  const tolH = h * 0.005;
+  return Math.abs(a[0] - b[0]) <= tolW
+    && Math.abs(a[2] - b[2]) <= tolW
+    && Math.abs(a[1] - b[1]) <= tolH
+    && Math.abs(a[3] - b[3]) <= tolH;
+}
+
+// Does `stored` fully contain `other`? StickyImageWMS fetches each
+// frame with a 1.5× buffer around the view, so small pans stay
+// inside the buffer and the stored extent still covers the new view.
+// When it does, we can keep using the frames with a UV offset in the
+// warp shader to line content up at the correct world position.
+function extentContains(stored, other) {
+  if (!stored || !other) return false;
+  const w = Math.abs(stored[2] - stored[0]);
+  const h = Math.abs(stored[3] - stored[1]);
+  const tol = Math.max(w, h) * 1e-4;
+  return stored[0] <= other[0] + tol
+    && stored[1] <= other[1] + tol
+    && stored[2] >= other[2] - tol
+    && stored[3] >= other[3] - tol;
 }
 
 export class RadarInterpolator {
@@ -156,18 +171,25 @@ export class RadarInterpolator {
     }
   }
 
-  // Is there enough data to render (A, B, t) for the given extent?
-  // Requires: both frame textures uploaded, a flow texture computed
-  // for the pair (via computeFlow), and — if a view extent is
-  // passed — both frames' stored extents close enough to it that the
-  // warp output will align when OL blits it at the current view.
+  // Is there enough data to render (A, B, t) covering the given
+  // view extent? Requires:
+  //   - both frame textures uploaded,
+  //   - a flow texture computed for the pair (via computeFlow),
+  //   - A and B fetched at approximately the same stored extent so
+  //     they share a UV coordinate system for the flow,
+  //   - the stored extent fully contains the current view so the
+  //     warp shader's UV-transformed sampling has data to fetch.
+  // When the view has only shifted within the stored buffer, this
+  // returns true and renderAt builds a UV offset to place content
+  // at the correct world position in the output canvas.
   hasFlow(timeA, timeB, extent = null) {
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     if (!a || !b) return false;
     if (!this.flows.has(`${timeA}|${timeB}`)) return false;
     if (!extent) return true;
-    return extentMatches(a.extent, extent) && extentMatches(b.extent, extent);
+    if (!extentApproxEqual(a.extent, b.extent)) return false;
+    return extentContains(a.extent, extent);
   }
 
   // Produce the flow texture for (A, B) — LK-computed if useFlow is
@@ -199,7 +221,7 @@ export class RadarInterpolator {
   // the pixelRatio-adjusted size OL requested, which matters on
   // retina (source images are fetched with hidpi:false, so A's
   // native size is half of what OL wants on 2× displays).
-  renderAt(timeA, timeB, t, targetW = 0, targetH = 0) {
+  renderAt(timeA, timeB, t, targetW = 0, targetH = 0, canvasExtent = null) {
     const a = this.frames.get(timeA);
     const b = this.frames.get(timeB);
     const flow = this.flows.get(`${timeA}|${timeB}`);
@@ -216,11 +238,44 @@ export class RadarInterpolator {
       this.canvas.height = h;
     }
 
+    // Compute the UV transform from output canvas → stored frame UV
+    // so the shader draws content at the correct world position when
+    // the canvas extent differs from the stored extent (small pan
+    // within the 1.5× fetch buffer). Identity when extents match.
+    let scaleX = 1;
+    let scaleY = 1;
+    let offsetX = 0;
+    let offsetY = 0;
+    if (canvasExtent && a.extent) {
+      const se = a.extent;
+      const seW = se[2] - se[0];
+      const seH = se[3] - se[1];
+      if (seW && seH) {
+        const ceW = canvasExtent[2] - canvasExtent[0];
+        const ceH = canvasExtent[3] - canvasExtent[1];
+        scaleX = ceW / seW;
+        scaleY = ceH / seH;
+        offsetX = (canvasExtent[0] - se[0]) / seW;
+        offsetY = (canvasExtent[1] - se[1]) / seH;
+      }
+    }
+
     const { gl } = this;
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    this.warp.render(a.texture, b.texture, flow.texture, t, w, h);
+    this.warp.render(
+      a.texture,
+      b.texture,
+      flow.texture,
+      t,
+      w,
+      h,
+      scaleX,
+      scaleY,
+      offsetX,
+      offsetY,
+    );
 
     return this.canvas;
   }

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -1,52 +1,162 @@
-// Public API for optical-flow interpolation. Phase 1 skeleton: the
-// class compiles, plugs into the call sites FramePool will use in
-// later phases, and never actually warps a pixel. Every method is a
-// no-op or returns a sentinel that makes the caller fall back to
-// discrete frame display.
+// Client-side pyramidal Lucas-Kanade optical flow + motion-compensated
+// warp for radar animation interpolation.
 //
-// Phase 2 will add the warp renderer (with zero flow, visually a
-// crossfade) to validate GL context plumbing and OL integration.
-// Phase 3 adds pyramidal Lucas–Kanade flow computation. Phase 4
-// handles nodata masking, webglcontextlost recovery, and memory
-// budget enforcement.
+// Phase 2 state: frame upload, canvas output, OpenLayers integration,
+// and the warp shader all work. Flow fields are zeroed RG16F textures
+// (no LK yet), so the visual effect is a straight crossfade — but the
+// whole GPU pipeline is exercised so Phase 3 only needs to swap in
+// real flow compute.
+//
+// Instance ownership: one RadarInterpolator per interpolating pool
+// (radar, satellite). Each owns its own WebGL2 context on an offscreen
+// canvas; that canvas is what the pool's warp layer displays via an
+// ol/source/ImageCanvas. Sharing a single GL context across pools is a
+// Phase 4 optimization — per-pool GL is simpler and, with only two
+// interpolating pools, the memory cost is tolerable.
 
 import canInterpolate from './capabilities';
+import WarpRenderer from './warp';
+import { createRgbaTexture, createRg16fTexture } from './glUtils';
 
 export { canInterpolate };
 
-// Phase 1 skeleton methods don't read `this`. Later phases will hold GPU
-// state (textures, programs, flow cache) and access it through `this`.
-/* eslint-disable class-methods-use-this */
 export class RadarInterpolator {
-  constructor(opts = {}) {
-    this.gl = opts.gl || null;
-    this.flowResolution = opts.flowResolution || 256;
-    this.pyramidLevels = opts.pyramidLevels || 3;
-    this.iterations = opts.iterations || 5;
+  constructor({ flowResolution = 256 } = {}) {
+    this.flowResolution = flowResolution;
+
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = 1;
+    this.canvas.height = 1;
+    this.gl = this.canvas.getContext('webgl2', {
+      alpha: true,
+      premultipliedAlpha: true,
+      preserveDrawingBuffer: true,
+      antialias: false,
+    });
+    if (!this.gl) {
+      throw new Error('RadarInterpolator: WebGL2 unavailable');
+    }
+    // Enable either extension — canInterpolate already verified one
+    // of them is available; we just need to activate it for the
+    // RG16F flow texture to be renderable later.
+    this.gl.getExtension('EXT_color_buffer_half_float');
+    this.gl.getExtension('EXT_color_buffer_float');
+
+    this.warp = new WarpRenderer(this.gl);
+
+    // Keyed by time ISO string. Values: { texture, width, height }.
+    this.frames = new Map();
+    // Keyed by `${timeA}|${timeB}`. Values: { texture }.
+    this.flows = new Map();
   }
 
-  // Called from FramePool.imageloadend once a slot's bitmap finishes
-  // loading. Phase 3 will upload to GPU and kick off flow computation
-  // for any newly-completable pair.
-  onSlotLoaded(/* slot, image */) {}
+  // Called from FramePool on imageloadend once a slot's bitmap is
+  // usable. Uploads the image to a GL texture keyed by the slot's
+  // TIME. If a previous texture existed for that TIME (e.g., after a
+  // STYLES change invalidated it), it's replaced.
+  onSlotLoaded(slot, image) {
+    if (!slot || !slot.time || !image) return;
+    const w = image.naturalWidth || image.width;
+    const h = image.naturalHeight || image.height;
+    if (!w || !h) return;
+    const existing = this.frames.get(slot.time);
+    if (existing) this.gl.deleteTexture(existing.texture);
+    const texture = createRgbaTexture(this.gl, w, h, image);
+    this.frames.set(slot.time, { texture, width: w, height: h });
+  }
 
-  // Called from FramePool._resyncAllParams after a WMS-param change.
-  // `flowInvariant` is true when only STYLES / FORMAT changed — flow
-  // can be kept and reused with the re-styled bitmaps once they land.
-  // Phase 3 will conditionally clear the flow cache.
-  onParamsChanged(/* { flowInvariant } */) {}
+  // Called from FramePool._resyncAllParams. If the change wasn't
+  // flow-invariant (LAYERS / ELEVATION / URL moved), throw out the
+  // flow cache — the underlying physical field has changed. Frame
+  // textures are separately invalidated when the pool's slots
+  // refetch; onSlotLoaded overwrites them when the new bitmaps land.
+  onParamsChanged({ flowInvariant } = {}) {
+    if (!flowInvariant) {
+      for (const f of this.flows.values()) this.gl.deleteTexture(f.texture);
+      this.flows.clear();
+    }
+    // Frame textures are always replaced on new bitmaps, so we don't
+    // pre-emptively delete them here — doing so would leave a window
+    // where hasFlow returned false but showTime was already showing
+    // the new frame.
+  }
 
-  // Called when a slot's view-cached image is no longer valid (pan /
-  // zoom pushed the sticky out of the requested extent) OR when the
-  // slot's TIME is reassigned during a window slide. Phase 3 will
-  // drop any flow pair that references the invalidated time.
-  invalidateSlot(/* time */) {}
+  // Called from FramePool when a slot goes stale (pan/zoom invalidated
+  // view coverage, or window slide dropped this TIME). Drop the frame
+  // texture and any flow pairs referencing this time.
+  invalidateSlot(time) {
+    if (!time) return;
+    const f = this.frames.get(time);
+    if (f) {
+      this.gl.deleteTexture(f.texture);
+      this.frames.delete(time);
+    }
+    for (const [key, flow] of this.flows) {
+      if (key.startsWith(`${time}|`) || key.endsWith(`|${time}`)) {
+        this.gl.deleteTexture(flow.texture);
+        this.flows.delete(key);
+      }
+    }
+  }
 
-  // Is there a usable flow field for (A, B)? Phase 1 always returns
-  // false so FramePool.showInterpolated falls back to the discrete
-  // display path.
-  hasFlow(/* timeA, timeB */) { return false; }
+  // Is there enough data to render (A, B, t)? In Phase 2, "flow
+  // ready" really just means "both bitmaps uploaded" — the zero flow
+  // texture is created on demand.
+  hasFlow(timeA, timeB) {
+    return this.frames.has(timeA) && this.frames.has(timeB);
+  }
 
-  // Render the warped frame for (A, B, t). Phase 1 returns null.
-  renderAt(/* timeA, timeB, t */) { return null; }
+  // Draw the warped image for (A, B, t) into this.canvas. Returns
+  // the canvas, or null if we don't have both frames yet.
+  renderAt(timeA, timeB, t) {
+    const a = this.frames.get(timeA);
+    const b = this.frames.get(timeB);
+    if (!a || !b) return null;
+
+    // A and B can disagree on pixel dimensions if the user panned
+    // between their loads. Phase 2 picks A's dimensions as the
+    // analysis grid; the warp shader samples B using the same UVs
+    // regardless, which smears B at the edges when dimensions
+    // differ. Acceptable for the shake-out phase; Phase 3 will
+    // resample both onto a common analysis grid before LK runs.
+    const w = a.width;
+    const h = a.height;
+
+    if (this.canvas.width !== w || this.canvas.height !== h) {
+      this.canvas.width = w;
+      this.canvas.height = h;
+    }
+
+    const flowTex = this._getOrCreateFlow(timeA, timeB);
+
+    const { gl } = this;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    this.warp.render(a.texture, b.texture, flowTex, t, w, h);
+
+    return this.canvas;
+  }
+
+  _getOrCreateFlow(timeA, timeB) {
+    const key = `${timeA}|${timeB}`;
+    let flow = this.flows.get(key);
+    if (!flow) {
+      // Phase 2: zero-filled flow. Phase 3 will populate this via
+      // pyramidal LK before any render call that needs it.
+      const r = this.flowResolution;
+      const texture = createRg16fTexture(this.gl, r, r, null);
+      flow = { texture };
+      this.flows.set(key, flow);
+    }
+    return flow.texture;
+  }
+
+  dispose() {
+    for (const f of this.frames.values()) this.gl.deleteTexture(f.texture);
+    for (const f of this.flows.values()) this.gl.deleteTexture(f.texture);
+    this.frames.clear();
+    this.flows.clear();
+    this.warp.dispose();
+  }
 }

--- a/src/animation/interpolation/index.js
+++ b/src/animation/interpolation/index.js
@@ -27,9 +27,17 @@ export class RadarInterpolator {
     this.canvas = document.createElement('canvas');
     this.canvas.width = 1;
     this.canvas.height = 1;
+    // premultipliedAlpha:false — our warp shader outputs straight
+    // (non-premultiplied) RGBA by taking mix() of two non-premultiplied
+    // texture samples. With premultipliedAlpha:true the browser would
+    // re-multiply during compositing, darkening semi-transparent pixels
+    // (coastlines, radar-range edges, nodata). preserveDrawingBuffer:true
+    // keeps the buffer between our gl.clear calls — OL may read the
+    // canvas slightly out of phase with our draws, and without this the
+    // browser can wipe the buffer between draw and composite.
     this.gl = this.canvas.getContext('webgl2', {
       alpha: true,
-      premultipliedAlpha: true,
+      premultipliedAlpha: false,
       preserveDrawingBuffer: true,
       antialias: false,
     });

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -51,27 +51,16 @@ void main() {
   // (also computed in that space) is applied consistently.
   vec4 a = texture(uFrameA, src - uT * flow);
   vec4 b = texture(uFrameB, src + (1.0 - uT) * flow);
-  // Nodata handling. Three regimes depending on sample alphas:
-  //   - both transparent → output transparent.
-  //   - one transparent (leading/trailing edge of a moving cell,
-  //     or a coastline/range boundary): use the other side's color
-  //     at full intensity but fade its alpha linearly with t. The
-  //     naive mix() faded color AND alpha, giving a quadratic
-  //     composite that dimmed boundaries mid-loop (brightness
-  //     pumping). Snap-to-full alpha at the first nonzero t made
-  //     echoes pop forward at each advance. Linear alpha fade is
-  //     the right middle: color stays correct, alpha slides 0↔1
-  //     linearly, no pumping and no popping.
-  //   - both opaque → normal mix.
-  if (a.a < 0.001 && b.a < 0.001) {
-    fragColor = vec4(0.0);
-  } else if (a.a < 0.001) {
-    fragColor = vec4(b.rgb, b.a * uT);
-  } else if (b.a < 0.001) {
-    fragColor = vec4(a.rgb, a.a * (1.0 - uT));
-  } else {
-    fragColor = mix(a, b, uT);
-  }
+  // Plain mix, no nodata fallback. Earlier experiments with a
+  // snap-to-full fallback and a linear-alpha fade both made
+  // non-overlapping cell regions (leading/trailing edges where the
+  // flow hasn't closed the gap) MORE visible as ghosts, which the
+  // user reads as blur. mix()'s quadratic composite keeps those
+  // ghosts at ~25% intensity instead, closer to invisible. The
+  // underlying issue that creates the ghosts is that flow isn't
+  // tracking enough of the motion; fixing that removes the need
+  // for any clever boundary treatment.
+  fragColor = mix(a, b, uT);
 }
 `;
 

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -51,17 +51,24 @@ void main() {
   // (also computed in that space) is applied consistently.
   vec4 a = texture(uFrameA, src - uT * flow);
   vec4 b = texture(uFrameB, src + (1.0 - uT) * flow);
-  // Nodata fallback: at coastlines and radar-range edges one sample
-  // is full-alpha and the other is zero. mix() would fade the
-  // boundary towards alpha 0.5 at t=0.5 — visible as brightness
-  // pumping during playback. Prefer whichever side has data so the
-  // edge stays stable.
+  // Nodata handling. Three regimes depending on sample alphas:
+  //   - both transparent → output transparent.
+  //   - one transparent (leading/trailing edge of a moving cell,
+  //     or a coastline/range boundary): use the other side's color
+  //     at full intensity but fade its alpha linearly with t. The
+  //     naive mix() faded color AND alpha, giving a quadratic
+  //     composite that dimmed boundaries mid-loop (brightness
+  //     pumping). Snap-to-full alpha at the first nonzero t made
+  //     echoes pop forward at each advance. Linear alpha fade is
+  //     the right middle: color stays correct, alpha slides 0↔1
+  //     linearly, no pumping and no popping.
+  //   - both opaque → normal mix.
   if (a.a < 0.001 && b.a < 0.001) {
     fragColor = vec4(0.0);
   } else if (a.a < 0.001) {
-    fragColor = b;
+    fragColor = vec4(b.rgb, b.a * uT);
   } else if (b.a < 0.001) {
-    fragColor = a;
+    fragColor = vec4(a.rgb, a.a * (1.0 - uT));
   } else {
     fragColor = mix(a, b, uT);
   }

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -59,9 +59,13 @@ export default class WarpRenderer {
 
   // Draw to whatever FBO is currently bound (null = default FBO =
   // this.gl.canvas). Caller is responsible for binding the right
-  // FBO and setting the canvas dimensions before calling.
+  // FBO and clearing it before calling.
   render(frameATex, frameBTex, flowTex, t, viewportW, viewportH) {
     const { gl } = this;
+    // Ensure the draw fully overwrites the cleared buffer rather
+    // than blending with any leftover content — defensive against
+    // GL state getting nudged into BLEND by another code path.
+    gl.disable(gl.BLEND);
     gl.viewport(0, 0, viewportW, viewportH);
     gl.useProgram(this.program);
 

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -43,14 +43,28 @@ uniform vec2 uOffset;
 in vec2 vUv;
 out vec4 fragColor;
 
+// Sample the texture only when the UV is inside [0,1]; outside,
+// return transparent. CLAMP_TO_EDGE wrap would otherwise smear a
+// stretched row of edge pixels along the viewport boundary when the
+// canvas extent sits near the stored frame's edge (small pan right
+// to the limit of the 1.5× fetch buffer).
+vec4 sampleBounded(sampler2D tex, vec2 uv) {
+  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+    return vec4(0.0);
+  }
+  return texture(tex, uv);
+}
+
 void main() {
   vec2 src = vUv * uScale + uOffset;
   vec2 flow = texture(uFlow, src).rg;
   // Forward-warp A by t*flow, backward-warp B by (1-t)*flow, blend.
   // All UVs here are in the stored frames' space so the flow texture
   // (also computed in that space) is applied consistently.
-  vec4 a = texture(uFrameA, src - uT * flow);
-  vec4 b = texture(uFrameB, src + (1.0 - uT) * flow);
+  vec2 srcA = src - uT * flow;
+  vec2 srcB = src + (1.0 - uT) * flow;
+  vec4 a = sampleBounded(uFrameA, srcA);
+  vec4 b = sampleBounded(uFrameB, srcB);
   // Plain mix, no nodata fallback. Earlier experiments with a
   // snap-to-full fallback and a linear-alpha fade both made
   // non-overlapping cell regions (leading/trailing edges where the

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -32,15 +32,25 @@ uniform sampler2D uFrameA;
 uniform sampler2D uFrameB;
 uniform sampler2D uFlow;
 uniform float uT;
+// Affine transform from output-canvas UV to stored-frame UV.
+// When canvas extent equals stored extent: uScale=(1,1), uOffset=(0,0).
+// When canvas has shifted (small pan within the loaded buffer):
+// uOffset moves the sampling so the content lands at the correct
+// world position in the output.
+uniform vec2 uScale;
+uniform vec2 uOffset;
 
 in vec2 vUv;
 out vec4 fragColor;
 
 void main() {
-  vec2 flow = texture(uFlow, vUv).rg;
+  vec2 src = vUv * uScale + uOffset;
+  vec2 flow = texture(uFlow, src).rg;
   // Forward-warp A by t*flow, backward-warp B by (1-t)*flow, blend.
-  vec4 a = texture(uFrameA, vUv - uT * flow);
-  vec4 b = texture(uFrameB, vUv + (1.0 - uT) * flow);
+  // All UVs here are in the stored frames' space so the flow texture
+  // (also computed in that space) is applied consistently.
+  vec4 a = texture(uFrameA, src - uT * flow);
+  vec4 b = texture(uFrameB, src + (1.0 - uT) * flow);
   fragColor = mix(a, b, uT);
 }
 `;
@@ -55,12 +65,28 @@ export default class WarpRenderer {
     this.uFrameB = gl.getUniformLocation(this.program, 'uFrameB');
     this.uFlow = gl.getUniformLocation(this.program, 'uFlow');
     this.uT = gl.getUniformLocation(this.program, 'uT');
+    this.uScale = gl.getUniformLocation(this.program, 'uScale');
+    this.uOffset = gl.getUniformLocation(this.program, 'uOffset');
   }
 
   // Draw to whatever FBO is currently bound (null = default FBO =
   // this.gl.canvas). Caller is responsible for binding the right
-  // FBO and clearing it before calling.
-  render(frameATex, frameBTex, flowTex, t, viewportW, viewportH) {
+  // FBO and clearing it before calling. scaleX/Y and offsetX/Y
+  // define an affine mapping from output UV to stored-frame UV —
+  // identity (1,1,0,0) when the canvas extent equals the stored
+  // extent.
+  render(
+    frameATex,
+    frameBTex,
+    flowTex,
+    t,
+    viewportW,
+    viewportH,
+    scaleX = 1,
+    scaleY = 1,
+    offsetX = 0,
+    offsetY = 0,
+  ) {
     const { gl } = this;
     // Ensure the draw fully overwrites the cleared buffer rather
     // than blending with any leftover content — defensive against
@@ -82,6 +108,8 @@ export default class WarpRenderer {
     gl.uniform1i(this.uFlow, 2);
 
     gl.uniform1f(this.uT, t);
+    gl.uniform2f(this.uScale, scaleX, scaleY);
+    gl.uniform2f(this.uOffset, offsetX, offsetY);
 
     drawFullscreen(gl, this.vbo, this.aPos);
   }

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -51,7 +51,20 @@ void main() {
   // (also computed in that space) is applied consistently.
   vec4 a = texture(uFrameA, src - uT * flow);
   vec4 b = texture(uFrameB, src + (1.0 - uT) * flow);
-  fragColor = mix(a, b, uT);
+  // Nodata fallback: at coastlines and radar-range edges one sample
+  // is full-alpha and the other is zero. mix() would fade the
+  // boundary towards alpha 0.5 at t=0.5 — visible as brightness
+  // pumping during playback. Prefer whichever side has data so the
+  // edge stays stable.
+  if (a.a < 0.001 && b.a < 0.001) {
+    fragColor = vec4(0.0);
+  } else if (a.a < 0.001) {
+    fragColor = b;
+  } else if (b.a < 0.001) {
+    fragColor = a;
+  } else {
+    fragColor = mix(a, b, uT);
+  }
 }
 `;
 

--- a/src/animation/interpolation/warp.js
+++ b/src/animation/interpolation/warp.js
@@ -1,0 +1,89 @@
+// Motion-compensated warp renderer. The fragment shader takes two
+// RGBA frame textures A and B plus an RG16F flow texture in
+// normalized-UV displacement units, and produces a mixed output at
+// fractional time `t ∈ [0, 1]`.
+//
+// Phase 2: flow is always zero, so the shader degenerates to a plain
+// crossfade (A at t=0, B at t=1, linear in between). This exists to
+// prove GL context plumbing, texture upload, FBO/canvas output, and
+// OpenLayers integration before Phase 3 introduces real Lucas-Kanade
+// flow.
+//
+// Shader sources are inline strings — no webpack/raw-loader config
+// change needed.
+
+import {
+  createProgram, createFullscreenTriangle, drawFullscreen,
+} from './glUtils';
+
+const VERT = `#version 300 es
+in vec2 aPos;
+out vec2 vUv;
+void main() {
+  vUv = aPos * 0.5 + 0.5;
+  gl_Position = vec4(aPos, 0.0, 1.0);
+}
+`;
+
+const FRAG = `#version 300 es
+precision highp float;
+
+uniform sampler2D uFrameA;
+uniform sampler2D uFrameB;
+uniform sampler2D uFlow;
+uniform float uT;
+
+in vec2 vUv;
+out vec4 fragColor;
+
+void main() {
+  vec2 flow = texture(uFlow, vUv).rg;
+  // Forward-warp A by t*flow, backward-warp B by (1-t)*flow, blend.
+  vec4 a = texture(uFrameA, vUv - uT * flow);
+  vec4 b = texture(uFrameB, vUv + (1.0 - uT) * flow);
+  fragColor = mix(a, b, uT);
+}
+`;
+
+export default class WarpRenderer {
+  constructor(gl) {
+    this.gl = gl;
+    this.program = createProgram(gl, VERT, FRAG);
+    this.vbo = createFullscreenTriangle(gl);
+    this.aPos = gl.getAttribLocation(this.program, 'aPos');
+    this.uFrameA = gl.getUniformLocation(this.program, 'uFrameA');
+    this.uFrameB = gl.getUniformLocation(this.program, 'uFrameB');
+    this.uFlow = gl.getUniformLocation(this.program, 'uFlow');
+    this.uT = gl.getUniformLocation(this.program, 'uT');
+  }
+
+  // Draw to whatever FBO is currently bound (null = default FBO =
+  // this.gl.canvas). Caller is responsible for binding the right
+  // FBO and setting the canvas dimensions before calling.
+  render(frameATex, frameBTex, flowTex, t, viewportW, viewportH) {
+    const { gl } = this;
+    gl.viewport(0, 0, viewportW, viewportH);
+    gl.useProgram(this.program);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, frameATex);
+    gl.uniform1i(this.uFrameA, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, frameBTex);
+    gl.uniform1i(this.uFrameB, 1);
+
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(gl.TEXTURE_2D, flowTex);
+    gl.uniform1i(this.uFlow, 2);
+
+    gl.uniform1f(this.uT, t);
+
+    drawFullscreen(gl, this.vbo, this.aPos);
+  }
+
+  dispose() {
+    this.gl.deleteProgram(this.program);
+    this.gl.deleteBuffer(this.vbo);
+  }
+}

--- a/src/animation/stickyImageWMS.js
+++ b/src/animation/stickyImageWMS.js
@@ -100,6 +100,26 @@ export default class StickyImageWMS extends ImageWMS {
     this._sticky = null;
   }
 
+  // Clear the parent ImageSource's cached image wrapper so the next
+  // super.getImage call creates a fresh one at the current view
+  // extent. Needed because OL's own render pipeline keeps calling
+  // getImage on the primary layer's source during a pan, and the
+  // cache can lock in an intermediate wrapper whose extent doesn't
+  // match the final view. A load completing on that wrapper stores
+  // the mid-pan extent on the interpolator frame, which then fails
+  // the extent-equality check against neighbouring slots loaded at
+  // the final view and the LK compute is skipped.
+  //
+  // Sticky is preserved so the layer keeps drawing the old-extent
+  // image while the new wrapper loads.
+  resetImageCache() {
+    this.image_ = null;
+    if (this._currentAbortController) {
+      this._currentAbortController.abort();
+      this._currentAbortController = null;
+    }
+  }
+
   // Promote an image to sticky. Used from imageloadend when the slot
   // is not currently primary (so OL never calls getImage through the
   // sticky override, which is the other place sticky gets updated).

--- a/src/animation/stickyImageWMS.js
+++ b/src/animation/stickyImageWMS.js
@@ -103,21 +103,29 @@ export default class StickyImageWMS extends ImageWMS {
   // Clear the parent ImageSource's cached image wrapper so the next
   // super.getImage call creates a fresh one at the current view
   // extent. Needed because OL's own render pipeline keeps calling
-  // getImage on the primary layer's source during a pan, and the
-  // cache can lock in an intermediate wrapper whose extent doesn't
-  // match the final view. A load completing on that wrapper stores
-  // the mid-pan extent on the interpolator frame, which then fails
-  // the extent-equality check against neighbouring slots loaded at
-  // the final view and the LK compute is skipped.
+  // getImage on the primary layer's source during a pan or zoom,
+  // and the cache can lock in an intermediate wrapper whose extent
+  // doesn't match the final view. A load completing on that wrapper
+  // stores the mid-interaction extent on the interpolator frame,
+  // which then fails the extent-equality check against neighbouring
+  // slots loaded at the final view and the LK compute is skipped.
+  //
+  // OL 10 stores the wrapper on `this.image` (no trailing
+  // underscore). Also null the `wantedExtent_/Resolution_/Projection_`
+  // so the cache-check short-circuit at ImageSource.getImageInternal
+  // can't match either via the wanted hint or the cached wrapper.
   //
   // Sticky is preserved so the layer keeps drawing the old-extent
   // image while the new wrapper loads.
   resetImageCache() {
-    this.image_ = null;
     if (this._currentAbortController) {
       this._currentAbortController.abort();
       this._currentAbortController = null;
     }
+    this.image = null;
+    this.wantedExtent_ = null;
+    this.wantedResolution_ = null;
+    this.wantedProjection_ = null;
   }
 
   // Promote an image to sticky. Used from imageloadend when the slot

--- a/src/index.html
+++ b/src/index.html
@@ -98,6 +98,13 @@
       <button class="chip" role="radio" aria-checked="false" data-theme="dark">Tumma</button>
       <button class="chip" role="radio" aria-checked="false" data-theme="light">Vaalea</button>
     </div>
+    <div class="menu-divider"></div>
+    <div class="menu-header">Interpolointi</div>
+    <div class="theme-chips" role="radiogroup" aria-label="Interpolointi">
+      <button class="chip" role="radio" aria-checked="false" data-interp="off">Pois</button>
+      <button class="chip" role="radio" aria-checked="false" data-interp="crossfade">Häivytys</button>
+      <button class="chip" role="radio" aria-checked="false" data-interp="flow">Virtaus</button>
+    </div>
   </div>
 
   <button id="locationLayerButton" class="location-fab noselect" aria-pressed="false" aria-label="Paikannus">

--- a/src/radar.js
+++ b/src/radar.js
@@ -803,7 +803,14 @@ let isInteracting = false;
 // timeline from what's on screen.
 const renderTick = function (now) {
   animationId = window.requestAnimationFrame(renderTick);
-  if (isInteracting) return;
+  // Skip both advance and warp render while the user is mid-drag
+  // OR while OL is mid-tween (e.g., smooth zoom from a scroll wheel).
+  // Without the getAnimating() check, every wheel tick keeps
+  // playback advancing, and each advance fires pool.showTime →
+  // _prefetchAroundCurrent → 3-6 WMS fetches per visible pool. A
+  // few seconds of scroll-while-playing can launch 30-60 fetches
+  // on top of what the debounced moveend will prefetch.
+  if (isInteracting || map.getView().getAnimating()) return;
 
   const stepDuration = 1000 / options.frameRate;
   if (now - lastAdvance >= stepDuration) {

--- a/src/radar.js
+++ b/src/radar.js
@@ -178,6 +178,18 @@ const poolLoadStates = {
   lightningLayer: new Array(13).fill(false),
   observationLayer: new Array(13).fill(false),
 };
+// Per-cell "flow ready" state. Only populated for pools that have an
+// interpolator attached (radar, satellite when interp is enabled).
+// True means both endpoints of the pair starting at this index are
+// loaded AND the interpolator has a computed flow field — playback
+// through this timestep will show a motion-compensated warp instead
+// of a jump to the next discrete frame.
+const poolFlowStates = {
+  satelliteLayer: new Array(13).fill(false),
+  radarLayer: new Array(13).fill(false),
+  lightningLayer: new Array(13).fill(false),
+  observationLayer: new Array(13).fill(false),
+};
 
 const VISIBLE = new Set(safeParseJSON('VISIBLE', ['radarLayer']));
 const ACTIVE = new Set(safeParseJSON('ACTIVE', [options.defaultRadarLayer]));
@@ -185,13 +197,20 @@ const ACTIVE = new Set(safeParseJSON('ACTIVE', [options.defaultRadarLayer]));
 function updateTimelineCell(i) {
   if (!timeline) return;
   let allLoaded = true;
+  let flowPending = false;
   for (const name of Object.keys(framePools)) {
-    if (VISIBLE.has(name) && framePools[name] && !poolLoadStates[name][i]) {
-      allLoaded = false;
-      break;
-    }
+    const pool = framePools[name];
+    if (!pool || !VISIBLE.has(name)) continue; // eslint-disable-line no-continue
+    if (!poolLoadStates[name][i]) allLoaded = false;
+    // A pool only marks flow-pending if it actually has an
+    // interpolator attached. Lightning/observation (no interp) and
+    // radar/satellite with mode=off never flag this cell.
+    if (pool.interpolator && !poolFlowStates[name][i]) flowPending = true;
   }
   timeline.setLoadState(i, allLoaded);
+  // Flow-pending only meaningful when the cell is loaded — a not-
+  // yet-loaded cell is shown as "loading" with priority anyway.
+  timeline.setFlowPending(i, allLoaded && flowPending);
 }
 
 function recomputeAllTimelineCells() {
@@ -1944,6 +1963,10 @@ const main = () => {
     const pool = new FramePool({ primaryLayer: layer, map });
     pool.onLoadStateChange = (idx, loaded) => {
       poolLoadStates[name][idx] = loaded;
+      updateTimelineCell(idx);
+    };
+    pool.onFlowStateChange = (idx, ready) => {
+      poolFlowStates[name][idx] = ready;
       updateTimelineCell(idx);
     };
     framePools[name] = pool;

--- a/src/radar.js
+++ b/src/radar.js
@@ -787,6 +787,14 @@ function updateClock() {
 
 let isInteracting = false;
 
+function anyPoolZooming() {
+  for (const name of Object.keys(framePools)) {
+    const p = framePools[name];
+    if (p && p.isZoomGestureActive && p.isZoomGestureActive()) return true;
+  }
+  return false;
+}
+
 // Playback loop. Split into two cadences so interpolation can layer on
 // top cleanly in later phases:
 //   - Advance (slow): bump the discrete timestep by a full frame when
@@ -803,14 +811,15 @@ let isInteracting = false;
 // timeline from what's on screen.
 const renderTick = function (now) {
   animationId = window.requestAnimationFrame(renderTick);
-  // Skip both advance and warp render while the user is mid-drag
-  // OR while OL is mid-tween (e.g., smooth zoom from a scroll wheel).
-  // Without the getAnimating() check, every wheel tick keeps
-  // playback advancing, and each advance fires pool.showTime →
-  // _prefetchAroundCurrent → 3-6 WMS fetches per visible pool. A
-  // few seconds of scroll-while-playing can launch 30-60 fetches
-  // on top of what the debounced moveend will prefetch.
-  if (isInteracting || map.getView().getAnimating()) return;
+  // Skip both advance and warp render while the user is mid-drag,
+  // while OL is mid-tween (e.g., smooth zoom from a scroll wheel),
+  // or while any pool is inside an active wheel-zoom gesture (we
+  // hold the pause until 300ms after the last wheel event so slow
+  // scrolls don't fire prefetch bursts between tween gaps).
+  // Without these gates, every wheel tick keeps playback
+  // advancing, and each advance fires pool.showTime →
+  // _prefetchAroundCurrent → 3-6 WMS fetches per visible pool.
+  if (isInteracting || map.getView().getAnimating() || anyPoolZooming()) return;
 
   const stepDuration = 1000 / options.frameRate;
   if (now - lastAdvance >= stepDuration) {

--- a/src/radar.js
+++ b/src/radar.js
@@ -102,16 +102,20 @@ function readInitialInterpMode() {
 
 canInterpolate().then((ok) => {
   interpCapable = ok;
-  interpMode = ok ? readInitialInterpMode() : 'off';
+  interpMode = ok ? readInitialInterpMode() : DEFAULT_INTERP_MODE;
   // eslint-disable-next-line no-console
   console.info(`[tutka] INTERP: capable=${ok} mode=${interpMode}`);
-  track(ok ? 'interp-available' : 'interp-unsupported');
+  // One event per boot with both properties so Umami can split
+  // capability counts AND see the resolved initial mode. Returning
+  // visitors whose localStorage already opted into a non-default
+  // mode show up here too, which lets us track adoption over time.
+  track('interp-boot', { capable: ok, mode: interpMode });
   attachInterpolators();
   updateInterpChipsState();
 }).catch((err) => {
   // eslint-disable-next-line no-console
   console.warn('[tutka] INTERP probe failed:', err);
-  track('interp-probe-error');
+  track('interp-boot', { capable: false, mode: DEFAULT_INTERP_MODE, error: true });
 });
 
 function attachInterpolators() {

--- a/src/radar.js
+++ b/src/radar.js
@@ -30,7 +30,7 @@ import Timeline from './timeline';
 import wmsServerConfiguration from './config';
 import createLongPressHandler from './longpress';
 import FramePool from './animation/framePool';
-import { canInterpolate } from './animation/interpolation';
+import { canInterpolate, RadarInterpolator } from './animation/interpolation';
 
 dayjs.locale('fi');
 dayjs.extend(utcPlugin);
@@ -65,15 +65,6 @@ let startDate = new Date(Math.floor(Date.now() / 300000) * 300000 - 300000 * 12)
 // id — was a setInterval handle before the RAF refactor). Null when paused.
 let animationId = null;
 let lastAdvance = 0;
-// Resolved at module load; Phase 1 only logs the result. Pool construction
-// does not block on this. Phase 2 will read interpEnabled to gate
-// constructing a RadarInterpolator for the radar and satellite pools.
-let interpEnabled = false;
-canInterpolate().then((ok) => {
-  interpEnabled = ok;
-  debug(`INTERP: ${interpEnabled ? 'enabled' : 'disabled'}`);
-  track(interpEnabled ? 'interp-available' : 'interp-unsupported');
-});
 const layerInfo = {};
 let timeline;
 let mapTime = '';
@@ -83,6 +74,33 @@ const framePools = {
   lightningLayer: null,
   observationLayer: null,
 };
+
+// Probe runs at module load and may settle before or after main()
+// constructs the pools. attachInterpolators is idempotent; it's
+// called both from this .then and from the end of pool construction
+// in main() so whichever runs later does the wiring.
+let interpEnabled = false;
+canInterpolate().then((ok) => {
+  interpEnabled = ok;
+  debug(`INTERP: ${interpEnabled ? 'enabled' : 'disabled'}`);
+  track(interpEnabled ? 'interp-available' : 'interp-unsupported');
+  attachInterpolators();
+});
+
+function attachInterpolators() {
+  if (!interpEnabled) return;
+  const playing = animationId !== null;
+  for (const name of ['radarLayer', 'satelliteLayer']) {
+    const pool = framePools[name];
+    if (pool && !pool.interpolator) {
+      pool.setInterpolator(new RadarInterpolator());
+      // If the user is already playing when the probe finishes
+      // resolving, catch up — otherwise interp stays off until the
+      // user pauses and plays again.
+      if (playing) pool.setInterpActive(true);
+    }
+  }
+}
 const poolLoadStates = {
   satelliteLayer: new Array(13).fill(false),
   radarLayer: new Array(13).fill(false),
@@ -712,6 +730,13 @@ const renderTick = function (now) {
   }
 };
 
+function setInterpActiveAll(active) {
+  for (const name of Object.keys(framePools)) {
+    const pool = framePools[name];
+    if (pool && pool.interpolator) pool.setInterpActive(active);
+  }
+}
+
 const play = function () {
   if (animationId === null) {
     debug('PLAY');
@@ -719,6 +744,7 @@ const play = function () {
     lastAdvance = window.performance.now();
     animationId = window.requestAnimationFrame(renderTick);
     document.getElementById('playstopButton').innerHTML = 'pause';
+    setInterpActiveAll(true);
   }
 };
 
@@ -729,6 +755,7 @@ const stop = function () {
     window.cancelAnimationFrame(animationId);
     animationId = null;
     document.getElementById('playstopButton').innerHTML = 'play_arrow';
+    setInterpActiveAll(false);
   }
 };
 
@@ -1809,6 +1836,10 @@ const main = () => {
     };
     framePools[name] = pool;
   }
+  // Pools are now in framePools. If the capability probe has already
+  // resolved, wire interpolators up now; otherwise the probe's .then
+  // will call attachInterpolators once the verdict lands.
+  attachInterpolators();
   recomputeAllTimelineCells();
   window.__tutka = { map, framePools };
 

--- a/src/radar.js
+++ b/src/radar.js
@@ -81,11 +81,15 @@ const framePools = {
 //   - 'crossfade' : warp layer with zero-flow — smooth A→B fade.
 //   - 'flow'      : warp layer with LK-computed optical flow — motion-
 //                   compensated interpolation.
-// Resolved on boot from URL override (?interp=…) then localStorage,
-// defaulting to 'flow' when the device is capable.
+// Resolved on boot from URL override (?interp=…) then localStorage.
+// Default is 'off' (discrete frames, the historical behavior). A
+// stored mode that's no longer in VALID_INTERP_MODES — e.g. if we
+// ever rename or drop an option — is ignored and the default wins,
+// so the live storage format is self-healing across releases.
 const VALID_INTERP_MODES = ['off', 'crossfade', 'flow'];
 const INTERP_MODE_KEY = 'interpMode';
-let interpMode = 'off';
+const DEFAULT_INTERP_MODE = 'off';
+let interpMode = DEFAULT_INTERP_MODE;
 let interpCapable = false;
 
 function readInitialInterpMode() {
@@ -93,7 +97,7 @@ function readInitialInterpMode() {
   if (VALID_INTERP_MODES.includes(urlMode)) return urlMode;
   const stored = localStorage.getItem(INTERP_MODE_KEY);
   if (VALID_INTERP_MODES.includes(stored)) return stored;
-  return 'flow';
+  return DEFAULT_INTERP_MODE;
 }
 
 canInterpolate().then((ok) => {

--- a/src/radar.js
+++ b/src/radar.js
@@ -1074,7 +1074,13 @@ function layerInfoPlaylist(event) {
   const layer = event.target;
   const name = layer.get('name');
   const info = layer.get('info');
-  const opacity = layer.get('opacity') * 100;
+  // Prefer the user-chosen opacity when the interpolator has zeroed
+  // the layer's actual opacity for its transparent swap. Falls back
+  // to layer.opacity for non-interp layers (lightning, observation,
+  // or any layer when interp is off).
+  const userOp = layer.get('_userOpacity');
+  const effectiveOpacity = userOp !== undefined ? userOp : layer.get('opacity');
+  const opacity = effectiveOpacity * 100;
 
   if (typeof info === 'undefined') return;
 

--- a/src/radar.js
+++ b/src/radar.js
@@ -82,9 +82,14 @@ const framePools = {
 let interpEnabled = false;
 canInterpolate().then((ok) => {
   interpEnabled = ok;
-  debug(`INTERP: ${interpEnabled ? 'enabled' : 'disabled'}`);
+  // eslint-disable-next-line no-console
+  console.info(`[tutka] INTERP: ${interpEnabled ? 'enabled' : 'disabled'}`);
   track(interpEnabled ? 'interp-available' : 'interp-unsupported');
   attachInterpolators();
+}).catch((err) => {
+  // eslint-disable-next-line no-console
+  console.warn('[tutka] INTERP probe failed:', err);
+  track('interp-probe-error');
 });
 
 function attachInterpolators() {

--- a/src/radar.js
+++ b/src/radar.js
@@ -1528,6 +1528,11 @@ document.querySelectorAll('#overflowMenu .chip[data-interp]').forEach((chip) => 
     setInterpMode(chip.getAttribute('data-interp'));
   });
 });
+// Initialise chip disabled/selected state up front — before the
+// capability probe resolves, interpCapable is false so only 'off'
+// is tappable. Otherwise taps arrive at setInterpMode which
+// silently rejects non-'off' modes, and the user sees no feedback.
+updateInterpChipsState();
 
 // POI layers — map features that users can toggle independently of data layers.
 // Adding a future POI = one entry in this registry; the overflow menu row and

--- a/src/radar.js
+++ b/src/radar.js
@@ -1013,8 +1013,24 @@ function layerInfoPlaylist(event) {
 
   if (typeof info === 'undefined') return;
 
-  // If only opacity changed, update slider value without full DOM rebuild
+  // FramePool.showTime swaps primary.setSource(slot.source) every
+  // discrete frame advance during playback. That fires propertychange
+  // with key='source'. Without this guard the whole playlist DOM
+  // rebuilds 2× per second during playback (visible as a pulsing
+  // hover state on style chips), churning CPU for no user-visible
+  // reason — source swaps within the pool never change which WMS
+  // layer/style/URL the user selected.
+  if (event.key === 'source') return;
+
+  // If only opacity changed, update slider value without full DOM rebuild.
+  // Skip updates triggered by the interpolator's internal transparent
+  // swap (framepool._setPrimaryTransparent), which marks the layer
+  // with `_interpHiding` before writing opacity — otherwise the slider
+  // would jump to 0 whenever the warp takes over.
   if (event.key === 'opacity') {
+    if (layer.get('_interpHiding') !== undefined && layer.get('_interpHiding') !== false) {
+      return;
+    }
     const existingSlider = document.getElementById(`${name}Slider`);
     if (existingSlider) {
       existingSlider.value = opacity;

--- a/src/radar.js
+++ b/src/radar.js
@@ -76,17 +76,34 @@ const framePools = {
   observationLayer: null,
 };
 
-// Probe runs at module load and may settle before or after main()
-// constructs the pools. attachInterpolators is idempotent; it's
-// called both from this .then and from the end of pool construction
-// in main() so whichever runs later does the wiring.
-let interpEnabled = false;
+// Three interpolation modes:
+//   - 'off'       : no warp layer; animation shows discrete frames only.
+//   - 'crossfade' : warp layer with zero-flow — smooth A→B fade.
+//   - 'flow'      : warp layer with LK-computed optical flow — motion-
+//                   compensated interpolation.
+// Resolved on boot from URL override (?interp=…) then localStorage,
+// defaulting to 'flow' when the device is capable.
+const VALID_INTERP_MODES = ['off', 'crossfade', 'flow'];
+const INTERP_MODE_KEY = 'interpMode';
+let interpMode = 'off';
+let interpCapable = false;
+
+function readInitialInterpMode() {
+  const urlMode = new URLSearchParams(window.location.search).get('interp');
+  if (VALID_INTERP_MODES.includes(urlMode)) return urlMode;
+  const stored = localStorage.getItem(INTERP_MODE_KEY);
+  if (VALID_INTERP_MODES.includes(stored)) return stored;
+  return 'flow';
+}
+
 canInterpolate().then((ok) => {
-  interpEnabled = ok;
+  interpCapable = ok;
+  interpMode = ok ? readInitialInterpMode() : 'off';
   // eslint-disable-next-line no-console
-  console.info(`[tutka] INTERP: ${interpEnabled ? 'enabled' : 'disabled'}`);
-  track(interpEnabled ? 'interp-available' : 'interp-unsupported');
+  console.info(`[tutka] INTERP: capable=${ok} mode=${interpMode}`);
+  track(ok ? 'interp-available' : 'interp-unsupported');
   attachInterpolators();
+  updateInterpChipsState();
 }).catch((err) => {
   // eslint-disable-next-line no-console
   console.warn('[tutka] INTERP probe failed:', err);
@@ -94,18 +111,66 @@ canInterpolate().then((ok) => {
 });
 
 function attachInterpolators() {
-  if (!interpEnabled) return;
+  if (interpMode === 'off') return;
   const playing = animationId !== null;
+  const useFlow = interpMode === 'flow';
   for (const name of ['radarLayer', 'satelliteLayer']) {
     const pool = framePools[name];
     if (pool && !pool.interpolator) {
-      pool.setInterpolator(new RadarInterpolator());
-      // If the user is already playing when the probe finishes
-      // resolving, catch up — otherwise interp stays off until the
-      // user pauses and plays again.
+      pool.setInterpolator(new RadarInterpolator({ useFlow }));
+      pool.refreshFlows();
       if (playing) pool.setInterpActive(true);
     }
   }
+}
+
+function detachInterpolators() {
+  for (const name of ['radarLayer', 'satelliteLayer']) {
+    const pool = framePools[name];
+    if (pool && pool.interpolator) {
+      pool.setInterpActive(false);
+      pool.setInterpolator(null);
+    }
+  }
+}
+
+function setInterpMode(mode) {
+  if (!VALID_INTERP_MODES.includes(mode)) return;
+  if (mode !== 'off' && !interpCapable) return;
+  if (interpMode === mode) return;
+  const prev = interpMode;
+  interpMode = mode;
+  localStorage.setItem(INTERP_MODE_KEY, mode);
+  if (mode === 'off') {
+    detachInterpolators();
+  } else if (prev === 'off') {
+    attachInterpolators();
+  } else {
+    // Swap between crossfade and flow on existing interpolators —
+    // cheaper than rebuilding the whole pipeline.
+    const useFlow = mode === 'flow';
+    for (const name of ['radarLayer', 'satelliteLayer']) {
+      const pool = framePools[name];
+      if (pool && pool.interpolator) {
+        pool.interpolator.setUseFlow(useFlow);
+        pool.refreshFlows();
+      }
+    }
+  }
+  updateInterpChipsState();
+  track('interp-mode', { mode });
+}
+
+function updateInterpChipsState() {
+  document.querySelectorAll('#overflowMenu .chip[data-interp]').forEach((chip) => {
+    const m = chip.getAttribute('data-interp');
+    chip.setAttribute('aria-checked', String(m === interpMode));
+    if (!interpCapable && m !== 'off') {
+      chip.setAttribute('aria-disabled', 'true');
+    } else {
+      chip.removeAttribute('aria-disabled');
+    }
+  });
 }
 const poolLoadStates = {
   satelliteLayer: new Array(13).fill(false),
@@ -1448,6 +1513,13 @@ window.addEventListener('touchend', closeOverflowIfOutside);
 document.querySelectorAll('#overflowMenu .chip[data-theme]').forEach((chip) => {
   chip.addEventListener('mouseup', () => {
     setUserTheme(chip.getAttribute('data-theme'));
+  });
+});
+
+document.querySelectorAll('#overflowMenu .chip[data-interp]').forEach((chip) => {
+  chip.addEventListener('mouseup', () => {
+    if (chip.getAttribute('aria-disabled') === 'true') return;
+    setInterpMode(chip.getAttribute('data-interp'));
   });
 });
 

--- a/src/radar.js
+++ b/src/radar.js
@@ -30,6 +30,7 @@ import Timeline from './timeline';
 import wmsServerConfiguration from './config';
 import createLongPressHandler from './longpress';
 import FramePool from './animation/framePool';
+import { canInterpolate } from './animation/interpolation';
 
 dayjs.locale('fi');
 dayjs.extend(utcPlugin);
@@ -60,7 +61,19 @@ let ownPosition = [];
 let ownPosition4326 = [];
 let geolocation;
 let startDate = new Date(Math.floor(Date.now() / 300000) * 300000 - 300000 * 12);
+// Handle of the currently-running playback loop (now a requestAnimationFrame
+// id — was a setInterval handle before the RAF refactor). Null when paused.
 let animationId = null;
+let lastAdvance = 0;
+// Resolved at module load; Phase 1 only logs the result. Pool construction
+// does not block on this. Phase 2 will read interpEnabled to gate
+// constructing a RadarInterpolator for the radar and satellite pools.
+let interpEnabled = false;
+canInterpolate().then((ok) => {
+  interpEnabled = ok;
+  debug(`INTERP: ${interpEnabled ? 'enabled' : 'disabled'}`);
+  track(interpEnabled ? 'interp-available' : 'interp-unsupported');
+});
 const layerInfo = {};
 let timeline;
 let mapTime = '';
@@ -666,17 +679,45 @@ function updateClock() {
 
 let isInteracting = false;
 
+// Playback loop. Split into two cadences so interpolation can layer on
+// top cleanly in later phases:
+//   - Advance (slow): bump the discrete timestep by a full frame when
+//     wall-clock elapsed exceeds stepDuration. This is today's setTime
+//     call. stepDuration is read from options.frameRate on every tick
+//     so the speed button takes effect without restart.
+//   - Render (fast): every RAF, ask each visible pool to render at the
+//     current fractional `t` between the last advance and the next.
+//     Phase 1's showInterpolated is a no-op, so playback is visually
+//     identical to the previous setInterval-based loop.
+//
+// isInteracting gates both cadences — OL won't redraw during pan/zoom
+// and advancing the clock while the image is frozen would desync the
+// timeline from what's on screen.
+const renderTick = function (now) {
+  animationId = window.requestAnimationFrame(renderTick);
+  if (isInteracting) return;
+
+  const stepDuration = 1000 / options.frameRate;
+  if (now - lastAdvance >= stepDuration) {
+    lastAdvance = now;
+    setTime();
+    return;
+  }
+
+  const t = (now - lastAdvance) / stepDuration;
+  for (const name of Object.keys(framePools)) {
+    if (!VISIBLE.has(name)) continue; // eslint-disable-line no-continue
+    const pool = framePools[name];
+    if (pool) pool.showInterpolated(t);
+  }
+};
+
 const play = function () {
   if (animationId === null) {
     debug('PLAY');
     IS_FOLLOWING = false;
-    // Skip auto-advance ticks while the user is dragging/zooming —
-    // OL refuses to redraw during interaction (INTERACTING hint), so
-    // letting the clock and timeline advance while the image is frozen
-    // would desync them.
-    animationId = window.setInterval(() => {
-      if (!isInteracting) setTime();
-    }, 1000 / options.frameRate);
+    lastAdvance = window.performance.now();
+    animationId = window.requestAnimationFrame(renderTick);
     document.getElementById('playstopButton').innerHTML = 'pause';
   }
 };
@@ -685,7 +726,7 @@ const stop = function () {
   if (animationId !== null) {
     debug('STOP');
     IS_FOLLOWING = false;
-    window.clearInterval(animationId);
+    window.cancelAnimationFrame(animationId);
     animationId = null;
     document.getElementById('playstopButton').innerHTML = 'play_arrow';
   }

--- a/src/radar.js
+++ b/src/radar.js
@@ -1847,6 +1847,14 @@ const main = () => {
   map.on('pointerdrag', () => { isInteracting = true; });
   map.on('moveend', () => {
     isInteracting = false;
+    // Defer the next playback advance by a full stepDuration after any
+    // view change. Without this, the advance cadence fires on the very
+    // next RAF tick after a pan (since lastAdvance accumulated while
+    // isInteracting was true), which races with the moveend-triggered
+    // prefetch in FramePool — second prefetch aborts the first, noisy
+    // "Image load error" shows up in the console for every aborted
+    // request.
+    lastAdvance = window.performance.now();
     const zoom = Math.min(map.getView().getZoom(), 16);
     localStorage.setItem('metZoom', zoom);
   });

--- a/src/radar.js
+++ b/src/radar.js
@@ -65,6 +65,7 @@ let startDate = new Date(Math.floor(Date.now() / 300000) * 300000 - 300000 * 12)
 // id — was a setInterval handle before the RAF refactor). Null when paused.
 let animationId = null;
 let lastAdvance = 0;
+let lastWarpTick = 0;
 const layerInfo = {};
 let timeline;
 let mapTime = '';
@@ -726,6 +727,13 @@ const renderTick = function (now) {
     setTime();
     return;
   }
+
+  // Throttle warp updates to ~30 Hz. Crossfade is visually smooth
+  // at 30 fps and halves the number of full OL renders we trigger
+  // (each showInterpolated call bumps the warp source's revision,
+  // which schedules an OL layer re-render).
+  if (now - lastWarpTick < 33) return;
+  lastWarpTick = now;
 
   const t = (now - lastAdvance) / stepDuration;
   for (const name of Object.keys(framePools)) {

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -35,6 +35,17 @@ class Timeline {
     if (!elem) return;
     elem.classList.toggle('timeline-loading', !loaded);
   }
+
+  // Flow-pending means the raw bitmap is loaded but the interpolator
+  // doesn't have a flow field yet for the pair starting at this
+  // index. Shown as a distinct color so the user can see which
+  // timesteps will "jump" during playback because the warp has no
+  // intermediate to render.
+  setFlowPending(index, pending) {
+    const elem = this.parent.children[index];
+    if (!elem) return;
+    elem.classList.toggle('timeline-flow-pending', pending);
+  }
 }
 
 export default Timeline;


### PR DESCRIPTION
## Summary
- Replaces `setInterval`-based playback with a two-cadence RAF loop (slow advance + fast render) so continuous interpolation between 5-minute radar frames is possible.
- Adds a WebGL2 interpolation pipeline (offscreen canvas per interpolating pool, warp fragment shader, single-level Lucas-Kanade flow solver).
- Exposes a three-mode selector in the overflow menu: **Pois** (off), **Häivytys** (crossfade / zero flow), **Virtaus** (motion-compensated). Default is `flow` when the device probes as capable, otherwise `off`. Overridable via `?interp=off|crossfade|flow` URL query string; persisted to `localStorage`.
- Also includes a few pre-existing-bug fixes surfaced while debugging — notably the playlist DOM rebuilding on every frame swap (slider + style chips + listeners) which was pulsing CPU 2×/sec regardless of interp mode.

## Plan document
Full design and phase plan in `docs/animation-interpolation-plan.md` (first commit). Amended in that commit after a hostile review pass — key corrections: iOS needs `EXT_color_buffer_half_float` not `EXT_color_buffer_float`; `ol-hashed` owns the URL hash so override uses `?query=` not `#hash=`; `ol/source/ImageCanvas` with per-RAF updates works OK (not a custom `Layer.render`); memory math redone with the real `imageRatio=1.5`.

## Phases delivered
- **Phase 1** — Skeleton + capability gating + RAF playback refactor.
- **Phase 2** — Warp shader with zero flow (crossfade path, proves full GL→OL integration).
- **Phase 3** — Real Lucas-Kanade flow computation (single level, 7×7 window).

## Phase 4 polish (not in this PR)
- Geographic nodata masking at radar range-circle edges.
- `webglcontextlost` / `visibilitychange` recovery for iOS.
- Memory cap / eviction per pool.
- Pyramidal LK for stepped palettes and large displacements.

## Test plan
- [ ] Open app on desktop Safari / Chrome. Check console for `[tutka] INTERP: capable=true mode=flow`.
- [ ] Play radar animation with each mode:
  - `Pois` — animation should behave exactly as before the PR (2 fps discrete frames).
  - `Häivytys` — smooth crossfade between frames, no motion tracking.
  - `Virtaus` — cells visibly slide along motion between frames.
- [ ] Toggle radar visibility via map layer button — warp follows.
- [ ] Adjust opacity slider in playlist during playback — changes reflect on warp; opens playlist again, slider still shows user value (not zero).
- [ ] Pan map (small and large distances) during playback — flow keeps working on small pans within the 1.5× buffer; large pans briefly show primary's stale-while-loading before new frames load and flow resumes.
- [ ] Zoom in/out — flow suppressed during view animation, resumes once new frames land.
- [ ] Press stop + step through frames with j/l/space — discrete stepping works; no stale interpolated content stuck on top.
- [ ] Switch radar style (FMI / Bookbinder / etc.) — flow cache invalidates on LAYERS/URL change; continues working on STYLES change.
- [ ] Mobile iPhone / Android — verify interp enables (check console), animation smooth, GPU process doesn't stay high CPU when paused.
- [ ] Layer z-order during playback: POIs (radar sites, airfields, own position), range rings, observations, lightning should all render above radar/satellite warp.

## Known issues / tradeoffs
- FMI's stepped classical palette has flat luminance inside each band; LK's 2×2 normal equations go singular there and flow falls back to zero → the visual degrades to crossfade. Bookbinder and other continuous palettes track motion properly. Fix is pyramidal LK (Phase 4).
- Slight brightness pumping at cell leading/trailing edges where motion isn't fully captured by single-level LK. Pyramid or iterative refinement will reduce this.
- Loop end still has a 500 ms static at the last frame (discrete advance semantics). No longer has a brightness pop because the frame is rendered through warp at t=1 rather than falling through to primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)