### PR TITLE
Add Mittaa tool: two-point distance + velocity (Phase 2)

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -1375,3 +1375,259 @@ html, body {
   color: var(--dark-medium-emphasis-text-color);
   margin-top: 1px;
 }
+
+/* ========================================================================
+   Työkalut menu row (in overflow menu)
+   ======================================================================== */
+
+#overflowMenu .menu-row.menu-tool {
+  all: unset;
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 16px;
+  gap: 14px;
+  cursor: pointer;
+  color: var(--dark-high-emphasis-text-color);
+  transition: background-color 120ms ease;
+  font-family: inherit;
+  font-size: 14px;
+  box-sizing: border-box;
+  width: 100%;
+}
+#overflowMenu .menu-row.menu-tool:hover { background-color: rgba(18, 188, 250, 0.08); }
+#overflowMenu .menu-row.menu-tool:focus-visible { background-color: rgba(18, 188, 250, 0.12); }
+#overflowMenu .menu-row.menu-tool .material-icons {
+  font-size: 20px;
+  color: var(--dark-primary-color);
+  flex-shrink: 0;
+}
+#overflowMenu .menu-row.menu-tool .menu-label {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 500;
+}
+#overflowMenu .menu-row.menu-tool .menu-sub {
+  font-size: 12px;
+  color: var(--dark-medium-emphasis-text-color);
+}
+
+/* ========================================================================
+   Primary toolbar menu button — cyan glow when a tool is armed.
+   ======================================================================== */
+
+#menuButton.tool-armed {
+  color: var(--dark-primary-color);
+  box-shadow:
+    0 4px 20px rgba(0, 0, 0, 0.35),
+    inset 0 0 0 1.5px rgba(18, 188, 250, 0.55);
+}
+
+/* ========================================================================
+   Tool chip — appears below the primary toolbar while a modal tool is
+   armed (currently: Mittaa). Glass pill, dismissible.
+   ======================================================================== */
+
+.tool-chip {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 70px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 95;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 6px 0 12px;
+  background-color: rgba(0, 0, 0, 0.60);
+  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  backdrop-filter: blur(24px) saturate(140%);
+  border: 1px solid rgba(18, 188, 250, 0.45);
+  border-radius: 18px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35),
+              inset 0 0 0 1px rgba(18, 188, 250, 0.15);
+  color: var(--dark-high-emphasis-text-color);
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  user-select: none;
+  max-width: calc(100vw - 32px);
+}
+.tool-chip[hidden] { display: none; }
+
+.tool-chip .chip-icon {
+  font-size: 18px;
+  color: var(--dark-primary-color);
+  flex-shrink: 0;
+}
+.tool-chip .chip-label { letter-spacing: 0.06em; }
+.tool-chip .chip-hint {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--dark-medium-emphasis-text-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+.tool-chip .chip-close {
+  all: unset;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
+.tool-chip .chip-close:hover { background: rgba(255, 255, 255, 0.15); }
+.tool-chip .chip-close .material-icons {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ========================================================================
+   Measure card — docked readout for the Mittaa tool.
+   Desktop: top-right, 280px.
+   Mobile: below the tool chip, full width (minus safe-area).
+   ======================================================================== */
+
+.measure-card {
+  position: fixed;
+  z-index: 90;
+  padding: 10px 12px 12px;
+  background-color: rgba(22, 22, 24, 0.82);
+  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  backdrop-filter: blur(24px) saturate(140%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  color: var(--dark-high-emphasis-text-color);
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  line-height: 1.3;
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+}
+.measure-card[hidden] { display: none; }
+
+@media (min-width: 769px) {
+  .measure-card {
+    top: calc(env(safe-area-inset-top, 0px) + 116px);
+    right: 16px;
+    width: 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .measure-card {
+    top: calc(env(safe-area-inset-top, 0px) + 118px);
+    left: max(8px, env(safe-area-inset-left, 0px));
+    right: max(8px, env(safe-area-inset-right, 0px));
+  }
+}
+
+.measure-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.measure-card-icon {
+  font-size: 18px;
+  color: var(--dark-primary-color);
+}
+.measure-card-title {
+  flex: 1;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dark-medium-emphasis-text-color);
+}
+.measure-card-close {
+  all: unset;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  box-sizing: border-box;
+}
+.measure-card-close:hover { background: rgba(255, 255, 255, 0.12); }
+.measure-card-close .material-icons {
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.measure-card-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 14px;
+}
+
+.measure-item { min-width: 0; }
+.measure-item[hidden] { display: none; }
+
+.measure-label {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dark-medium-emphasis-text-color);
+  margin-bottom: 2px;
+}
+.measure-value {
+  display: block;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--dark-primary-color);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.measure-sub {
+  display: block;
+  font-size: 11px;
+  color: var(--dark-medium-emphasis-text-color);
+  margin-top: 1px;
+  font-variant-numeric: tabular-nums;
+}
+
+.measure-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.measure-btn {
+  all: unset;
+  flex: 1;
+  text-align: center;
+  padding: 7px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--dark-high-emphasis-text-color);
+  cursor: pointer;
+  box-sizing: border-box;
+  transition: background-color 120ms ease;
+}
+.measure-btn:hover { background: rgba(255, 255, 255, 0.12); }
+.measure-btn.measure-btn-primary {
+  background: var(--dark-primary-color-bg);
+  color: var(--dark-primary-color);
+  box-shadow: inset 0 0 0 1px rgba(18, 188, 250, 0.45);
+}
+.measure-btn.measure-btn-primary:hover { background: rgba(18, 188, 250, 0.22); }
+.measure-btn.measure-btn-copied { background: rgba(18, 188, 250, 0.28); }

--- a/src/index.html
+++ b/src/index.html
@@ -89,6 +89,13 @@
 
   <div id="overflowMenuBackdrop"></div>
   <div id="overflowMenu" role="menu" hidden>
+    <div class="menu-header">Työkalut</div>
+    <button id="measureTool" class="menu-row menu-tool" type="button" role="menuitem">
+      <i class="material-icons" aria-hidden="true">straighten</i>
+      <span class="menu-label">Mittaa</span>
+      <span class="menu-sub">etäisyys · nopeus</span>
+    </button>
+    <div class="menu-divider"></div>
     <div class="menu-header">Karttakohteet</div>
     <div id="poiList"></div>
     <div class="menu-divider"></div>
@@ -112,6 +119,52 @@
   </button>
 
   <div id="coachmark" aria-live="polite" hidden></div>
+
+  <div id="toolChip" class="tool-chip" role="status" hidden>
+    <i class="material-icons chip-icon" aria-hidden="true">straighten</i>
+    <span class="chip-label">MITTAA</span>
+    <span class="chip-hint"></span>
+    <button type="button" class="chip-close" aria-label="Sulje työkalu">
+      <i class="material-icons" aria-hidden="true">close</i>
+    </button>
+  </div>
+
+  <div id="measureCard" class="measure-card" role="region" aria-label="Mittaus" hidden>
+    <div class="measure-card-head">
+      <i class="material-icons measure-card-icon" aria-hidden="true">straighten</i>
+      <span class="measure-card-title">Mittaus</span>
+      <button type="button" class="measure-card-close measure-action-done" aria-label="Sulje mittaus">
+        <i class="material-icons" aria-hidden="true">close</i>
+      </button>
+    </div>
+    <div class="measure-card-grid">
+      <div class="measure-item measure-distance">
+        <span class="measure-label">Etäisyys</span>
+        <span class="measure-value"></span>
+        <span class="measure-sub">T1 → T2</span>
+      </div>
+      <div class="measure-item measure-bearing">
+        <span class="measure-label">Suunta</span>
+        <span class="measure-value"></span>
+        <span class="measure-sub"></span>
+      </div>
+      <div class="measure-item measure-time">
+        <span class="measure-label">Aika</span>
+        <span class="measure-value"></span>
+        <span class="measure-sub"></span>
+      </div>
+      <div class="measure-item measure-velocity">
+        <span class="measure-label">Nopeus</span>
+        <span class="measure-value"></span>
+        <span class="measure-sub"></span>
+      </div>
+    </div>
+    <div class="measure-actions">
+      <button type="button" class="measure-btn measure-action-reset">Nollaa</button>
+      <button type="button" class="measure-btn measure-action-copy">Kopioi</button>
+      <button type="button" class="measure-btn measure-btn-primary measure-action-done">Valmis</button>
+    </div>
+  </div>
 
   <div id="map"></div>
  

--- a/src/radar.js
+++ b/src/radar.js
@@ -2007,7 +2007,16 @@ const main = () => {
   tools = initTools({
     map,
     getOwnPosition: () => ownPosition4326,
+    getFrameTimestamp: () => (startDate ? startDate.getTime() : Date.now()),
   });
+
+  const measureToolBtn = document.getElementById('measureTool');
+  if (measureToolBtn) {
+    measureToolBtn.addEventListener('click', () => {
+      closeOverflowMenu();
+      tools.arm();
+    });
+  }
 
   window.__tutka = { map, framePools, tools };
 
@@ -2042,6 +2051,18 @@ const main = () => {
   map.on('click', (evt) => {
     const hit = map.forEachFeatureAtPixel(evt.pixel, (f) => f);
     const pin = tools && tools.getPinFeature();
+
+    // Measurement mode: route taps to the measure tool. Snap to the
+    // feature's own coordinate when the tap hits a Point feature so
+    // users can measure from a radar site or airfield exactly.
+    if (tools && tools.isArmed()) {
+      let coord = evt.coordinate;
+      if (hit && hit.getGeometry && hit.getGeometry().getType() === 'Point') {
+        coord = hit.getGeometry().getCoordinates();
+      }
+      tools.handleMeasureTap(coord);
+      return;
+    }
 
     if (pin && hit === pin) {
       // Tap on our own marker pin — toggle its readout card.

--- a/src/tools.js
+++ b/src/tools.js
@@ -3,8 +3,9 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
+import LineString from 'ol/geom/LineString';
 import {
-  Circle as CircleStyle, Fill, Stroke, Style,
+  Circle as CircleStyle, Fill, Stroke, Style, Text,
 } from 'ol/style';
 import { fromLonLat, transform } from 'ol/proj';
 import { getDistance } from 'ol/sphere';
@@ -19,6 +20,60 @@ const PIN_STYLE = new Style({
   }),
 });
 
+const T1_CIRCLE = new CircleStyle({
+  radius: 9,
+  fill: new Fill({ color: '#12BCFA' }),
+  stroke: new Stroke({ color: '#ffffff', width: 2 }),
+});
+
+const T2_CIRCLE = new CircleStyle({
+  radius: 9,
+  fill: new Fill({ color: '#E255C7' }),
+  stroke: new Stroke({ color: '#ffffff', width: 2 }),
+});
+
+const LINE_STYLE = new Style({
+  stroke: new Stroke({
+    color: 'rgba(18, 188, 250, 0.85)',
+    width: 2,
+    lineDash: [6, 4],
+  }),
+});
+
+function pinLabelStyle(circle, bg, fg, text) {
+  return new Style({
+    image: circle,
+    text: new Text({
+      text,
+      font: 'bold 11px Roboto, sans-serif',
+      offsetY: -22,
+      textAlign: 'center',
+      fill: new Fill({ color: fg }),
+      backgroundFill: new Fill({ color: bg }),
+      padding: [2, 6, 2, 6],
+    }),
+  });
+}
+
+function lineLabelStyle(text) {
+  return new Style({
+    stroke: new Stroke({
+      color: 'rgba(18, 188, 250, 0.85)',
+      width: 2,
+      lineDash: [6, 4],
+    }),
+    text: new Text({
+      text,
+      placement: 'line',
+      font: 'bold 12px Roboto, sans-serif',
+      fill: new Fill({ color: '#ffffff' }),
+      // Outline so the label stays legible over any radar/map colour
+      stroke: new Stroke({ color: 'rgba(0, 0, 0, 0.85)', width: 3 }),
+      overflow: true,
+    }),
+  });
+}
+
 const COMPASS_16_EN = [
   'N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE',
   'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW',
@@ -30,11 +85,15 @@ function compassIndex(deg) {
 
 function formatDistance(meters) {
   if (meters < 1000) return `${Math.round(meters)} m`;
-  if (meters < 10000) return `${(meters / 1000).toFixed(2)} km`;
-  return `${(meters / 1000).toFixed(1)} km`;
+  if (meters < 10000) return `${(meters / 1000).toFixed(1)} km`;
+  return `${Math.round(meters / 1000)} km`;
 }
 
-function buildCard() {
+function formatHHMM(ms) {
+  return new Date(ms).toLocaleTimeString('fi', { hour: '2-digit', minute: '2-digit' });
+}
+
+function buildMarkerCard() {
   const card = document.createElement('div');
   card.id = 'markerCard';
   card.className = 'marker-card';
@@ -71,18 +130,21 @@ function buildCard() {
   return card;
 }
 
-export default function initTools({ map, getOwnPosition }) {
-  const toolsLayer = new VectorLayer({
+export default function initTools({ map, getOwnPosition, getFrameTimestamp }) {
+  // ---------------------------------------------------------------
+  // Location marker (ambient, non-modal)
+  // ---------------------------------------------------------------
+  const markerLayer = new VectorLayer({
     source: new VectorSource(),
     style: PIN_STYLE,
   });
-  map.addLayer(toolsLayer);
+  map.addLayer(markerLayer);
 
-  const card = buildCard();
-  document.body.appendChild(card);
+  const markerCard = buildMarkerCard();
+  document.body.appendChild(markerCard);
 
-  const overlay = new Overlay({
-    element: card,
+  const markerOverlay = new Overlay({
+    element: markerCard,
     positioning: 'bottom-center',
     offset: [0, -22],
     stopEvent: true,
@@ -91,41 +153,40 @@ export default function initTools({ map, getOwnPosition }) {
       margin: 20,
     },
   });
-  map.addOverlay(overlay);
+  map.addOverlay(markerOverlay);
 
-  const dmEl = card.querySelector('.marker-coord-dm');
-  const ddEl = card.querySelector('.marker-coord-sub');
-  const copyBtn = card.querySelector('.marker-coord');
-  const distRow = card.querySelector('.marker-item-distance');
-  const bearRow = card.querySelector('.marker-item-bearing');
+  const dmEl = markerCard.querySelector('.marker-coord-dm');
+  const ddEl = markerCard.querySelector('.marker-coord-sub');
+  const copyBtn = markerCard.querySelector('.marker-coord');
+  const distRow = markerCard.querySelector('.marker-item-distance');
+  const bearRow = markerCard.querySelector('.marker-item-bearing');
   const distValue = distRow.querySelector('.marker-value');
   const bearValue = bearRow.querySelector('.marker-value');
   const bearSub = bearRow.querySelector('.marker-sub');
-  const closeBtn = card.querySelector('.marker-card-close');
+  const markerCloseBtn = markerCard.querySelector('.marker-card-close');
 
-  let coord4326 = null;
-  let pinFeature = null;
-  let cardVisible = false;
+  let markerCoord4326 = null;
+  let markerFeature = null;
+  let markerCardVisible = false;
 
-  function updateCardVisibility() {
-    if (pinFeature && coord4326 && cardVisible) {
-      overlay.setPosition(fromLonLat(coord4326));
+  function updateMarkerCardVisibility() {
+    if (markerFeature && markerCoord4326 && markerCardVisible) {
+      markerOverlay.setPosition(fromLonLat(markerCoord4326));
     } else {
-      overlay.setPosition(undefined);
+      markerOverlay.setPosition(undefined);
     }
   }
 
-  function render() {
-    if (!coord4326) return;
-
-    dmEl.textContent = `${Dms.toLat(coord4326[1], 'dm', 2)}  ${Dms.toLon(coord4326[0], 'dm', 2)}`;
-    ddEl.textContent = `${coord4326[1].toFixed(5)}° · ${coord4326[0].toFixed(5)}°`;
+  function renderMarker() {
+    if (!markerCoord4326) return;
+    dmEl.textContent = `${Dms.toLat(markerCoord4326[1], 'dm', 2)}  ${Dms.toLon(markerCoord4326[0], 'dm', 2)}`;
+    ddEl.textContent = `${markerCoord4326[1].toFixed(5)}° · ${markerCoord4326[0].toFixed(5)}°`;
 
     const own = getOwnPosition();
     if (own && own.length === 2) {
-      const meters = getDistance(coord4326, own);
+      const meters = getDistance(markerCoord4326, own);
       const p1 = new LatLon(own[1], own[0]);
-      const p2 = new LatLon(coord4326[1], coord4326[0]);
+      const p2 = new LatLon(markerCoord4326[1], markerCoord4326[0]);
       const brg = p1.initialBearingTo(p2);
       distValue.textContent = formatDistance(meters);
       bearValue.textContent = `${brg.toFixed(0)}°`;
@@ -136,46 +197,45 @@ export default function initTools({ map, getOwnPosition }) {
       distRow.hidden = true;
       bearRow.hidden = true;
     }
-
-    if (cardVisible) overlay.setPosition(fromLonLat(coord4326));
+    if (markerCardVisible) markerOverlay.setPosition(fromLonLat(markerCoord4326));
   }
 
-  function dropOrMove(mapCoord) {
-    coord4326 = transform(mapCoord, map.getView().getProjection(), 'EPSG:4326');
-    if (pinFeature) {
-      pinFeature.getGeometry().setCoordinates(mapCoord);
+  function dropOrMoveMarker(mapCoord) {
+    markerCoord4326 = transform(mapCoord, map.getView().getProjection(), 'EPSG:4326');
+    if (markerFeature) {
+      markerFeature.getGeometry().setCoordinates(mapCoord);
     } else {
-      pinFeature = new Feature({ geometry: new Point(mapCoord) });
-      toolsLayer.getSource().addFeature(pinFeature);
+      markerFeature = new Feature({ geometry: new Point(mapCoord) });
+      markerLayer.getSource().addFeature(markerFeature);
     }
-    cardVisible = true;
-    updateCardVisibility();
-    render();
+    markerCardVisible = true;
+    updateMarkerCardVisibility();
+    renderMarker();
   }
 
-  function remove() {
-    if (pinFeature) toolsLayer.getSource().removeFeature(pinFeature);
-    pinFeature = null;
-    coord4326 = null;
-    cardVisible = false;
-    updateCardVisibility();
+  function removeMarker() {
+    if (markerFeature) markerLayer.getSource().removeFeature(markerFeature);
+    markerFeature = null;
+    markerCoord4326 = null;
+    markerCardVisible = false;
+    updateMarkerCardVisibility();
   }
 
-  function toggleCard() {
-    if (!pinFeature) return;
-    cardVisible = !cardVisible;
-    updateCardVisibility();
+  function toggleMarkerCard() {
+    if (!markerFeature) return;
+    markerCardVisible = !markerCardVisible;
+    updateMarkerCardVisibility();
   }
 
-  closeBtn.addEventListener('click', (e) => {
+  markerCloseBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    remove();
+    removeMarker();
   });
 
   copyBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    if (!coord4326) return;
-    const text = `${coord4326[1].toFixed(5)}, ${coord4326[0].toFixed(5)}`;
+    if (!markerCoord4326) return;
+    const text = `${markerCoord4326[1].toFixed(5)}, ${markerCoord4326[0].toFixed(5)}`;
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(text).catch(() => {});
     }
@@ -183,13 +243,245 @@ export default function initTools({ map, getOwnPosition }) {
     setTimeout(() => copyBtn.classList.remove('marker-copied'), 800);
   });
 
-  updateCardVisibility();
+  updateMarkerCardVisibility();
+
+  // ---------------------------------------------------------------
+  // Measurement tool (modal: Mittaa)
+  // ---------------------------------------------------------------
+  const measureLayer = new VectorLayer({
+    source: new VectorSource(),
+    // Per-feature styles are set via setStyle() in handleMeasureTap so the
+    // pin labels can carry their captured timestamp. The line feature has no
+    // own style and falls back to this layer default.
+    style: (feat) => (feat.get('kind') === 'line' ? LINE_STYLE : undefined),
+  });
+  map.addLayer(measureLayer);
+
+  const measureCard = document.getElementById('measureCard');
+  const toolChip = document.getElementById('toolChip');
+  const toolChipHint = toolChip ? toolChip.querySelector('.chip-hint') : null;
+  const toolChipClose = toolChip ? toolChip.querySelector('.chip-close') : null;
+  const menuButtonEl = document.getElementById('menuButton');
+
+  let measureArmed = false;
+  let measureState = 'idle'; // 'idle' | 'awaiting-t1' | 'awaiting-t2' | 'showing-result'
+  let t1Feature = null;
+  let t2Feature = null;
+  let lineFeature = null;
+  let t1Coord4326 = null;
+  let t2Coord4326 = null;
+  let t1Ts = null;
+  let t2Ts = null;
+
+  const mv = measureCard ? {
+    distance: measureCard.querySelector('.measure-distance .measure-value'),
+    distanceSub: measureCard.querySelector('.measure-distance .measure-sub'),
+    bearing: measureCard.querySelector('.measure-bearing .measure-value'),
+    bearingSub: measureCard.querySelector('.measure-bearing .measure-sub'),
+    time: measureCard.querySelector('.measure-time .measure-value'),
+    timeSub: measureCard.querySelector('.measure-time .measure-sub'),
+    velocity: measureCard.querySelector('.measure-velocity .measure-value'),
+    velocitySub: measureCard.querySelector('.measure-velocity .measure-sub'),
+    timeRow: measureCard.querySelector('.measure-time'),
+    velocityRow: measureCard.querySelector('.measure-velocity'),
+  } : null;
+
+  function setChipHint(txt) {
+    if (toolChipHint) toolChipHint.textContent = txt ? `· ${txt}` : '';
+  }
+
+  function clearMeasureFeatures() {
+    const src = measureLayer.getSource();
+    if (t1Feature) { src.removeFeature(t1Feature); t1Feature = null; }
+    if (t2Feature) { src.removeFeature(t2Feature); t2Feature = null; }
+    if (lineFeature) { src.removeFeature(lineFeature); lineFeature = null; }
+    t1Coord4326 = null;
+    t2Coord4326 = null;
+    t1Ts = null;
+    t2Ts = null;
+    if (measureCard) measureCard.hidden = true;
+  }
+
+  function drawMeasureLine() {
+    if (!t1Feature || !t2Feature) return;
+    const src = measureLayer.getSource();
+    if (lineFeature) src.removeFeature(lineFeature);
+    lineFeature = new Feature({
+      kind: 'line',
+      geometry: new LineString([
+        t1Feature.getGeometry().getCoordinates(),
+        t2Feature.getGeometry().getCoordinates(),
+      ]),
+    });
+    src.addFeature(lineFeature);
+  }
+
+  function renderMeasurement() {
+    if (!mv || !t1Coord4326 || !t2Coord4326) return;
+    const meters = getDistance(t1Coord4326, t2Coord4326);
+    const p1 = new LatLon(t1Coord4326[1], t1Coord4326[0]);
+    const p2 = new LatLon(t2Coord4326[1], t2Coord4326[0]);
+    const brg = p1.initialBearingTo(p2);
+
+    mv.distance.textContent = formatDistance(meters);
+    mv.bearing.textContent = `${brg.toFixed(0)}°`;
+    mv.bearingSub.textContent = COMPASS_16_EN[compassIndex(brg)];
+
+    const dtMs = (t1Ts != null && t2Ts != null) ? t2Ts - t1Ts : 0;
+    const absDt = Math.abs(dtMs);
+    const hasTime = absDt >= 60000; // at least 1 minute to be meaningful
+
+    if (hasTime) {
+      const mins = Math.round(absDt / 60000);
+      mv.time.textContent = `${mins} min`;
+      mv.timeSub.textContent = `${formatHHMM(t1Ts)} → ${formatHHMM(t2Ts)}`;
+      const ms = meters / (absDt / 1000);
+      mv.velocity.textContent = `${ms.toFixed(1)} m/s`;
+      mv.velocitySub.textContent = `${(ms * 3.6).toFixed(1)} km/h`;
+    }
+    mv.timeRow.hidden = !hasTime;
+    mv.velocityRow.hidden = !hasTime;
+    if (lineFeature) lineFeature.setStyle(lineLabelStyle(formatDistance(meters)));
+  }
+
+  function armMeasure() {
+    if (measureArmed) return;
+    measureArmed = true;
+    measureState = 'awaiting-t1';
+    clearMeasureFeatures();
+    // Hide marker card while measuring (keep the pin; restore card on disarm)
+    if (markerCardVisible) markerOverlay.setPosition(undefined);
+    if (toolChip) toolChip.hidden = false;
+    setChipHint('napauta karttaa');
+    if (menuButtonEl) menuButtonEl.classList.add('tool-armed');
+  }
+
+  function disarmMeasure() {
+    if (!measureArmed) return;
+    measureArmed = false;
+    measureState = 'idle';
+    clearMeasureFeatures();
+    if (toolChip) toolChip.hidden = true;
+    if (menuButtonEl) menuButtonEl.classList.remove('tool-armed');
+    // Restore marker card if the pin is still there and it was visible before
+    if (markerFeature && markerCoord4326 && markerCardVisible) {
+      markerOverlay.setPosition(fromLonLat(markerCoord4326));
+    }
+  }
+
+  function handleMeasureTap(mapCoord) {
+    const src = measureLayer.getSource();
+    const coord4326 = transform(mapCoord, map.getView().getProjection(), 'EPSG:4326');
+    const ts = typeof getFrameTimestamp === 'function' ? getFrameTimestamp() : Date.now();
+
+    if (measureState === 'awaiting-t1' || measureState === 'showing-result') {
+      // First placement, or tap 3 → start new pair
+      if (t1Feature) src.removeFeature(t1Feature);
+      if (t2Feature) src.removeFeature(t2Feature);
+      if (lineFeature) src.removeFeature(lineFeature);
+      t1Feature = new Feature({ kind: 't1', geometry: new Point(mapCoord) });
+      t1Feature.setStyle(pinLabelStyle(T1_CIRCLE, '#12BCFA', '#06202a', `T1 · ${formatHHMM(ts)}`));
+      t2Feature = null;
+      lineFeature = null;
+      src.addFeature(t1Feature);
+      t1Coord4326 = coord4326;
+      t1Ts = ts;
+      t2Coord4326 = null;
+      t2Ts = null;
+      if (measureCard) measureCard.hidden = true;
+      measureState = 'awaiting-t2';
+      setChipHint('napauta toista pistettä');
+    } else if (measureState === 'awaiting-t2') {
+      t2Feature = new Feature({ kind: 't2', geometry: new Point(mapCoord) });
+      t2Feature.setStyle(pinLabelStyle(T2_CIRCLE, '#E255C7', '#2a001f', `T2 · ${formatHHMM(ts)}`));
+      src.addFeature(t2Feature);
+      t2Coord4326 = coord4326;
+      t2Ts = ts;
+      drawMeasureLine();
+      renderMeasurement();
+      if (measureCard) measureCard.hidden = false;
+      measureState = 'showing-result';
+      setChipHint('napauta uuteen aloittaaksesi alusta');
+    }
+  }
+
+  // Measurement action wires
+  if (toolChipClose) {
+    toolChipClose.addEventListener('click', (e) => {
+      e.stopPropagation();
+      disarmMeasure();
+    });
+  }
+
+  if (measureCard) {
+    const resetBtn = measureCard.querySelector('.measure-action-reset');
+    const copyMeasureBtn = measureCard.querySelector('.measure-action-copy');
+    const doneBtns = measureCard.querySelectorAll('.measure-action-done');
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        clearMeasureFeatures();
+        measureState = 'awaiting-t1';
+        setChipHint('napauta karttaa');
+      });
+    }
+    if (copyMeasureBtn) {
+      copyMeasureBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (!t1Coord4326 || !t2Coord4326) return;
+        const meters = getDistance(t1Coord4326, t2Coord4326);
+        const p1 = new LatLon(t1Coord4326[1], t1Coord4326[0]);
+        const p2 = new LatLon(t2Coord4326[1], t2Coord4326[0]);
+        const brg = p1.initialBearingTo(p2);
+        const dtMs = (t1Ts != null && t2Ts != null) ? t2Ts - t1Ts : 0;
+        const absDt = Math.abs(dtMs);
+        const lines = [
+          'Mittaus',
+          `T1: ${t1Coord4326[1].toFixed(5)}, ${t1Coord4326[0].toFixed(5)}`,
+          `T2: ${t2Coord4326[1].toFixed(5)}, ${t2Coord4326[0].toFixed(5)}`,
+          `Etäisyys: ${formatDistance(meters)}`,
+          `Suunta: ${brg.toFixed(0)}° ${COMPASS_16_EN[compassIndex(brg)]}`,
+        ];
+        if (absDt >= 60000) {
+          const mins = Math.round(absDt / 60000);
+          const ms = meters / (absDt / 1000);
+          lines.push(`Aika: ${mins} min (${formatHHMM(t1Ts)} → ${formatHHMM(t2Ts)})`);
+          lines.push(`Nopeus: ${ms.toFixed(1)} m/s (${(ms * 3.6).toFixed(1)} km/h)`);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(lines.join('\n')).catch(() => {});
+        }
+        copyMeasureBtn.classList.add('measure-btn-copied');
+        setTimeout(() => copyMeasureBtn.classList.remove('measure-btn-copied'), 800);
+      });
+    }
+    doneBtns.forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        disarmMeasure();
+      });
+    });
+  }
+
+  // Esc disarms measurement
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && measureArmed) {
+      disarmMeasure();
+    }
+  });
 
   return {
-    dropOrMove,
-    remove,
-    toggleCard,
-    refresh: render,
-    getPinFeature: () => pinFeature,
+    // marker
+    dropOrMove: dropOrMoveMarker,
+    remove: removeMarker,
+    toggleCard: toggleMarkerCard,
+    refresh: renderMarker,
+    getPinFeature: () => markerFeature,
+    // measurement
+    arm: armMeasure,
+    disarm: disarmMeasure,
+    isArmed: () => measureArmed,
+    handleMeasureTap,
   };
 }


### PR DESCRIPTION
## Summary
- Modal measurement tool opened from a new **Työkalut** section at the top of the overflow menu. One entry for now: **Mittaa** (etäisyys · nopeus).
- First tap places **T1** (cyan pin, `T1 · HH:MM` label), second tap places **T2** (magenta pin), dashed line between them carries an along-line distance label. A third tap starts a new pair.
- Each tap captures the current animation frame timestamp (`startDate`). When T1 and T2 are on different frames, the docked readout shows `Etäisyys`, `Suunta`, `Aika`, `Nopeus`; same-frame taps hide the time/velocity rows and show only distance + bearing.

## Decisions made
- **Feature tap while armed** → snaps the measurement point to the feature's coordinate (radar site / airfield). Lets users measure storm-cell distance from a known station exactly.
- **Location marker coexistence** → ambient marker from Phase 1 is hidden while Mittaa is armed and restored on disarm. The pin stays put, only the card is hidden.
- **Layer split** → separate `measureLayer`, independent of the Phase 1 marker layer, so clear-on-exit is clean.

## Implementation notes
- `src/tools.js` grew to host both subsystems. Shared helpers (`formatDistance`, `compassIndex`, `COMPASS_16_EN`) live at module scope; the two tools have independent state inside `initTools`.
- `formatDistance` now rounds integers ≥ 10 km and keeps 1 decimal for 1–10 km, matching requested line-label density.
- Line label uses OL's `Text` style with `placement: 'line'` — text follows the line angle, black outline for legibility over any map colour. Label shows distance only (`"27 km"` / `"7.3 km"` / `"876 m"`).
- Pin labels are OL `Text` with `backgroundFill` + `padding`, per-feature `setStyle()` so the captured timestamp can be baked in at placement time.
- `more_horiz` FAB gets a `tool-armed` cyan glow class while any modal tool is active — will extend cleanly if future tools are added.

## Disarming
- Chip close, **Valmis** on the readout, or **Esc**.

## Test plan
- [ ] `more_horiz → Mittaa` arms the tool (chip appears, menu button glows cyan)
- [ ] Tap empty → T1 cyan pin with `T1 · HH:MM` label; chip hint updates
- [ ] Tap again (different frame) → T2 magenta pin + dashed line + docked readout (4 values)
- [ ] Tap again → replaces with a new T1
- [ ] Same-frame tap pair → card hides `Aika` + `Nopeus` rows; line label still shows distance
- [ ] Tap airfield while armed → point snaps to the airfield coordinate, not the tap pixel
- [ ] Place ambient marker first, then arm Mittaa → marker card hides, pin stays; disarm → card returns
- [ ] Chip close, Valmis, Esc all disarm cleanly
- [ ] Nollaa clears T1/T2 but keeps tool armed; Kopioi writes a text summary to clipboard
- [ ] Existing radar playback / layer switching unaffected
- [ ] iOS Safari smoke test

## Follow-ups (not this PR)
- Sidebar removal still blocked on relocating the AIKA real-clock display (tracked separately).
- Could add a frame-snap indicator on the timeline for T1 / T2 (originally in the mockup as tl-marker flags); deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)