### PR TITLE
feat: radar menu cleanup, fit-to-coverage, and Czech radar

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -195,6 +195,15 @@ const wmsServerConfiguration = {
     license: 'CC-BY-4.0',
     disabled: false,
   },
+  cz: {
+    url: 'https://meteocore.app.meteo.fi/wms',
+    layer: 'chmi-radar-composite-dbz',
+    refresh: 60000,
+    category: 'radarLayer',
+    attribution: 'CHMI',
+    license: 'CC-BY-4.0',
+    disabled: false,
+  },
   vn: {
     url: 'https://vietnam.smartmet.fi/wms',
     namespace: 'vnmha:radar',

--- a/src/index.html
+++ b/src/index.html
@@ -294,16 +294,16 @@
   <!-- Long press satellite parameter menu -->
   <div id="satelliteLongPressMenu">
     <div class="menu-item" data-layer="rgb_eview">
-      <span class="menu-label">HRV</span>
+      <span class="menu-label">Yö/päivä</span>
     </div>
     <div class="menu-item" data-layer="rgb_convection">
-      <span class="menu-label">CNV</span>
+      <span class="menu-label">Konvektio</span>
     </div>
     <div class="menu-item" data-layer="rgb_naturalenhncd">
-      <span class="menu-label">Natural</span>
+      <span class="menu-label">Luonnonväri</span>
     </div>
     <div class="menu-item" data-layer="rgb_geocolour">
-      <span class="menu-label">MTG Geo</span>
+      <span class="menu-label">Geo Colour</span>
     </div>
   </div>
 
@@ -311,9 +311,6 @@
   <div id="radarLongPressMenu">
     <div class="menu-item" data-layer="fmi-radar-composite-dbz">
       <span class="menu-label">Suomi</span>
-    </div>
-    <div class="menu-item" data-layer="radar:radar_finland_rr">
-      <span class="menu-label">RATE</span>
     </div>
     <div class="menu-item" data-layer="opera-reflectivity">
       <span class="menu-label">Eurooppa</span>
@@ -329,6 +326,9 @@
     </div>
     <div class="menu-item" data-layer="dwd-radar-composite-dbz">
       <span class="menu-label">Saksa</span>
+    </div>
+    <div class="menu-item" data-layer="chmi-radar-composite-dbz">
+      <span class="menu-label">Tšekki</span>
     </div>
     <div class="menu-item" data-layer="h60b">
       <span class="menu-label">MSG sade</span>

--- a/src/probe.js
+++ b/src/probe.js
@@ -17,6 +17,7 @@ const EDR_COLLECTIONS = new Set([
   'smhi-radar-composite-dbz',
   'dmi-radar-composite-dbz',
   'dwd-radar-composite-dbz',
+  'chmi-radar-composite-dbz',
 ]);
 
 // Fixed visible dBZ range for the chart Y axis. Anything below 0 dBZ

--- a/src/radar.js
+++ b/src/radar.js
@@ -1259,6 +1259,29 @@ function updateLayer(layer, wmslayer, opts = {}) {
   }
 }
 
+// Pan/zoom the map to a layer's advertised coverage. Used by the radar
+// long-press menu so picking e.g. "Ruotsi" recentres on Sweden's radar
+// footprint. No-op until the layer's GetCapabilities has populated a
+// geographic bounding box, or if the transform yields a degenerate extent
+// (e.g. a full-disc box clipped at the Web Mercator poles).
+function fitToLayerExtent(wmslayer) {
+  const info = layerInfo[wmslayer];
+  if (!info || !Array.isArray(info.bbox)) return;
+  const view = map.getView();
+  const extent = transformExtent(info.bbox, 'EPSG:4326', view.getProjection());
+  if (!extent || !extent.every(Number.isFinite)) return;
+  view.fit(extent, {
+    size: map.getSize(),
+    // Leave room for the top toolbar and bottom timeline so the footprint
+    // isn't tucked under the chrome.
+    padding: [60, 30, 90, 30],
+    // Guard against zooming to street level on a tiny footprint; country-
+    // and continent-scale boxes land well below this and are unaffected.
+    maxZoom: 12,
+    duration: 500,
+  });
+}
+
 // Restore the user's previously selected sublayer for one category (e.g.
 // 'radarLayer') after that category's WMS GetCapabilities has populated
 // layerInfo. If the stored layer is no longer advertised by the server,
@@ -1780,7 +1803,11 @@ const radarMenu = createLongPressHandler(
   'radarLayerButton',
   'radarLongPressMenu',
   () => { toggleAndAnnounce(radarLayer, 'radarLayerButton', 'button'); },
-  (id) => { updateLayer(radarLayer, id, { source: 'longpress' }); radarMenu.hide(); },
+  (id) => {
+    updateLayer(radarLayer, id, { source: 'longpress' });
+    fitToLayerExtent(id);
+    radarMenu.hide();
+  },
   () => radarLayer.getSource().getParams().LAYERS,
   () => radarLayer.getVisible(),
   onLongPressDiscovered,
@@ -2260,6 +2287,14 @@ function getLayerInfo(layer, wms, supportsWebp = false) {
     [product.crs] = layer.CRS;
   } else {
     product.crs = 'EPSG:4326';
+  }
+
+  // Geographic coverage advertised in GetCapabilities, as
+  // [minLon, minLat, maxLon, maxLat] in EPSG:4326. Used to pan/zoom the
+  // map to a radar source's footprint when it's picked from the radar
+  // long-press menu (see fitToLayerExtent).
+  if (Array.isArray(layer.EX_GeographicBoundingBox)) {
+    product.bbox = layer.EX_GeographicBoundingBox;
   }
 
   if (typeof wms.title !== 'undefined') {


### PR DESCRIPTION
## Summary

Four related changes to the radar/satellite layer menus:

- **Remove radar RATE item** — drops the `radar_finland_rr` (precipitation-rate) entry from the radar long-press menu. No dangling references remain.
- **Rename satellite menu labels** to plain Finnish: `HRV → Yö/päivä`, `CNV → Konvektio`, `Natural → Luonnonväri`, `MTG Geo → Geo Colour`. The old **HRV** label was also misleading — `rgb_eview` is the day/night cloud RGB, not the high-res visible channel. Layer ids are unchanged; only the visible labels.
- **Fit map to radar coverage** — picking an item from the radar menu now pans/zooms the map to that source's advertised footprint. Captures `EX_GeographicBoundingBox` from GetCapabilities into `layerInfo`, then `view.fit`s with padding (clears the top toolbar / bottom timeline), a `maxZoom 12` guard against over-zooming tiny footprints, and a 500ms animation. No-op if capabilities haven't loaded or the transformed extent is non-finite (full-disc boxes clipped at the Mercator poles). Scoped to the radar menu only.
- **Add Czech (Tšekki) radar** — new `cz` config entry for meteocore `chmi-radar-composite-dbz` (attribution CHMI, CC-BY-4.0) plus a `Tšekki` menu item.

## Verification

- `npx eslint` clean; `npm run build` clean (only pre-existing bundle-size warnings).
- Confirmed against the live server that meteocore advertises `chmi-radar-composite-dbz` and that it carries an `EX_GeographicBoundingBox` (≈ 11.27–19.62 °E, 48.05–51.46 °N), so fit-to-coverage works for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)