### PR TITLE
Add Vesiväylät (fairways) POI overlay

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
 
   <!-- Security -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' umami.app.meteo.fi; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; img-src 'self' data: blob: *.meteo.fi *.fmi.fi *.eumetsat.int *.arcgisonline.com geo.weather.gc.ca; connect-src 'self' *.meteo.fi *.fmi.fi umami.app.meteo.fi view.eumetsat.int geo.weather.gc.ca; worker-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' umami.app.meteo.fi; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; img-src 'self' data: blob: *.meteo.fi *.fmi.fi *.eumetsat.int *.arcgisonline.com geo.weather.gc.ca; connect-src 'self' *.meteo.fi *.fmi.fi umami.app.meteo.fi view.eumetsat.int geo.weather.gc.ca avoinapi.vaylapilvi.fi; worker-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
 

--- a/src/radar.js
+++ b/src/radar.js
@@ -402,9 +402,34 @@ const vesivaylatStylesDark = makeVesivaylatStyles({
   secondary: [80, 190, 220, 0.7],
 });
 let vesivaylatStyleSet = vesivaylatStylesLight;
-function vesivaylatStyleFn(feature) {
+
+// Label nimifi along each fairway when zoomed in enough to actually read
+// it. Resolution is m/pixel; ≤ 200 m/px lands around zoom 10-11, which is
+// roughly "looking at a single bay or harbour". Above that threshold the
+// labels would just be a smear of unreadable text across the country.
+const VESIVAYLAT_LABEL_MAX_RES = 200;
+const vesivaylatLabelColors = {
+  light: { fill: '#003e58', halo: '#ffffff' },
+  dark: { fill: '#e0f6ff', halo: '#000000' },
+};
+const vesivaylatLabelStyle = new Style({
+  text: new Text({
+    font: '11px Calibri,sans-serif',
+    placement: 'line',
+    overflow: false,
+    fill: new Fill({ color: vesivaylatLabelColors.light.fill }),
+    stroke: new Stroke({ color: vesivaylatLabelColors.light.halo, width: 2.5 }),
+  }),
+});
+
+function vesivaylatStyleFn(feature, resolution) {
   const cls = feature.get('vaylaluokkakoodi');
-  return vesivaylatStyleSet[cls] || vesivaylatStyleSet.default;
+  const base = vesivaylatStyleSet[cls] || vesivaylatStyleSet.default;
+  if (resolution > VESIVAYLAT_LABEL_MAX_RES) return base;
+  const name = feature.get('nimifi');
+  if (!name) return base;
+  vesivaylatLabelStyle.getText().setText(name);
+  return [base, vesivaylatLabelStyle];
 }
 
 const rangeStyle = new Style({
@@ -599,6 +624,10 @@ const municipalityLayer = new VectorTileLayer({
 // ever exceeds it, switch to bbox strategy with a tilegrid snap.
 const vesivaylatLayer = new VectorLayer({
   visible: false,
+  // Declutter so overlapping nimifi labels along parallel fairway segments
+  // don't pile up at harbours. Stroke geometry still renders fully — only
+  // text participates in the decluttering.
+  declutter: true,
   source: new Vector({
     format: new GeoJSON(),
     url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylat_uusi/items?f=application/geo%2Bjson&limit=10000',
@@ -1015,6 +1044,14 @@ function applyIcaoTheme(theme) {
   icaoLayer.changed();
 }
 
+function applyVesivaylatTheme(theme) {
+  vesivaylatStyleSet = theme === 'light' ? vesivaylatStylesLight : vesivaylatStylesDark;
+  const t = vesivaylatLabelColors[theme] || vesivaylatLabelColors.dark;
+  vesivaylatLabelStyle.getText().getFill().setColor(t.fill);
+  vesivaylatLabelStyle.getText().getStroke().setColor(t.halo);
+  vesivaylatLayer.changed();
+}
+
 function setMapLayer(maplayer) {
   debug(`Set ${maplayer} map.`);
   switch (maplayer) {
@@ -1025,8 +1062,7 @@ function setMapLayer(maplayer) {
       lightGrayReferenceLayer.setVisible(true);
       municipalityLayer.setStyle(municipalityStyleLight);
       applyIcaoTheme('light');
-      vesivaylatStyleSet = vesivaylatStylesLight;
-      vesivaylatLayer.changed();
+      applyVesivaylatTheme('light');
       break;
     case 'dark':
       darkGrayBaseLayer.setVisible(true);
@@ -1035,8 +1071,7 @@ function setMapLayer(maplayer) {
       lightGrayReferenceLayer.setVisible(false);
       municipalityLayer.setStyle(municipalityStyleDark);
       applyIcaoTheme('dark');
-      vesivaylatStyleSet = vesivaylatStylesDark;
-      vesivaylatLayer.changed();
+      applyVesivaylatTheme('dark');
       break;
     default:
       break;

--- a/src/radar.js
+++ b/src/radar.js
@@ -380,6 +380,33 @@ const municipalityStyleDark = new Style({
   }),
 });
 
+// Waterways / fairways (Vesiväylät). Stroke weight follows the fairway
+// class — VL1 (commercial main route) reads heaviest, minor routes
+// tail off. Cyan/teal hue keeps the layer from colliding with the blue
+// of the airspace layer when both are on.
+function makeVesivaylatStyles(palette) {
+  const stroke = (color, width) => new Style({ stroke: new Stroke({ color, width }) });
+  return {
+    1: stroke(palette.main, 1.8),
+    2: stroke(palette.main, 1.4),
+    3: stroke(palette.secondary, 1.1),
+    default: stroke(palette.secondary, 0.8),
+  };
+}
+const vesivaylatStylesLight = makeVesivaylatStyles({
+  main: [0, 110, 160, 0.7],
+  secondary: [0, 130, 180, 0.5],
+});
+const vesivaylatStylesDark = makeVesivaylatStyles({
+  main: [100, 220, 240, 0.9],
+  secondary: [80, 190, 220, 0.7],
+});
+let vesivaylatStyleSet = vesivaylatStylesLight;
+function vesivaylatStyleFn(feature) {
+  const cls = feature.get('vaylaluokkakoodi');
+  return vesivaylatStyleSet[cls] || vesivaylatStyleSet.default;
+}
+
 const rangeStyle = new Style({
   stroke: new Stroke({
     color: [128, 128, 128, 0.7],
@@ -565,6 +592,21 @@ const municipalityLayer = new VectorTileLayer({
   style: municipalityStyleLight,
 });
 
+// Fairways (Vesiväylät) — OGC API Features from Väylävirasto. The
+// dataset is ~770 KB gzipped (1901 LineString features as of 2026-05),
+// small enough to fetch once on first toggle-on using OL's default
+// "all" loading strategy. Limit=10000 leaves headroom; if the dataset
+// ever exceeds it, switch to bbox strategy with a tilegrid snap.
+const vesivaylatLayer = new VectorLayer({
+  visible: false,
+  source: new Vector({
+    format: new GeoJSON(),
+    url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylat_uusi/items?f=application/geo%2Bjson&limit=10000',
+    attributions: 'Väylävirasto',
+  }),
+  style: vesivaylatStyleFn,
+});
+
 const guideLayer = new VectorLayer({
   source: new Vector(),
   style: rangeStyle,
@@ -596,6 +638,7 @@ const layers = [
   lightGrayReferenceLayer,
   darkGrayReferenceLayer,
   municipalityLayer,
+  vesivaylatLayer,
   radarSiteLayer,
   icaoLayer,
   ownPositionLayer,
@@ -982,6 +1025,8 @@ function setMapLayer(maplayer) {
       lightGrayReferenceLayer.setVisible(true);
       municipalityLayer.setStyle(municipalityStyleLight);
       applyIcaoTheme('light');
+      vesivaylatStyleSet = vesivaylatStylesLight;
+      vesivaylatLayer.changed();
       break;
     case 'dark':
       darkGrayBaseLayer.setVisible(true);
@@ -990,6 +1035,8 @@ function setMapLayer(maplayer) {
       lightGrayReferenceLayer.setVisible(false);
       municipalityLayer.setStyle(municipalityStyleDark);
       applyIcaoTheme('dark');
+      vesivaylatStyleSet = vesivaylatStylesDark;
+      vesivaylatLayer.changed();
       break;
     default:
       break;
@@ -1683,6 +1730,13 @@ const poiRegistry = [
     icon: 'location_city',
     defaultOn: false,
     layerRef: () => municipalityLayer,
+  },
+  {
+    id: 'vesivaylat',
+    label: 'Vesiväylät',
+    icon: 'directions_boat',
+    defaultOn: false,
+    layerRef: () => vesivaylatLayer,
   },
 ];
 

--- a/src/radar.js
+++ b/src/radar.js
@@ -403,6 +403,19 @@ const vesivaylatStylesDark = makeVesivaylatStyles({
 });
 let vesivaylatStyleSet = vesivaylatStylesLight;
 
+// Fairway navigation areas (vaylaalueet_uusi) — MultiPolygons of the
+// channel footprint, rendered as a subtle dark wash behind the line
+// geometry so the user sees "this whole zone is the fairway, not just
+// the centreline". Theme-aware alpha: dark basemap needs more opacity
+// to register, light basemap needs less so the wash doesn't dominate.
+const vesivaylaAreaFills = {
+  light: 'rgba(0, 0, 0, 0.13)',
+  dark: 'rgba(0, 0, 0, 0.35)',
+};
+const vesivaylaAreaStyle = new Style({
+  fill: new Fill({ color: vesivaylaAreaFills.light }),
+});
+
 // Label nimifi along each fairway when zoomed in enough to actually read
 // it. Resolution is m/pixel; ≤ 200 m/px lands around zoom 10-11, which is
 // roughly "looking at a single bay or harbour". Above that threshold the
@@ -622,6 +635,16 @@ const municipalityLayer = new VectorTileLayer({
 // small enough to fetch once on first toggle-on using OL's default
 // "all" loading strategy. Limit=10000 leaves headroom; if the dataset
 // ever exceeds it, switch to bbox strategy with a tilegrid snap.
+const vesivaylaAreaLayer = new VectorLayer({
+  visible: false,
+  source: new Vector({
+    format: new GeoJSON(),
+    url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylaalueet_uusi/items?f=application/geo%2Bjson&limit=10000',
+    attributions: 'Väylävirasto',
+  }),
+  style: vesivaylaAreaStyle,
+});
+
 const vesivaylatLayer = new VectorLayer({
   visible: false,
   // Declutter so overlapping nimifi labels along parallel fairway segments
@@ -667,6 +690,7 @@ const layers = [
   lightGrayReferenceLayer,
   darkGrayReferenceLayer,
   municipalityLayer,
+  vesivaylaAreaLayer,
   vesivaylatLayer,
   radarSiteLayer,
   icaoLayer,
@@ -1050,6 +1074,8 @@ function applyVesivaylatTheme(theme) {
   vesivaylatLabelStyle.getText().getFill().setColor(t.fill);
   vesivaylatLabelStyle.getText().getStroke().setColor(t.halo);
   vesivaylatLayer.changed();
+  vesivaylaAreaStyle.getFill().setColor(vesivaylaAreaFills[theme] || vesivaylaAreaFills.light);
+  vesivaylaAreaLayer.changed();
 }
 
 function setMapLayer(maplayer) {
@@ -1771,7 +1797,10 @@ const poiRegistry = [
     label: 'Vesiväylät',
     icon: 'directions_boat',
     defaultOn: false,
-    layerRef: () => vesivaylatLayer,
+    // Area fill renders behind the line geometry — both flip together
+    // off the same toggle. Order here doesn't drive z-order; the layers
+    // array does (vesivaylaAreaLayer sits before vesivaylatLayer there).
+    layerRef: () => [vesivaylaAreaLayer, vesivaylatLayer],
   },
 ];
 
@@ -1794,7 +1823,9 @@ function persistPoiState() {
 
 function applyPoiVisibility() {
   poiRegistry.forEach((entry) => {
-    entry.layerRef().setVisible(!!POI_STATE[entry.id]);
+    const ref = entry.layerRef();
+    const visible = !!POI_STATE[entry.id];
+    (Array.isArray(ref) ? ref : [ref]).forEach((l) => l.setVisible(visible));
   });
 }
 


### PR DESCRIPTION
## Summary
New POI in the Karttakohteet menu — Finnish fairways sourced from Väylävirasto's OGC API Features endpoint:

```
https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylat_uusi/items?f=application/geo+json&limit=10000
```

1901 LineString features as of 2026-05; ~3.3 MB raw / ~770 KB over the wire with gzip. Small enough to fetch all-at-once on first toggle-on using OL's default "all" loading strategy. CORS is open (`access-control-allow-origin: *`).

## Style
Stroke weight follows fairway class (`vaylaluokkakoodi`):
| Class | Width | Notes |
|---|---|---|
| VL1 | 1.8 | Commercial main routes |
| VL2 | 1.4 | Secondary commercial |
| VL3 | 1.1 | – |
| Other | 0.8 | Minor routes |

Cyan / teal hue keeps it visually distinct from the airspace layer's blue when both are toggled on. Light + dark style sets swap from `setMapLayer` alongside Kunnat / Ilmatila / Lentokentät labels.

Default off; the icon in the menu is `directions_boat`.

## If the dataset grows
At ~2000 features the all-strategy is fine. If it ever exceeds OGC's `limit=10000` cap, switch to `bboxStrategy` with a tilegrid snap so panning doesn't refetch on every pixel of movement.

## Test plan
- [ ] Open Karttakohteet menu — new "Vesiväylät" row with boat icon.
- [ ] Toggle on — fairways appear; thicker on commercial routes.
- [ ] Network panel: one request to `avoinapi.vaylapilvi.fi`, ~770 KB, on first toggle-on; no refetch on pan/zoom.
- [ ] Light/dark theme swap — colors flip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)