### PR TITLE
SW: restore clientsClaim + auto-reload on controllerchange

### DIFF
--- a/assets/sw-register.js
+++ b/assets/sw-register.js
@@ -21,13 +21,30 @@ if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
   // can fire its error event before window.load. We still miss anything
   // that errors before sw-register.js executes, but this catches lazy
   // fetches and late assets, which is the common failure shape.
+  // Telemetry helper — loud about its own failures so we can see in
+  // DevTools whether the event actually reached umami. The previous
+  // silent guard hid the fact that none of the sw-* events were
+  // surfacing even when the banner WAS shown.
+  const swTrack = (event, data) => {
+    if (typeof umami === 'undefined' || !umami || typeof umami.track !== 'function') {
+      console.warn('[sw-register] umami not available for event:', event, data);
+      return;
+    }
+    try {
+      umami.track(event, data);
+      console.log('[sw-register] telemetry sent:', event, data);
+    } catch (err) {
+      console.warn('[sw-register] umami.track threw for', event, err);
+    }
+  };
+
   window.addEventListener('error', (event) => {
     const { target } = event;
     if (!target || target.tagName !== 'SCRIPT') return;
     const src = target.src || '';
     if (!/\/(radar|openlayers|vendors|runtime)[.-][^/]*\.js$/.test(src)) return;
     console.warn('Chunk load failed, unregistering SWs and reloading:', src);
-    if (typeof umami !== 'undefined') umami.track('sw-chunk-load-error', { src });
+    swTrack('sw-chunk-load-error', { src });
     navigator.serviceWorker.getRegistrations()
       .then((regs) => Promise.all(regs.map((r) => r.unregister())))
       .finally(() => { window.location.reload(); });
@@ -56,20 +73,14 @@ if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
         navigator.serviceWorker.addEventListener('controllerchange', () => {
           if (reloading) return;
           reloading = true;
-          if (typeof umami !== 'undefined') {
-            umami.track('sw-controllerchange-reload');
-          }
+          swTrack('sw-controllerchange-reload');
           window.location.reload();
         });
-
-        function track(event, data) {
-          if (typeof umami !== 'undefined') umami.track(event, data);
-        }
 
         function showUpdateBanner() {
           if (bannerShown) return;
           bannerShown = true;
-          track('sw-update-shown');
+          swTrack('sw-update-shown');
           const banner = document.createElement('div');
           banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#333;color:#fff;padding:12px;text-align:center;z-index:10000;font-family:sans-serif';
           banner.textContent = 'Uusi versio saatavilla. ';
@@ -77,7 +88,7 @@ if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
           btn.textContent = 'Päivitä';
           btn.style.cssText = 'margin-left:12px;padding:6px 16px;background:#fff;color:#333;border:none;border-radius:4px;cursor:pointer';
           btn.onclick = function () {
-            track('sw-update-clicked');
+            swTrack('sw-update-clicked');
             // SW config has skipWaiting:true so the new worker is already
             // activated. A plain reload creates a new client which picks
             // up the new active worker and the fresh precache.

--- a/assets/sw-register.js
+++ b/assets/sw-register.js
@@ -43,6 +43,24 @@ if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
         console.log('ServiceWorker registered with scope:', registration.scope);
 
         let bannerShown = false;
+        let reloading = false;
+
+        // The SW config has clientsClaim: true, so when the new worker
+        // activates it immediately takes control of this tab and fires
+        // `controllerchange`. Reload exactly once at that point — gives
+        // a fresh navigation served by the new precache. Belt-and-
+        // suspenders against statechange timing quirks: even if the
+        // statechange handler below misses 'installed' (e.g. WebKit
+        // dispatching events fast enough that state already moved on),
+        // the controllerchange firing on activate is unambiguous.
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (reloading) return;
+          reloading = true;
+          if (typeof umami !== 'undefined') {
+            umami.track('sw-controllerchange-reload');
+          }
+          window.location.reload();
+        });
 
         function track(event, data) {
           if (typeof umami !== 'undefined') umami.track(event, data);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,27 +60,38 @@ module.exports = (env, argv) => {
       ...(isProduction ? [
         new GenerateSW({
           swDest: 'sw.js',
-          // skipWaiting ON, clientsClaim OFF.
+          // skipWaiting + clientsClaim, both ON. This is the pre-audit
+          // configuration, restored after a real-world failure mode
+          // surfaced in iOS Safari standalone PWAs and prod Mac Safari:
           //
-          // The fully message-driven activation flow (skipWaiting: false +
-          // SKIP_WAITING postMessage) is correct in principle but unsafe to
-          // ship in a single PR: every client currently installed is running
-          // the OLD `sw-register.js` — which only knows `location.reload()`,
-          // not the message handshake. With auto-skipWaiting off, those
-          // old reloads do nothing (new SW stays in `waiting` forever),
-          // and the user is stranded on the previous build with no path
-          // forward. Telemetry post-deploy showed exactly that: zero
-          // `sw-*` events recorded because no client ever made it to the
-          // new code.
+          // With `clientsClaim: false` the new SW activates but does NOT
+          // claim the open tabs. The previous active SW transitions to
+          // `redundant`, and WebKit (per its current implementation)
+          // returns `null` from `navigator.serviceWorker.controller`
+          // when the controlling SW is redundant and no successor has
+          // claimed the client. Both the OLD and NEW `sw-register.js`
+          // gate the update banner on `controller` being truthy
+          // (to distinguish "first install" from "update available"),
+          // so the banner was never shown to anyone running with the
+          // previous deploy still in their precache.
           //
-          // `skipWaiting` alone is fine; the mid-session controller flip
-          // that motivated the audit was driven by `clientsClaim`, not
-          // `skipWaiting`. With clientsClaim off the new SW becomes the
-          // registration's active worker on install but does NOT claim
-          // existing tabs — they keep running on the old SW until the
-          // user explicitly reloads (via the banner or otherwise).
+          // With `clientsClaim: true` the new SW immediately controls
+          // the open tabs, `controller` flips from old → new (both
+          // truthy), the gated banner check passes, and we additionally
+          // get a `controllerchange` event the page can use to reload
+          // itself (see sw-register.js).
+          //
+          // The chunk-404 risk that originally motivated dropping
+          // `clientsClaim` doesn't apply to this app: we have zero
+          // dynamic imports (verified by `grep -rn 'import(' src/`),
+          // so the in-memory page never refetches its JS bundles
+          // after the controller flips. Lazy non-JS fetches
+          // (radars-finland.json, airfields-finland.json,
+          // airspace-finland.json) are plain non-hashed filenames and
+          // exist under the same URL in the new precache.
           maximumFileSizeToCacheInBytes: 5000000, // 5MB
           skipWaiting: true,
+          clientsClaim: true,
           // Activate-time cleanup of stale Workbox precache caches.
           // Safe in this app because nothing is lazily code-split — all
           // JS is loaded at startup, so the running tab doesn't need


### PR DESCRIPTION
## Summary
After PR #88 the update banner stopped firing on iOS standalone PWAs and on Mac Safari for the production URL. Diagnosis:

With `clientsClaim: false` + `skipWaiting: true` (PR #88's config), the new SW activates but does NOT claim open tabs. The previously active SW transitions to `redundant`. **WebKit returns `null` from `navigator.serviceWorker.controller` when the controlling SW is redundant and no successor has claimed the client.** Both the OLD and the NEW `sw-register.js` gate the update-banner condition on `navigator.serviceWorker.controller` being truthy (the way they distinguish a first install from an update), so the banner is silently suppressed for everyone whose previous SW just went redundant. The user-reported pattern matches exactly:

| Surface | Behavior |
|---|---|
| Mac Safari preview channels (fresh SW each visit) | banner shows ✅ |
| Mac Safari production (older SW going redundant) | no banner ❌ |
| iOS PWA standalone | no banner ❌ |

## Fix

- **`webpack.config.js`** — `clientsClaim: true` added back. The new SW claims the tab on activate, controller flips old→new (both truthy), the gated banner check passes, AND we get a `controllerchange` event to drive a clean reload.
- **`assets/sw-register.js`** — `controllerchange` listener that reloads exactly once (guarded by a `reloading` flag) when the new SW takes control. Belt-and-suspenders against any remaining statechange-timing quirks. Also tracks `sw-controllerchange-reload` so we can see which path drove each update (banner-click vs auto).

## Why the audit's original concern doesn't apply here
The chunk-404 risk that motivated dropping `clientsClaim` doesn't apply to this app — `grep -rn 'import(' src/` returns zero hits, so the in-memory page never refetches its JS bundles after the controller flips. Lazy non-JS fetches go to plain non-hashed filenames (`radars-finland.json`, `airfields-finland.json`, `airspace-finland.json`, etc.) that exist under the same URL in the new precache, so a cache miss falls through to network successfully.

## Test plan
- [ ] After deploy, watch umami `sw-update-shown` count rise on the next subsequent deploy.
- [ ] iOS PWA: open with old SW installed, deploy a new build, watch the banner appear within ~10 min — or the page silently auto-reloads via `controllerchange`.
- [ ] Mac Safari prod: same — banner OR auto-reload, no more silent staleness.
- [ ] Check console: `ServiceWorker registered with scope:` appears once per session, no SW errors.
- [ ] Telemetry: `sw-controllerchange-reload` should fire roughly when banner-click rates drop (auto-reload path replacing manual click for some users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)