### PR TITLE
Fix zero-size WMS GetMap requests from FramePool prefetch

### DIFF
--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -253,7 +253,10 @@ export default class FramePool {
   _getViewContext() {
     const view = this.map.getView();
     const size = this.map.getSize();
-    if (!size) return null;
+    // Match OL's own renderer guard (hasArea). Without the zero check
+    // calculateExtent collapses to [cx, cy, cx, cy] and triggerLoad fires
+    // WMS GETs with WIDTH=0/HEIGHT=0 and a point BBOX.
+    if (!size || size[0] <= 0 || size[1] <= 0) return null;
     return {
       extent: view.calculateExtent(size),
       resolution: view.getResolution(),
@@ -723,7 +726,7 @@ export default class FramePool {
   // include the 1.5× fetch buffer) contains this 1× view.
   _viewExtent() {
     const size = this.map.getSize();
-    if (!size) return null;
+    if (!size || size[0] <= 0 || size[1] <= 0) return null;
     return this.map.getView().calculateExtent(size);
   }
 


### PR DESCRIPTION
## Summary
- Upstream WMS (`meteocore.app.meteo.fi/wms`) was seeing 400s on requests like `WIDTH=0&HEIGHT=0&BBOX=2941506.22,10191476.78,2941506.22,10191476.78` for `fmi-radar-composite-dbz`.
- Root cause: `FramePool._getViewContext` / `_viewExtent` (`src/animation/framePool.js`) guarded against `!size` but let `[0, 0]` through. With a zero-sized map container `view.calculateExtent` collapses to a point and `StickyImageWMS.triggerLoad` emits a degenerate `GetMap`.
- Triggers (all in `framePool.js`): `_resyncAllParams` on WMS `change:source`/param changes, the primary layer's `change:visible` listener, and `_handleMoveend` — each ending in `_prefetchAroundCurrent`. If the map element was zero-sized at that moment (pre-layout, background tab, PWA backgrounded), the bad request went out.
- Fix: mirror OL's own `hasArea` guard — bail when `size[0] <= 0 || size[1] <= 0`.

## Test plan
- [ ] Cold-load the app, switch radar layer products, toggle layer visibility — confirm no WMS request goes out with `WIDTH=0` / zero-area BBOX (devtools Network filter `WIDTH=0`).
- [ ] Background the tab / PWA, return to it — no degenerate prefetch on resume.
- [ ] Normal animation playback unchanged: window slides, frame preloading, and warp interpolation still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)