### PR TITLE
Probe: surface current reflectivity value in chart + marker card

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -639,6 +639,12 @@ html, body {
     pointer-events: none;
   }
   .probe-message[hidden] { display: none; }
+  .probe-readout {
+    font-size: 11px;
+    fill: var(--dark-primary-color);
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+  }
 
 .noselect {
     -webkit-touch-callout: none; /* iOS Safari */
@@ -1395,6 +1401,7 @@ html, body {
 
 .marker-item { min-width: 0; }
 .marker-item[hidden] { display: none; }
+.marker-item-probe { grid-column: 1 / -1; }
 
 .marker-label {
   display: block;

--- a/src/probe.js
+++ b/src/probe.js
@@ -93,12 +93,16 @@ function normalizeDbz(v) {
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
-export default function initProbe({ container }) {
+export default function initProbe({ container, onValueChange }) {
   if (!container) {
     return {
       setPin() {}, setActiveLayer() {}, setCursor() {},
     };
   }
+
+  const emitValue = typeof onValueChange === 'function'
+    ? (v) => { try { onValueChange(v); } catch (_) { /* ignore */ } }
+    : () => {};
 
   // Remove the initial `hidden` attribute so the element is always in the
   // layout — the height: 0 / .open transition handles the show/hide.
@@ -109,6 +113,11 @@ export default function initProbe({ container }) {
   svg.setAttribute('preserveAspectRatio', 'none');
   svg.setAttribute('class', 'probe-svg');
   container.appendChild(svg);
+
+  const readout = document.createElementNS(SVG_NS, 'text');
+  readout.setAttribute('class', 'probe-readout');
+  readout.setAttribute('text-anchor', 'end');
+  readout.setAttribute('y', '14');
 
   const message = document.createElement('div');
   message.className = 'probe-message';
@@ -122,6 +131,15 @@ export default function initProbe({ container }) {
   let cursorMs = null; // current animation frame ms
   let inFlight = null; // AbortController for active fetch
   let state = 'idle'; // 'idle' | 'loading' | 'ready' | 'empty' | 'error'
+
+  // Per-cell peak value, set in render(). Each slot is { dbz, norm } where
+  // dbz is the raw peak reflectivity (used for the readout, may exceed
+  // Y_MAX_DBZ) and norm is the clamped 0..1 value used for bar height.
+  let peakByCell = [];
+  // Sentinel value distinct from null/number so the very first transition
+  // (idle → null) doesn't get short-circuited by the de-dupe check.
+  const NO_EMIT = Symbol('no-emit');
+  let lastEmittedDbz = NO_EMIT;
 
   // The load-state strip below has 13 equal-flex cells. To keep the chart's
   // bends and the vertical cursor visually centered on each cell, we anchor
@@ -144,6 +162,14 @@ export default function initProbe({ container }) {
     else if (state === 'empty') showMessage('Ei dataa tällä alueella');
     else if (state === 'error') showMessage('Tietojen haku epäonnistui');
     else showMessage('');
+    if (state !== 'ready') {
+      peakByCell = [];
+      readout.textContent = '';
+      if (lastEmittedDbz !== null) {
+        lastEmittedDbz = null;
+        emitValue(null);
+      }
+    }
   }
 
   function clearSvg() {
@@ -194,21 +220,22 @@ export default function initProbe({ container }) {
     // cadence, multiple samples land in one cell. Take the peak dBZ —
     // that's the meaningful answer for "did precipitation hit this point
     // during this slot" and gives exactly one bar per cell.
-    const peakByCell = new Array(STRIP_CELLS).fill(null);
+    peakByCell = new Array(STRIP_CELLS).fill(null);
     for (const p of visible) {
-      const norm = normalizeDbz(p.v);
-      if (norm == null) continue; // eslint-disable-line no-continue
+      if (p.v == null || p.v < Y_MIN_DBZ) continue; // eslint-disable-line no-continue
       const idx = frameIndex(p.t, startMs);
       if (idx == null || idx < 0 || idx >= STRIP_CELLS) continue; // eslint-disable-line no-continue
       const prev = peakByCell[idx];
-      if (prev == null || norm > prev) peakByCell[idx] = norm;
+      if (prev == null || p.v > prev.dbz) {
+        peakByCell[idx] = { dbz: p.v, norm: normalizeDbz(p.v) };
+      }
     }
 
     for (let idx = 0; idx < STRIP_CELLS; idx += 1) {
-      const norm = peakByCell[idx];
-      if (norm == null) continue; // eslint-disable-line no-continue
+      const cell = peakByCell[idx];
+      if (cell == null) continue; // eslint-disable-line no-continue
       const cx = (idx + 0.5) * cellW;
-      const h = Math.max(1.5, norm * innerH);
+      const h = Math.max(1.5, cell.norm * innerH);
       const rect = document.createElementNS(SVG_NS, 'rect');
       rect.setAttribute('class', 'probe-bar');
       rect.setAttribute('data-frame', String(idx));
@@ -219,11 +246,15 @@ export default function initProbe({ container }) {
       svg.appendChild(rect);
     }
 
+    readout.setAttribute('x', (W - 6).toFixed(1));
+    svg.appendChild(readout);
+
     setState('ready');
     updateCurrentFrame();
   }
 
-  // Highlight the bar matching the current animation frame.
+  // Highlight the bar matching the current animation frame and update the
+  // top-right readout + onValueChange callback to reflect that cell.
   function updateCurrentFrame() {
     if (state !== 'ready' || cursorMs == null || !windowMs || !resolutionMs) return;
     const idx = frameIndex(cursorMs, windowMs[0]);
@@ -232,6 +263,13 @@ export default function initProbe({ container }) {
       const isCurrent = Number(b.getAttribute('data-frame')) === idx;
       b.classList.toggle('current', isCurrent);
     });
+    const cell = (idx >= 0 && idx < peakByCell.length) ? peakByCell[idx] : null;
+    const dbz = cell ? cell.dbz : null;
+    readout.textContent = dbz == null ? '' : `${Math.round(dbz)} dBZ`;
+    if (dbz !== lastEmittedDbz) {
+      lastEmittedDbz = dbz;
+      emitValue(dbz == null ? null : { dbz });
+    }
   }
 
   async function refetch() {

--- a/src/radar.js
+++ b/src/radar.js
@@ -2018,7 +2018,10 @@ const main = () => {
   attachInterpolators();
   recomputeAllTimelineCells();
 
-  probe = initProbe({ container: document.getElementById('probeChart') });
+  probe = initProbe({
+    container: document.getElementById('probeChart'),
+    onValueChange: (v) => { if (tools) tools.setProbeValue(v); },
+  });
   if (radarLayer.getVisible()) {
     probe.setActiveLayer(radarLayer.getSource().getParams().LAYERS);
   }

--- a/src/tools.js
+++ b/src/tools.js
@@ -94,6 +94,20 @@ function formatHHMM(ms) {
   return new Date(ms).toLocaleTimeString('fi', { hour: '2-digit', minute: '2-digit' });
 }
 
+// Marshall-Palmer Z–R conversion for the marker-card sub line: turns dBZ into
+// a rainfall rate so readers who don't know dBZ get a "how hard is it raining"
+// answer alongside the meteorological value.
+function dbzToRainRateMmH(dbz) {
+  const z = 10 ** (dbz / 10);
+  return (z / 200) ** (1 / 1.6);
+}
+
+function formatRainRate(mmh) {
+  if (mmh < 0.1) return '<0.1 mm/h';
+  if (mmh < 10) return `${mmh.toFixed(1)} mm/h`;
+  return `${Math.round(mmh)} mm/h`;
+}
+
 function buildMarkerCard() {
   const card = document.createElement('div');
   card.id = 'markerCard';
@@ -123,6 +137,11 @@ function buildMarkerCard() {
       </div>
       <div class="marker-item marker-item-bearing">
         <span class="marker-label">Suunta</span>
+        <span class="marker-value"></span>
+        <span class="marker-sub"></span>
+      </div>
+      <div class="marker-item marker-item-probe" hidden>
+        <span class="marker-label">Heijastavuus</span>
         <span class="marker-value"></span>
         <span class="marker-sub"></span>
       </div>
@@ -166,10 +185,20 @@ export default function initTools({
   const copyBtn = markerCard.querySelector('.marker-coord');
   const distRow = markerCard.querySelector('.marker-item-distance');
   const bearRow = markerCard.querySelector('.marker-item-bearing');
+  const probeRow = markerCard.querySelector('.marker-item-probe');
   const distValue = distRow.querySelector('.marker-value');
   const bearValue = bearRow.querySelector('.marker-value');
   const bearSub = bearRow.querySelector('.marker-sub');
+  const probeValue = probeRow.querySelector('.marker-value');
+  const probeSub = probeRow.querySelector('.marker-sub');
   const markerCloseBtn = markerCard.querySelector('.marker-card-close');
+
+  function setProbeValue(v) {
+    if (!v || v.dbz == null) { probeRow.hidden = true; return; }
+    probeValue.textContent = `${Math.round(v.dbz)} dBZ`;
+    probeSub.textContent = formatRainRate(dbzToRainRateMmH(v.dbz));
+    probeRow.hidden = false;
+  }
 
   let markerCoord4326 = null;
   let markerFeature = null;
@@ -225,6 +254,7 @@ export default function initTools({
     markerFeature = null;
     markerCoord4326 = null;
     markerCardVisible = false;
+    setProbeValue(null);
     updateMarkerCardVisibility();
     emitPinChange(null);
   }
@@ -513,6 +543,7 @@ export default function initTools({
     toggleCard: toggleMarkerCard,
     refresh: renderMarker,
     getPinFeature: () => markerFeature,
+    setProbeValue,
     // measurement
     arm: armMeasure,
     disarm: disarmMeasure,


### PR DESCRIPTION
## Summary

- The probe chart from #77 shows bars but never prints the number — you can see shape, not magnitude. This PR surfaces the actual value in two places.
- **In-chart readout** (top-right SVG text): `32 dBZ`, updates per cursor frame.
- **Marker-card row** (`Heijastavuus`, spans both columns): value `32 dBZ`, sub `5.2 mm/h` via Marshall-Palmer (`Z = 10^(dBZ/10)`, `R = (Z/200)^(1/1.6)`).
- `peakByCell` is lifted to module state and now stores `{dbz, norm}` so the raw value survives the >50 dBZ display clamp (an extreme cell now reads `58 dBZ` instead of being silently capped to 50).

## Test plan

- [ ] `npm run dev`, drop a pin in a precipitation area on a dBZ layer (FMI radar composite, OPERA, etc.)
- [ ] Verify top-right of the chart shows `XX dBZ` and updates as the timeline cursor moves between frames
- [ ] Open the marker card — verify the `Heijastavuus` row reads e.g. `32 dBZ` / `5.2 mm/h`
- [ ] Pin in a clear-sky cell → no readout text, marker row stays hidden
- [ ] Switch to a non-EDR layer (lightning, satellite) → chart collapses, row hides
- [ ] Remove the pin → chart collapses, row hides
- [ ] Cursor at frame index 0 and the last cell — readout matches the highlighted bar (no off-by-one)
- [ ] Extreme cell with raw value > 50 dBZ — readout shows the real number, bar stays clamped at full height
- [ ] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)