### PR TITLE
fix: normalize EDR probe coordinates to avoid HTTP 400

### DIFF
--- a/src/probe.js
+++ b/src/probe.js
@@ -25,6 +25,16 @@ const EDR_COLLECTIONS = new Set([
 const Y_MIN_DBZ = 0;
 const Y_MAX_DBZ = 50;
 
+// OpenLayers hands back longitudes outside [-180, 180] when the map is panned
+// across world copies (e.g. lon 360.0017 for a point that is really near 0°).
+// The EDR server rejects those with HTTP 400, so wrap longitude into [-180, 180)
+// and clamp latitude into [-90, 90] before any coordinate reaches a query.
+function normalizeLonLat(lon, lat) {
+  const wrappedLon = ((((lon + 180) % 360) + 360) % 360) - 180;
+  const clampedLat = Math.max(-90, Math.min(90, lat));
+  return [wrappedLon, clampedLat];
+}
+
 const CACHE_TTL_MS = 60000;
 const CACHE_MAX = 20;
 const cache = new Map(); // insertion-ordered: oldest entry is first
@@ -330,7 +340,8 @@ export default function initProbe({ container, onValueChange }) {
 
   return {
     setPin(lonLat) {
-      pin = (lonLat && lonLat.length === 2) ? [lonLat[0], lonLat[1]] : null;
+      pin = (lonLat && lonLat.length === 2)
+        ? normalizeLonLat(lonLat[0], lonLat[1]) : null;
       recompute();
     },
     setActiveLayer(wmslayer) {


### PR DESCRIPTION
## Problem

When the map is panned across world copies, OpenLayers hands back longitudes outside `[-180, 180]` — e.g. `POINT(360.0017 53.2128)` for a point that is really near `0.0017°`. The meteocore EDR server rejects these out-of-range coordinates with **HTTP 400**, so the single-pin probe chart silently failed to load for those clicks:

```
GET /edr/collections/fmi-radar-composite-dbz/position → 400
  ?coords=POINT(360.0017 53.2128)&...
```

## Fix

Normalize at the `setPin()` boundary in `src/probe.js`:
- Wrap longitude into `[-180, 180)` via `((lon + 180) mod 360) - 180`
- Clamp latitude into `[-90, 90]` defensively

The normalized value flows into **both** the `coords=POINT(...)` query and the cache key, so clicking the "same" geographic point in different world copies now reuses one cache entry instead of issuing duplicate failing requests.

## Marker is unaffected

The visible map marker is drawn from the raw projected click coordinate in `src/tools.js` (`markerFeature` geometry + card overlay via `fromLonLat`). The normalization lives strictly downstream of that, inside the probe's HTTP query path only — so the pin still appears exactly where the user clicked.

## Test plan

- [x] `npx eslint src/probe.js` passes
- [ ] Pan east past the antimeridian, drop a pin over a radar-covered area, confirm the probe chart loads (no 400 in the network tab)