### PR TITLE
perf: stop refetching the whole WMS window on every pan (#92)

### DIFF
--- a/src/animation/framePool.js
+++ b/src/animation/framePool.js
@@ -632,26 +632,38 @@ export default class FramePool {
     this.warpLayer.getSource().changed();
   }
 
-  // Run once per debounced moveend. Drops OL's cached image wrapper
-  // on every slot source (so OL re-creates a fresh wrapper at the
-  // current view), checks each slot's loaded state against the new
-  // view, invalidates interpolator frames whose stickies no longer
-  // cover, then triggers prefetch around the current frame.
+  // Run once per debounced moveend. When an interpolator is attached,
+  // drops OL's cached image wrapper on every slot source (so OL
+  // re-creates a fresh wrapper at the current view). Then checks each
+  // slot's loaded state against the new view, invalidates interpolator
+  // frames whose stickies no longer cover, then triggers prefetch
+  // around the current frame.
   _handleMoveend() {
     const ctx = this._getViewContext();
     if (ctx) {
-      // First, drop each source's cached ImageWMS wrapper. OL's own
-      // render pipeline calls getImage on the primary layer's source
-      // during a pan, and the cache locks in a wrapper whose extent
-      // reflects the intermediate view. Without this reset, loads
-      // completing on those wrappers would store mid-pan extents
-      // that fail extentApproxEqual against neighbouring slots
-      // (which didn't get render-hit during the pan), and the
-      // interpolator would skip computeFlow for any pair involving
-      // the current slot — visible as two permanently-green cells
-      // on the timeline.
-      for (const slot of this.slots) {
-        slot.source.resetImageCache();
+      // First, drop each source's cached ImageWMS wrapper — but ONLY
+      // when an interpolator is attached. OL's own render pipeline
+      // calls getImage on the primary layer's source during a pan,
+      // and the cache locks in a wrapper whose extent reflects the
+      // intermediate view. Without this reset, loads completing on
+      // those wrappers would store mid-pan extents that fail
+      // extentApproxEqual against neighbouring slots (which didn't
+      // get render-hit during the pan), and the interpolator would
+      // skip computeFlow for any pair involving the current slot —
+      // visible as two permanently-green cells on the timeline.
+      //
+      // With no interpolator (interpMode 'off', the default) that
+      // failure mode cannot occur, and resetting here is pure loss:
+      // it nulls OL's containsExtent image-reuse, so the very next
+      // hasLoadedImageForView call below is a guaranteed cache miss
+      // and the whole window refetches — even for a pan that stayed
+      // well inside the 1.5x fetch buffer. Keeping the cache lets a
+      // within-buffer pan reuse the already-loaded image with no
+      // new GetMap request. See issue #92.
+      if (this.interpolator) {
+        for (const slot of this.slots) {
+          slot.source.resetImageCache();
+        }
       }
       for (const slot of this.slots) {
         if (!slot.time) continue; // eslint-disable-line no-continue


### PR DESCRIPTION
Fixes #92.

## Problem

`FramePool._handleMoveend` unconditionally called `resetImageCache()` on all 13 slot sources on **every** debounced pan (`framePool.js:653-655`). `resetImageCache` nulls `this.image` + `wantedExtent_/Resolution_/Projection_`, killing OpenLayers' `containsExtent` image-reuse — so the immediately-following `hasLoadedImageForView()` is a guaranteed cache miss, `slot.loaded` flips to `false`, and the entire 13-frame window refetches at the new extent.

This defeats the entire point of `imageRatio: 1.5`: each `GetMap` already covers 1.5× the viewport per axis specifically so a small pan stays inside the loaded image and needs **no request**. Today that buffer's bandwidth cost (2.25× pixels) is paid on every fetch while delivering zero pan savings.

## Fix

`resetImageCache` is only *needed* when an interpolator is attached — a mid-pan wrapper extent would otherwise fail the interpolator's extent-equality check and make it skip `computeFlow` (the "two permanently-green timeline cells" bug). For the default user (`interpMode` `'off'`, no interpolator) the reset is pure loss.

Guard the `resetImageCache` loop on `this.interpolator`:

- **No interpolator (default):** OL's cached 1.5× image survives a pan. A pan within the buffer reuses it → no `GetMap`. A pan beyond the buffer still misses → refetches, as before.
- **Interpolator attached:** behaviour unchanged — the reset still runs.

## Impact

A within-buffer pan goes from up to ~13 `GetMap` × visible layers down to **0** requests against the FMI / EUMETSAT / meteo.fi backends. Pans beyond the buffer are unaffected.

## Testing

- `npm run lint` — clean
- `npm run build` — succeeds (only pre-existing bundle-size warnings)
- Logic: with no interpolator, the `resetImageCache` loop is skipped; `hasLoadedImageForView` re-evaluates each slot against the final view extent via OL's native `containsExtent`, so `slot.loaded` and prefetch still react correctly to pans that leave the buffer. `invalidateSlot` inside the second loop is already `this.interpolator`-guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)