### PR TITLE
Hosting: don't long-cache the SW bootstrap files

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,15 @@
     ],
     "headers": [
       {
+        "source": "/@(sw.js|sw-register.js)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
         "source": "**/*.@(js|css|jpg|jpeg|gif|png|svg|ico|woff2|woff|ttf|eot)",
         "headers": [
           {


### PR DESCRIPTION
## Summary
`sw.js` and `sw-register.js` were inheriting the generic `**/*.js` rule in `firebase.json`, which serves every JS file with `Cache-Control: public, max-age=31536000, immutable`. That's correct for the hash-named webpack bundles (their filename is the cache key), wrong for the service-worker bootstrap files (their filename is stable but their content changes every deploy).

The HTTP spec says browsers should clamp SW-script caches to 24 h, but **Safari and older Firefox don't honour the clamp when `immutable` is present**, so a user can hold a stale `sw.js` for weeks. When that happens, `registration.update()` has nothing fresh to fetch and the update flow is silently dead. That's the long-tail of users on very old versions that analytics has been showing.

## Change
Add a more specific rule listed *before* the generic JS rule (first-match wins for `Cache-Control`):

```json
{
  "source": "/@(sw.js|sw-register.js)",
  "headers": [{ "key": "Cache-Control", "value": "no-cache, max-age=0, must-revalidate" }]
}
```

Both files now revalidate against the origin on every fetch — sub-KB conditional GETs, basically free.

## Followups (not in this PR)
- Rewrite `sw-register.js` to the canonical Workbox update flow: skipWaiting only on user click + `controllerchange` reload + race-safe listener attach.
- Drop `skipWaiting: true` / `clientsClaim: true` from `webpack.config.js` once the bootstrap is rewritten.

## Test plan
- [ ] Deploy → `curl -I https://tutka.meteo.fi/sw.js` returns `Cache-Control: no-cache, max-age=0, must-revalidate`.
- [ ] Same for `sw-register.js`.
- [ ] Hashed JS bundles still return `max-age=31536000, immutable` (regression check).
- [ ] Over the next ~7 days, `app-boot.build-date` distribution in umami should tighten toward the latest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)