### PR TITLE
Radar: opt out of webp wire format

### DIFF
--- a/src/radar.js
+++ b/src/radar.js
@@ -574,6 +574,13 @@ const radarLayer = new ImageLayer({
 // image/webp when the serving WMS advertises it in GetCapabilities (see
 // resolveFormat) — this is the fallback for servers that don't.
 radarLayer.set('defaultFormat', 'image/png');
+// Opt out of the webp wire format for radar specifically. Lossless webp
+// encoding on the meteocore server side is currently too slow to keep up
+// with retina-fullscreen request sizes; image/png is cached and served
+// more cheaply on that path. Revisit once requests are clamped to the
+// radar's native resolution (then payload size is bounded and the
+// encoding-time cost of lossless webp becomes worth the smaller bytes).
+radarLayer.set('disableWebp', true);
 
 // Lightning Layer
 const lightningLayer = new ImageLayer({
@@ -1161,7 +1168,7 @@ function removeSelectedParameter(selector) {
 // to one that lacks it resets FORMAT instead of leaving a stale webp.
 function resolveFormat(layer, info) {
   if (info && info.format) return info.format;
-  if (info && info.webp) return 'image/webp';
+  if (info && info.webp && !layer.get('disableWebp')) return 'image/webp';
   return layer.get('defaultFormat') || 'image/png';
 }
 


### PR DESCRIPTION
## Summary
Lossless webp encoding on the meteocore server is currently too slow to keep up with retina-fullscreen WMS request sizes (~5760×3240 px after `ratio: 1.5` inflation on a 4K display). Even though the bytes-on-wire are smaller, the server-side encoding latency hurts playback. PNG is served more cheaply on that path right now.

Disable webp for the **radar category specifically** — satellite / lightning / observation keep their current webp-when-advertised behaviour (none of those are served by meteocore and the GeoServer endpoints don't advertise webp anyway, so practically this is a radar-only revert).

## Changes
- `radarLayer.set('disableWebp', true)` at construction in `src/radar.js`. Documented with a comment that says when to flip it back.
- `resolveFormat(layer, info)` checks the new flag before promoting `info.webp` to `image/webp`. Falls back to `defaultFormat` (`image/png`) for radar from now on.

Single-line revert when we re-enable: delete the `radarLayer.set('disableWebp', true)` line.

## Follow-up
Once GetMap request sizes are clamped to each radar layer's native resolution (the planned per-layer `nativeResolutionMeters` change), request payload is bounded — encoding cost of lossless webp becomes worth the smaller bytes again, and this flag should come off.

## Test plan
- [ ] Network panel after deploy: radar GetMap requests come back as `image/png` again (was `image/webp` for the meteocore nations).
- [ ] Other categories unaffected — verify `image/jpeg` still on satellite full-disc RGBs, `image/png` + `TRANSPARENT=TRUE` on MSG RDT, etc.
- [ ] Playback responsiveness on radar visibly improves at fullscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)