### PR TITLE
Teach long-press menu via discovery hint on the coachmark

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -499,6 +499,10 @@ html, body {
     left: 50%;
     transform: translateX(-50%);
     z-index: 130;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
     padding: 6px 12px;
     background: rgba(0, 0, 0, 0.85);
     color: var(--dark-high-emphasis-text-color);
@@ -516,6 +520,12 @@ html, body {
   }
   #coachmark.show { opacity: 1; }
   #coachmark[hidden] { display: none; }
+  #coachmark .coach-hint {
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--dark-medium-emphasis-text-color);
+  }
+  #coachmark .coach-hint[hidden] { display: none; }
 
 
   #timecontrol {

--- a/src/index.html
+++ b/src/index.html
@@ -125,7 +125,10 @@
     <i id="gpsStatus" class="material-icons" aria-hidden="true">gps_not_fixed</i>
   </button>
 
-  <div id="coachmark" aria-live="polite" hidden></div>
+  <div id="coachmark" aria-live="polite" hidden>
+    <span class="coach-title"></span>
+    <span class="coach-hint" hidden></span>
+  </div>
 
   <div id="toolChip" class="tool-chip" role="status" hidden>
     <i class="material-icons chip-icon" aria-hidden="true">straighten</i>

--- a/src/longpress.js
+++ b/src/longpress.js
@@ -8,9 +8,10 @@
  * @param {Function} onSelect - called with the selected menu item's data-layer value
  * @param {Function} getActiveLayer - returns the current active WMS layer name for highlighting
  * @param {Function} isLayerVisible - returns whether the layer is currently visible
+ * @param {Function} [onMenuShown] - called whenever the long-press menu opens
  * @returns {{ show: Function, hide: Function }}
  */
-function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLayer, isLayerVisible) {
+function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLayer, isLayerVisible, onMenuShown) {
   let timer = null;
   let triggered = false;
   let startTime = 0;
@@ -39,6 +40,7 @@ function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLaye
     menu.style.left = `${left}px`;
     menu.style.top = `${top}px`;
     menu.style.visibility = 'visible';
+    if (onMenuShown) onMenuShown();
   }
 
   function hideMenu() {

--- a/src/radar.js
+++ b/src/radar.js
@@ -1565,6 +1565,10 @@ function toggleLayerVisibility(layer, source) {
   }
 }
 
+// Whether the user has already opened a long-press menu (persisted), so the
+// discovery hint in the coachmark stops appearing once the gesture is learned.
+let longPressDiscovered = safeParseJSON('LP_HINT_SEEN', false);
+
 // Toggle wrapper for segment-originated actions (button taps + keyboard
 // shortcuts). Announces the Finnish layer name via coachmark only when the
 // toggle turned the layer on. Deliberately not used by the playlist eye icon
@@ -1574,7 +1578,11 @@ function toggleAndAnnounce(layer, segId, source) {
   if (layer.getVisible()) {
     const seg = document.getElementById(segId);
     if (seg && typeof showCoachmark === 'function') {
-      showCoachmark(seg.getAttribute('data-name'));
+      // Teach the long-press menu on real button taps, until the user discovers
+      // it. Keyboard shortcuts (source: 'key') skip the "hold the button" hint.
+      showCoachmark(seg.getAttribute('data-name'), {
+        longPressHint: source === 'button' && !longPressDiscovered,
+      });
     }
   }
 }
@@ -1744,7 +1752,10 @@ document.getElementById('lightningLayerTitle').addEventListener('mouseup', () =>
   toggleLayerVisibility(lightningLayer, 'playlist');
 });
 
-// Long press menus for layer buttons
+// Long press menus for layer buttons. Opening any menu dismisses a lingering
+// discovery hint and records that the gesture has been learned.
+const onLongPressDiscovered = () => { hideCoachmarkNow(); markLongPressDiscovered(); };
+
 const observationMenu = createLongPressHandler(
   'observationLayerButton',
   'observationLongPressMenu',
@@ -1752,6 +1763,7 @@ const observationMenu = createLongPressHandler(
   (id) => { updateLayer(observationLayer, id, { source: 'longpress' }); observationMenu.hide(); },
   () => observationLayer.getSource().getParams().LAYERS,
   () => observationLayer.getVisible(),
+  onLongPressDiscovered,
 );
 
 const satelliteMenu = createLongPressHandler(
@@ -1761,6 +1773,7 @@ const satelliteMenu = createLongPressHandler(
   (id) => { updateLayer(satelliteLayer, id, { source: 'longpress' }); satelliteMenu.hide(); },
   () => satelliteLayer.getSource().getParams().LAYERS,
   () => satelliteLayer.getVisible(),
+  onLongPressDiscovered,
 );
 
 const radarMenu = createLongPressHandler(
@@ -1770,6 +1783,7 @@ const radarMenu = createLongPressHandler(
   (id) => { updateLayer(radarLayer, id, { source: 'longpress' }); radarMenu.hide(); },
   () => radarLayer.getSource().getParams().LAYERS,
   () => radarLayer.getVisible(),
+  onLongPressDiscovered,
 );
 
 const lightningMenu = createLongPressHandler(
@@ -1779,6 +1793,7 @@ const lightningMenu = createLongPressHandler(
   (id) => { updateLayer(lightningLayer, id, { source: 'longpress' }); lightningMenu.hide(); },
   () => lightningLayer.getSource().getParams().LAYERS,
   () => lightningLayer.getVisible(),
+  onLongPressDiscovered,
 );
 
 // Overflow menu (three-dots) — open/close + theme chip wiring
@@ -1969,12 +1984,26 @@ persistPoiState();
 buildPoiMenuRows();
 
 // Coachmark: briefly surfaces the Finnish layer name after it becomes visible,
-// so icon-only segments stay learnable.
+// so icon-only segments stay learnable. When the long-press menu hasn't been
+// discovered yet, the toast also teaches the hold gesture for ~3 s; the hint
+// stops appearing once any long-press menu has been opened (see LP_HINT_SEEN).
 const coachmarkEl = document.getElementById('coachmark');
+const coachmarkTitleEl = coachmarkEl.querySelector('.coach-title');
+const coachmarkHintEl = coachmarkEl.querySelector('.coach-hint');
+const LONG_PRESS_HINT_TEXT = 'Pidä pohjassa → lisää vaihtoehtoja';
 let coachmarkTimer = null;
-function showCoachmark(text) {
+
+function markLongPressDiscovered() {
+  if (longPressDiscovered) return;
+  longPressDiscovered = true;
+  localStorage.setItem('LP_HINT_SEEN', JSON.stringify(true));
+}
+
+function showCoachmark(text, { longPressHint = false } = {}) {
   if (!text) return;
-  coachmarkEl.textContent = text;
+  coachmarkTitleEl.textContent = text;
+  coachmarkHintEl.textContent = longPressHint ? LONG_PRESS_HINT_TEXT : '';
+  coachmarkHintEl.hidden = !longPressHint;
   coachmarkEl.hidden = false;
   coachmarkEl.getBoundingClientRect();
   coachmarkEl.classList.add('show');
@@ -1984,7 +2013,15 @@ function showCoachmark(text) {
     setTimeout(() => {
       if (!coachmarkEl.classList.contains('show')) coachmarkEl.hidden = true;
     }, 220);
-  }, 1400);
+  }, longPressHint ? 3000 : 1400);
+}
+
+// Immediately tear down the coachmark — used when a long-press succeeds so the
+// "hold the button" hint doesn't linger after the gesture has been performed.
+function hideCoachmarkNow() {
+  if (coachmarkTimer) clearTimeout(coachmarkTimer);
+  coachmarkEl.classList.remove('show');
+  coachmarkEl.hidden = true;
 }
 
 document.addEventListener('keyup', (event) => {


### PR DESCRIPTION
## Problem

The four top layer buttons (Satelliitti, Säätutka, Salamat, Havainto) each hide a **long-press menu** for picking a layer variant (e.g. radar: Suomi / RATE / Eurooppa / …). Users have a hard time discovering the gesture — the only affordance today is the subtle indicator bar under each segment.

## Approach

Extend the existing **coachmark** toast (already shown below the toolbar when a layer button turns a layer on) to also teach the hold gesture. When a layer button is tapped, the toast adds a dim second line — `Pidä pohjassa → lisää vaihtoehtoja` — and stays for ~3 s instead of 1.4 s.

To avoid nagging regulars, the hint stops appearing once the user opens any long-press menu, persisted via a new `LP_HINT_SEEN` localStorage flag. Opening a menu also dismisses a lingering hint immediately.

## Behaviour

- Tap a layer button (turning it on) → toast shows the layer name **and** the hold hint for ~3 s.
- Long-press a button → menu opens, any visible hint vanishes instantly, and the hint is permanently retired (persists across reloads).
- Keyboard layer shortcuts (`source: 'key'`) and turning a layer **off** show no hint — unchanged.

## Changes

- `src/index.html` — split `#coachmark` into `.coach-title` + dim `.coach-hint`.
- `assets/radar.css` — coachmark becomes a centered column; `.coach-hint` styled (11px, dim). Name-only display is visually unchanged.
- `src/longpress.js` — `createLongPressHandler` takes an optional `onMenuShown` callback, fired when a menu opens.
- `src/radar.js` — `showCoachmark(text, { longPressHint })`; `toggleAndAnnounce` passes the hint only for undiscovered button taps; opening a menu calls `hideCoachmarkNow()` + `markLongPressDiscovered()`. Finnish wording lives in one constant (`LONG_PRESS_HINT_TEXT`).

## Verification

- `npm run build` and ESLint both pass.
- Manual: `npm run dev`, clear `LP_HINT_SEEN` in DevTools, tap each of the 4 buttons (name + hint, ~3 s, two-line layout), long-press one (menu opens, hint stops appearing afterward), confirm keyboard shortcuts show no hint.

## Further ideas (not in this PR)

▾ chevron affordance on the segments, desktop right-click (`contextmenu`) to open the same menu, and press-and-hold fill feedback during the 500 ms hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)