### PR TITLE
Service worker: message-driven update flow + chunk-load self-heal

### DIFF
--- a/assets/sw-register.js
+++ b/assets/sw-register.js
@@ -1,33 +1,114 @@
+// Service-worker bootstrap. Three responsibilities:
+//
+//   1. Register the worker and check for updates on a 10-minute heartbeat.
+//   2. When a new worker reaches `installed`, show a one-shot "Päivitä"
+//      banner. Tapping it posts SKIP_WAITING (handled by sw-skip-waiting.js
+//      in the SW). Once the new worker becomes the controller we reload
+//      exactly once.
+//   3. Catch chunk-load 404s from a stale precached index.html that
+//      references hashed bundle URLs no longer hosted; recover by
+//      unregistering all SWs and reloading.
+//
+// The previous bootstrap had a race (listener attached inside the
+// register().then) and trusted skipWaiting+clientsClaim to flip the
+// controller mid-session — both wrong, both fixed here.
+
 if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
-  window.addEventListener('load', function () {
-    navigator.serviceWorker.register('/sw.js').then(function (registration) {
-      console.log('ServiceWorker registration successful with scope: ', registration.scope);
+  // Self-heal must attach as early as possible — the chunk failure can
+  // fire before the load event if a deferred bundle script 404s. Even so,
+  // this catches everything that happens after sw-register.js runs, which
+  // covers the dominant case (lazy chunks, late assets).
+  window.addEventListener('error', (event) => {
+    const { target } = event;
+    if (!target || target.tagName !== 'SCRIPT') return;
+    const src = target.src || '';
+    if (!/\/(radar|openlayers|vendors|runtime)[.-][^/]*\.js$/.test(src)) return;
+    console.warn('Chunk load failed, unregistering SWs and reloading:', src);
+    if (typeof umami !== 'undefined') umami.track('sw-chunk-load-error', { src });
+    navigator.serviceWorker.getRegistrations()
+      .then((regs) => Promise.all(regs.map((r) => r.unregister())))
+      .finally(() => { window.location.reload(); });
+  }, true);
 
-      // Check for updates periodically
-      setInterval(function () {
-        registration.update();
-      }, 600000); // Check every 10 minutes
+  window.addEventListener('load', () => {
+    // updateViaCache: 'none' is belt and suspenders. The default 'imports'
+    // already bypasses HTTP cache for the main SW script during update
+    // checks, but 'none' also covers any future importScripts() bundles.
+    navigator.serviceWorker
+      .register('/sw.js', { updateViaCache: 'none' })
+      .then((registration) => {
+        console.log('ServiceWorker registered with scope:', registration.scope);
 
-      // Listen for updates
-      registration.addEventListener('updatefound', function () {
-        var newWorker = registration.installing;
-        newWorker.addEventListener('statechange', function () {
-          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-            // New service worker is available — show a non-blocking notification
-            var banner = document.createElement('div');
-            banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#333;color:#fff;padding:12px;text-align:center;z-index:10000;font-family:sans-serif';
-            banner.textContent = 'Uusi versio saatavilla. ';
-            var btn = document.createElement('button');
-            btn.textContent = 'Päivitä';
-            btn.style.cssText = 'margin-left:12px;padding:6px 16px;background:#fff;color:#333;border:none;border-radius:4px;cursor:pointer';
-            btn.onclick = function () { window.location.reload(); };
-            banner.appendChild(btn);
-            document.body.appendChild(banner);
+        let reloading = false;
+        let bannerShown = false;
+
+        function track(event, data) {
+          if (typeof umami !== 'undefined') umami.track(event, data);
+        }
+
+        function showUpdateBanner(worker) {
+          if (bannerShown || !worker) return;
+          bannerShown = true;
+          track('sw-update-shown');
+          const banner = document.createElement('div');
+          banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#333;color:#fff;padding:12px;text-align:center;z-index:10000;font-family:sans-serif';
+          banner.textContent = 'Uusi versio saatavilla. ';
+          const btn = document.createElement('button');
+          btn.textContent = 'Päivitä';
+          btn.style.cssText = 'margin-left:12px;padding:6px 16px;background:#fff;color:#333;border:none;border-radius:4px;cursor:pointer';
+          btn.onclick = function () {
+            track('sw-update-clicked');
+            // The worker may have moved from 'installing' to 'waiting' by
+            // the time the user clicks; postMessage works in either state.
+            worker.postMessage({ type: 'SKIP_WAITING' });
+          };
+          banner.appendChild(btn);
+          document.body.appendChild(banner);
+        }
+
+        // Banner trigger: a new worker reaches 'installed' AND there's
+        // already a controller (so this isn't a first-ever install).
+        function watchWorker(worker) {
+          if (!worker) return;
+          if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+            showUpdateBanner(worker);
+            return;
           }
+          worker.addEventListener('statechange', () => {
+            if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+              showUpdateBanner(worker);
+            }
+          });
+        }
+
+        // Race-safe: check the registration's existing state first. If an
+        // update was already detected before we registered our listeners
+        // (browser auto-update before window.load), we still see it.
+        if (registration.waiting) watchWorker(registration.waiting);
+        if (registration.installing) watchWorker(registration.installing);
+        registration.addEventListener('updatefound', () => {
+          watchWorker(registration.installing);
         });
+
+        // controllerchange fires when the new SW claims the page. With
+        // clientsClaim off the trigger is our SKIP_WAITING -> skipWaiting
+        // round-trip; reload once so the page renders against the new
+        // precache cleanly.
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (reloading) return;
+          reloading = true;
+          window.location.reload();
+        });
+
+        // 10-minute update poll while the tab stays open. registration.update()
+        // returns a Promise; swallow rejections so a transient offline blip
+        // doesn't surface in the console.
+        setInterval(() => {
+          registration.update().catch(() => {});
+        }, 600000);
+      })
+      .catch((err) => {
+        console.warn('ServiceWorker registration failed:', err);
       });
-    }, function (err) {
-      console.log('ServiceWorker registration failed: ', err);
-    });
   });
 }

--- a/assets/sw-skip-waiting.js
+++ b/assets/sw-skip-waiting.js
@@ -1,0 +1,13 @@
+/* eslint-env serviceworker */
+/* eslint-disable no-restricted-globals */ // `self` is the ServiceWorkerGlobalScope here
+// Imported by the Workbox-generated sw.js (see webpack.config.js
+// `importScripts`). Pairs with sw-register.js: when the page detects an
+// installed-but-waiting worker and the user clicks Päivitä, the page
+// posts {type:'SKIP_WAITING'} to that worker; we then call skipWaiting()
+// so the SW activates, fires `controllerchange` in the page, and the
+// page reloads itself into the new version.
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/src/radar.js
+++ b/src/radar.js
@@ -1,3 +1,6 @@
+// deploy-marker: sw-update-flow-test — bump on PR #87 to force a fresh
+// radar.[contenthash].js so the deployed test build differs from the
+// previous one and the new banner flow can be exercised end-to-end.
 import { Map, View } from 'ol';
 import Geolocation from 'ol/Geolocation';
 import TileLayer from 'ol/layer/Tile';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,30 +5,30 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { GenerateSW } = require('workbox-webpack-plugin');
- 
+
 module.exports = (env, argv) => {
-    const isProduction = argv.mode === 'production';
-    
-    return {
+  const isProduction = argv.mode === 'production';
+
+  return {
     devtool: isProduction ? 'source-map' : 'cheap-module-source-map',
     entry: './src/radar.js',
     output: {
-        path: path.resolve(__dirname, 'dist'),
-        //filename: 'radar.js'
-        filename: 'radar.[contenthash].js',
+      path: path.resolve(__dirname, 'dist'),
+      // filename: 'radar.js'
+      filename: 'radar.[contenthash].js',
     },
     resolve: {
-        fallback: {
-            "util": require.resolve("util/")
-        }
+      fallback: {
+        util: require.resolve('util/'),
+      },
     },
     devServer: {
-        static: {
-            directory: path.join(__dirname, 'dist'),
-        },
-        compress: true,
-        port: 9000,
-        open: true
+      static: {
+        directory: path.join(__dirname, 'dist'),
+      },
+      compress: true,
+      port: 9000,
+      open: true,
     },
     // module: {
     //     rules: [
@@ -39,114 +39,123 @@ module.exports = (env, argv) => {
     //     ]
     //   },
     plugins: [
-        new webpack.ProvidePlugin({
-            process: 'process/browser',
+      new webpack.ProvidePlugin({
+        process: 'process/browser',
+      }),
+      // Only use compression in production
+      ...(isProduction ? [new CompressionPlugin()] : []),
+      new HtmlWebpackPlugin({
+        template: './src/index.html',
+      }),
+      new CleanWebpackPlugin(),
+      new CopyWebpackPlugin({
+        patterns: [
+          { from: 'assets', to: '.' },
+        ],
+      }),
+      new webpack.DefinePlugin({
+        BUILD_DATE: JSON.stringify(`${new Date().toISOString().slice(0, 16)}Z`),
+      }),
+      // Only generate service worker in production to avoid watch mode warnings
+      ...(isProduction ? [
+        new GenerateSW({
+          swDest: 'sw.js',
+          // clientsClaim / skipWaiting intentionally OFF. The new SW
+          // installs into 'waiting' and stays there until the page
+          // (sw-register.js) posts SKIP_WAITING in response to the user
+          // tapping Päivitä. Auto-skipping was flipping the active SW
+          // mid-session and orphaning the precache entries the still-
+          // rendered page was about to fetch — that's how users wound
+          // up stuck on old chunk URLs the new SW had already wiped.
+          importScripts: ['sw-skip-waiting.js'],
+          maximumFileSizeToCacheInBytes: 5000000, // 5MB
+          // Activate-time cleanup of previous Workbox precache caches.
+          // Safe with the message-driven activation flow above because
+          // the page reloads on `controllerchange` before the new SW
+          // serves a single request to it.
+          cleanupOutdatedCaches: true,
+          // Don't precache everything - be more selective
+          exclude: [/\.map$/, /manifest$/, /LICENSE/],
+          runtimeCaching: [{
+            urlPattern: new RegExp('^https://server\\.arcgisonline\\.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/'),
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'arcgis-cache',
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 24 * 60 * 60, // 1 day
+              },
+            },
+          },
+          {
+            urlPattern: new RegExp('^https://openlayers\\.org/en/latest/css/ol\\.css'),
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'openlayers-cache',
+              expiration: {
+                maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
+              },
+            },
+          },
+          {
+            urlPattern: /radar\.css/,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'css-cache',
+            },
+          },
+          {
+            urlPattern: new RegExp('^https://fonts\\.gstatic\\.com/'),
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'google-fonts-cache',
+              expiration: {
+                maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+              },
+            },
+          },
+          {
+            urlPattern: new RegExp('^https://wms\\.meteo\\.fi/geoserver/.*request=GetCapabilities'),
+            handler: 'NetworkFirst',
+          },
+          {
+            urlPattern: new RegExp('^https://geoserver\\.app\\.meteo\\.fi/geoserver/.*request=GetCapabilities'),
+            handler: 'NetworkFirst',
+          },
+          {
+            urlPattern: new RegExp('^https://view\\.eumetsat\\.int/geoserv/.*request=GetCapabilities'),
+            handler: 'NetworkFirst',
+          },
+          ],
         }),
-        // Only use compression in production
-        ...(isProduction ? [new CompressionPlugin()] : []),
-        new HtmlWebpackPlugin({
-          template: './src/index.html'
-        }),
-        new CleanWebpackPlugin(),
-        new CopyWebpackPlugin({
-            patterns: [
-                { from: 'assets', to: '.' }
-            ]
-        }),
-        new webpack.DefinePlugin({
-            'BUILD_DATE': JSON.stringify(new Date().toISOString().slice(0, 16) + 'Z')
-        }),
-        // Only generate service worker in production to avoid watch mode warnings
-        ...(isProduction ? [
-            new GenerateSW({
-                swDest: 'sw.js',
-                clientsClaim: true,
-                skipWaiting: true,
-                maximumFileSizeToCacheInBytes: 5000000, // 5MB
-                // Add cache busting strategy
-                cleanupOutdatedCaches: true,
-                // Don't precache everything - be more selective
-                exclude: [/\.map$/, /manifest$/, /LICENSE/],
-                runtimeCaching: [{
-                    urlPattern: new RegExp('^https://server\\.arcgisonline\\.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/'),
-                    handler: 'StaleWhileRevalidate',
-                    options: {
-                        cacheName: 'arcgis-cache',
-                        expiration: {
-                            maxEntries: 50,
-                            maxAgeSeconds: 24 * 60 * 60, // 1 day
-                        },
-                    },
-                },
-                {
-                    urlPattern: new RegExp('^https://openlayers\\.org/en/latest/css/ol\\.css'),
-                    handler: 'StaleWhileRevalidate',
-                    options: {
-                        cacheName: 'openlayers-cache',
-                        expiration: {
-                            maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
-                        },
-                    },
-                },
-                {
-                    urlPattern: /radar\.css/,
-                    handler: 'StaleWhileRevalidate',
-                    options: {
-                        cacheName: 'css-cache',
-                    },
-                },
-                {
-                    urlPattern: new RegExp('^https://fonts\\.gstatic\\.com/'),
-                    handler: 'StaleWhileRevalidate',
-                    options: {
-                        cacheName: 'google-fonts-cache',
-                        expiration: {
-                            maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
-                        },
-                    },
-                },
-                {
-                    urlPattern: new RegExp('^https://wms\\.meteo\\.fi/geoserver/.*request=GetCapabilities'),
-                    handler: 'NetworkFirst'
-                },
-                {
-                    urlPattern: new RegExp('^https://geoserver\\.app\\.meteo\\.fi/geoserver/.*request=GetCapabilities'),
-                    handler: 'NetworkFirst'
-                },
-                {
-                    urlPattern: new RegExp('^https://view\\.eumetsat\\.int/geoserv/.*request=GetCapabilities'),
-                    handler: 'NetworkFirst'
-                }
-            ]
-            })
-        ] : [])
+      ] : []),
     ],
     optimization: {
-        runtimeChunk: 'single',
-        splitChunks: {
+      runtimeChunk: 'single',
+      splitChunks: {
+        chunks: 'all',
+        maxInitialRequests: Infinity,
+        minSize: 0,
+        cacheGroups: {
+          default: {
+            minChunks: 2,
+            priority: -20,
+            reuseExistingChunk: true,
+          },
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            priority: -10,
             chunks: 'all',
-            maxInitialRequests: Infinity,
-            minSize: 0,
-            cacheGroups: {
-                default: {
-                    minChunks: 2,
-                    priority: -20,
-                    reuseExistingChunk: true
-                },
-                vendor: {
-                    test: /[\\/]node_modules[\\/]/,
-                    name: 'vendors',
-                    priority: -10,
-                    chunks: 'all'
-                },
-                openlayers: {
-                    test: /[\\/]node_modules[\\/]ol[\\/]/,
-                    name: 'openlayers',
-                    priority: 10,
-                    chunks: 'all'
-                }
-            }
-        }
-    }
-};
+          },
+          openlayers: {
+            test: /[\\/]node_modules[\\/]ol[\\/]/,
+            name: 'openlayers',
+            priority: 10,
+            chunks: 'all',
+          },
+        },
+      },
+    },
+  };
 };


### PR DESCRIPTION
## Summary
Replaces #86 (closed as no-op — see that PR's close comment for the reasoning). Targets the actual root cause of the long tail of users stuck on old builds.

The previous flow relied on `skipWaiting: true` + `clientsClaim: true`, which flips the active SW as soon as a new one finishes installing. Combined with `cleanupOutdatedCaches`, the new SW immediately wipes the previous precache — but the still-rendered page references the *old* hashed chunk URLs in its script tags. Anything the browser refetches after that point 404s, and there's no recovery path. That's the failure mode the analytics dashboard has been measuring.

## Changes

**`webpack.config.js`**
- Drop `skipWaiting: true` / `clientsClaim: true` from `GenerateSW`. The new SW now installs into `waiting` and stays there.
- Add `importScripts: ['sw-skip-waiting.js']` so the generated `sw.js` can react to a SKIP_WAITING message from the page.

**`assets/sw-skip-waiting.js` (NEW)**
- One-liner SW-side handler that calls `self.skipWaiting()` only on `{type:'SKIP_WAITING'}`.

**`assets/sw-register.js` (rewrite)**
- `register('/sw.js', { updateViaCache: 'none' })` — belt-and-suspenders.
- Race-safe update detection: inspect `registration.installing` / `.waiting` *before* attaching the `updatefound` listener, so a browser-initiated update that lands before `window.load` still surfaces the banner.
- Banner click posts SKIP_WAITING; page reloads on `controllerchange`.
- Window-level `error` listener catches failed bundle script loads (`radar.*/openlayers.*/vendors.*/runtime.*.js` 404), unregisters all SWs, and reloads. Defensive — should rarely fire after this PR — but covers stale-precache and old-installer cases.
- Three new umami events: `sw-update-shown`, `sw-update-clicked`, `sw-chunk-load-error`. The shown→clicked ratio finally tells us if banners reach users and convert.

## Verification

`grep -oE 'clientsClaim|skipWaiting|importScripts\\("sw-skip' dist/sw.js` after build:
```
importScripts("sw-skip
skipWaiting
```
- `clientsClaim` absent ✓
- `skipWaiting` appears only inside our SKIP_WAITING message handler, not at install time ✓
- `importScripts("sw-skip-waiting.js")` wired in ✓

## Already shipped (no work needed)

The `app-boot` event already includes `display-mode` (radar.js:2395), so segmenting the version-tail by `standalone` vs `browser` is doable in umami without further code — useful to size the iOS-homescreen-PWA cohort vs everyone else.

## Test plan post-deploy
- [ ] Open the live app, leave the tab on overnight, deploy a no-op change to bump hashes, watch the "Päivitä" banner appear within the 10-minute heartbeat.
- [ ] Click Päivitä — page should reload exactly once into the new version. No double-reload, no chunk 404 in DevTools network panel.
- [ ] After a few days, watch the `app-boot.build-date` distribution in umami tighten toward latest. Also look at `sw-update-shown` vs `sw-update-clicked` rate, and any `sw-chunk-load-error` volume.
- [ ] iOS standalone PWA (homescreen install): launch → first install gets no banner (correct) → after a deploy, relaunch should pick up the new SW on next activation cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)