### PR TITLE
perf: route WMS GetCapabilities HTTP errors into the backoff (#93)

### DIFF
--- a/src/radar.js
+++ b/src/radar.js
@@ -2053,7 +2053,16 @@ function getWMSCapabilities(wms, failCountArg = 0) {
 
   fetch(`${wms.url}?SERVICE=WMS&version=1.3.0&request=GetCapabilities${namespace}${layerParam}`, {
     signal: controller.signal,
-  }).then((response) => response.text()).then((text) => {
+  }).then((response) => {
+    // An HTTP error (typically 5xx from an overloaded WMS server)
+    // still resolves the fetch — without this check the error body
+    // flows on to .text()/parser.read, fails the structure check
+    // silently, and .finally reschedules at the flat full rate. The
+    // exponential backoff below only ever engages via .catch, so
+    // throwing here is what routes 4xx/5xx into the backoff.
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return response.text();
+  }).then((text) => {
     clearTimeout(timeoutId);
     debug(`Received WMS Capabilities ${wms.url}`);
     failCount = 0;


### PR DESCRIPTION
Fixes #93.

## Problem

`getWMSCapabilities` did `fetch(...).then(response => response.text())` with **no `response.ok` check** (`radar.js:2054-2056`). An HTTP 5xx — the common WMS server-overload mode — resolves the fetch *successfully*:

1. The error body reaches `parser.read`.
2. It fails the `Capability.Layer.Layer` structure check → silent `else` branch (`debug` only).
3. `failCount` was already reset to `0` at the top of the success `.then`.
4. `.finally` sees `failCount === 0` → reschedules at the flat full refresh rate (60s radar / 300s others).

The exponential backoff (`refresh`, 2×, 4×, max 5 min) only ever engages via `.catch`, which fires solely on network errors / aborts / timeouts. So a degraded endpoint returning 5xx keeps getting polled at full cadence indefinitely — the backoff is **dead for exactly the case it was built for**.

`StickyImageWMS` already checks `res.ok`, confirming this is an oversight, not intentional.

## Fix

Throw on `!response.ok` before `.text()`, so HTTP 4xx/5xx flow into `.catch`, increment `failCount`, and engage the existing backoff:

```js
}).then((response) => {
  if (!response.ok) throw new Error(`HTTP ${response.status}`);
  return response.text();
}).then((text) => {
```

The success path resets `failCount` to `0` only when a real caps document arrives; an HTTP error now throws *before* that reset, so `.catch` correctly increments and `.finally` applies the backoff.

## Impact

When an FMI / EUMETSAT / meteo.fi WMS endpoint is degraded and returning 5xx, clients now back off (up to 5 min between polls) instead of hammering the struggling backend at full rate.

## Scope

Strictly the `response.ok` check, as scoped in #93. The `else` branch for a *valid HTTP 200 with an unexpected body structure* is left as-is — after this fix a 5xx no longer reaches it.

## Testing

- `npm run lint` — clean
- `npm run build` — succeeds (only pre-existing bundle-size warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)