### PR TITLE
fix: skip applyWireFormat until the sublayer's caps are known

### DIFF
--- a/src/radar.js
+++ b/src/radar.js
@@ -1173,7 +1173,14 @@ function resolveFormat(layer, info) {
 // via its primary-source `change` listener.
 function applyWireFormat(layer) {
   const wmslayer = layer.getSource().getParams().LAYERS;
-  const fmt = resolveFormat(layer, layerInfo[wmslayer]);
+  const info = layerInfo[wmslayer];
+  // Until this sublayer's own GetCapabilities has populated layerInfo we
+  // don't yet know whether its server advertises webp. Leave FORMAT at
+  // the constructor default rather than churning it to png now and to
+  // webp later — the intermediate updateParams triggers a needless
+  // FramePool resync and an extra round of slot re-requests at startup.
+  if (!info) return;
+  const fmt = resolveFormat(layer, info);
   if (layer.getSource().getParams().FORMAT !== fmt) {
     layer.getSource().updateParams({ FORMAT: fmt });
   }


### PR DESCRIPTION
Follow-up review fix for `cfcf55d` ("perf: request image/webp from WMS servers that advertise it").

## Finding

`applyWireFormat` runs for all 4 category layers after **every** `GetCapabilities` response. If a non-radar caps response lands before meteocore's, the radar sublayer has no `layerInfo` entry yet, so `resolveFormat` falls back to `image/png`. Because the radar source carries no `FORMAT` param at construction (`getParams().FORMAT === undefined`), the guard `undefined !== 'image/png'` is true and it does `updateParams({ FORMAT: 'image/png' })`.

That intermediate write fires a FramePool primary-source `change` event → a full 13-slot param resync + an extra round of slot re-requests at startup — only to be redone moments later when meteocore's caps arrive and `FORMAT` flips to `image/webp`. Ironic churn for a bandwidth-reduction change.

## Fix

Return early from `applyWireFormat` when the current sublayer has no `layerInfo` entry yet. `FORMAT` stays at the constructor default until the sublayer's **own** caps response populates `layerInfo`, then `applyWireFormat` (called in that same handler, after `getLayers`) sets the final value — `png` or `webp` — in a single transition.

## Review notes on cfcf55d (the rest checks out)

- webp detection is correct — OL's `WMSCapabilities` parser exposes `Capability.Request.GetMap.Format` as a string array; meteocore advertises `image/webp`, the GeoServer endpoints (wms.meteo.fi, wms-obs, EUMETSAT) don't.
- `defaultFormat` values match each layer's constructor params → the new always-set `FORMAT` path is a true no-op for non-webp servers.
- FramePool mirrors `FORMAT` to its slots via the existing `change` listener; `flowInvariant` correctly excludes `FORMAT` so the interpolator flow cache survives a format change.
- Note (not a code issue): meteocore serves **lossy** webp (VP8 + alpha) — 227 kB vs 995 kB png for a sample radar tile (−77%). Worth confirming the lossy quality is acceptable for colormapped dBZ data, or tuning meteocore toward lossless/high-quality webp.

## Testing

`npm run lint` clean; `npm run build` succeeds (pre-existing bundle-size warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)