### PR TITLE
fix: skip the service-worker reload on first visit (#96)

### DIFF
--- a/assets/sw-register.js
+++ b/assets/sw-register.js
@@ -17,6 +17,14 @@
 // `registration.waiting` / `.installing` synchronously after register.
 
 if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
+  // Whether THIS page navigation started under SW control. Captured
+  // synchronously now: false on a first-ever visit (the page loaded
+  // uncontrolled), true on a return visit. `navigator.serviceWorker
+  // .controller` never changes until a `controllerchange` event fires,
+  // so this is a race-free first-install vs. genuine-update
+  // discriminator for the controllerchange handler. See issue #96.
+  const hadController = !!navigator.serviceWorker.controller;
+
   // Self-heal must attach as early as possible — a deferred bundle 404
   // can fire its error event before window.load. We still miss anything
   // that errors before sw-register.js executes, but this catches lazy
@@ -62,16 +70,28 @@ if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
         let bannerShown = false;
         let reloading = false;
 
-        // The SW config has clientsClaim: true, so when the new worker
+        // The SW config has clientsClaim: true, so when a new worker
         // activates it immediately takes control of this tab and fires
-        // `controllerchange`. Reload exactly once at that point — gives
-        // a fresh navigation served by the new precache. Belt-and-
-        // suspenders against statechange timing quirks: even if the
-        // statechange handler below misses 'installed' (e.g. WebKit
-        // dispatching events fast enough that state already moved on),
-        // the controllerchange firing on activate is unambiguous.
+        // `controllerchange`. Reload once at that point — but ONLY for a
+        // genuine update (hadController), never the first-ever install,
+        // where controllerchange just means clientsClaim() took control
+        // of an already-current page. Belt-and-suspenders against
+        // statechange timing quirks: even if the statechange handler
+        // below misses 'installed' (e.g. WebKit dispatching events fast
+        // enough that state already moved on), controllerchange on
+        // activate is an unambiguous update signal.
         navigator.serviceWorker.addEventListener('controllerchange', () => {
           if (reloading) return;
+          // First-ever visit: the page loaded uncontrolled and is
+          // already running current code straight from the network.
+          // Reloading here is pure waste — a full re-parse + re-boot
+          // (OpenLayers, the OL Map, all FramePools) and re-issued
+          // GetCapabilities fetches. Skip it; the precache is in place
+          // for the NEXT navigation anyway.
+          if (!hadController) {
+            swTrack('sw-controllerchange-firstinstall');
+            return;
+          }
           reloading = true;
           swTrack('sw-controllerchange-reload');
           window.location.reload();


### PR DESCRIPTION
Fixes #96.

## Problem

The `controllerchange` handler in `assets/sw-register.js` reloaded **unconditionally** — its only guard was the `reloading` re-entry flag, with no first-install check.

On a first-ever visit the page loads uncontrolled; `register('/sw.js')` resolves, the SW installs and activates, and Workbox's `clientsClaim()` runs `clients.claim()`, which fires `controllerchange` on the just-loaded page (uncontrolled → controlled). The handler reloaded — but this is a **first install, not an update**: the page is already running current code straight from the network.

The reload is pure waste: a full re-parse + re-boot (OpenLayers, the OL `Map`, all 4 `FramePool`s / ~52 `ImageLayer`s) plus re-issued `GetCapabilities` fetches, with a visible flash — and it hits **100% of first-time visitors** (and every visit after a cache clear / new device / new browser).

`showUpdateBanner` already makes the first-install-vs-update distinction via `navigator.serviceWorker.controller` (`watchWorker`, line ~105); the reload handler omitted that exact check.

## Fix

Capture `hadController = !!navigator.serviceWorker.controller` synchronously at script-execution time:

- **first visit** → `false` (page loaded uncontrolled)
- **return visit** → `true` (page loaded under the existing SW)

`controller` never changes until a `controllerchange` event, so capturing it up front is a race-free discriminator. The handler now reloads only when `hadController` is `true` (replacing a *prior* controller = genuine update). On first install it emits an `sw-controllerchange-firstinstall` telemetry event and returns — no reload.

Genuine updates are unaffected: the page loaded controlled by the old worker, `hadController` is `true`, the reload still fires (and the `statechange` → banner path remains as backup).

## Testing

- `node --check assets/sw-register.js` — valid
- `npx eslint assets/sw-register.js` — 0 errors (6 pre-existing `no-console` warnings, none new)
- `npm run build` — succeeds

Note: `sw-register.js` runs only on non-localhost, so it can't be exercised by the dev server — verification is by code trace. Worth a manual check in a fresh/incognito profile: first load should *not* double-reload; a subsequent deploy should still reload once.

Part of performance epic #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)