### PR TITLE
feat: load radar-site markers from live meteocore collections

### DIFF
--- a/assets/radars-finland.json
+++ b/assets/radars-finland.json
@@ -3,24 +3,24 @@
     "crs": {
         "type": "name",
         "properties": {
-          "name": "EPSG:4326"
+            "name": "EPSG:4326"
         }
-      },
+    },
     "features": [
         {
             "type": "Feature",
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    27.108057,
-                    60.903871,
-                    139
+                    27.10806,
+                    60.90387
                 ]
             },
             "properties": {
-                "name": "Kouvola",
-                "acronym": "ANJ",
-                "country": "fi"
+                "name": "Anjalankoski",
+                "nod": "fianj",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -28,14 +28,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    23.0768,
-                    61.7675
+                    22.50203,
+                    61.81081
                 ]
             },
             "properties": {
                 "name": "Kankaanpää",
-                "acronym": "KAN",
-                "country": "fi"
+                "nod": "fikan",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -43,14 +44,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    27.4439,
-                    68.4344
+                    27.44399,
+                    68.43443
                 ]
             },
             "properties": {
                 "name": "Kaunispää",
-                "acronym": "KAU",
-                "country": "fi"
+                "nod": "fikau",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -58,14 +60,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    29.7977,
-                    61.9070
+                    29.79772,
+                    61.906992
                 ]
             },
             "properties": {
                 "name": "Kesälahti",
-                "acronym": "KES",
-                "country": "fi"
+                "nod": "fikes",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -73,14 +76,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    21.6434,
-                    60.1285
+                    21.64338,
+                    60.12847
                 ]
             },
             "properties": {
-                "name": "Parainen",
-                "acronym": "KOR",
-                "country": "fi"
+                "name": "Korpo",
+                "nod": "fikor",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -88,14 +92,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    27.3815,
+                    27.38147,
                     62.8626
                 ]
             },
             "properties": {
                 "name": "Kuopio",
-                "acronym": "KUO",
-                "country": "fi"
+                "nod": "fikuo",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -103,14 +108,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    26.8969,
+                    26.896916,
                     67.1391
                 ]
             },
             "properties": {
                 "name": "Luosto",
-                "acronym": "LUO",
-                "country": "fi"
+                "nod": "filuo",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -118,15 +124,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    29.44892,
-                    63.83786,
-                    323
+                    29.44893,
+                    63.83786
                 ]
             },
             "properties": {
                 "name": "Nurmes",
-                "acronym": "NUR",
-                "country": "fi"
+                "nod": "finur",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -134,14 +140,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    25.4401,
-                    62.3045
+                    25.44009,
+                    62.30452
                 ]
             },
             "properties": {
                 "name": "Petäjävesi",
-                "acronym": "PET",
-                "country": "fi"
+                "nod": "fipet",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -149,14 +156,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    26.3189,
-                    64.7749
+                    26.31888,
+                    64.77493
                 ]
             },
             "properties": {
                 "name": "Utajärvi",
-                "acronym": "UTA",
-                "country": "fi"
+                "nod": "fiuta",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -164,14 +172,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    24.4956,
-                    60.5562
+                    24.495592,
+                    60.55619
                 ]
             },
             "properties": {
                 "name": "Vihti",
-                "acronym": "VIH",
-                "country": "fi"
+                "nod": "fivih",
+                "country": "fi",
+                "coverage_radius_m": 250000
             }
         },
         {
@@ -179,14 +188,47 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    23.8209,
-                    63.1048
+                    23.82086,
+                    63.10484
                 ]
             },
             "properties": {
                 "name": "Vimpeli",
-                "acronym": "VIM",
-                "country": "fi"
+                "nod": "fivim",
+                "country": "fi",
+                "coverage_radius_m": 250000
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    24.60213,
+                    59.397076
+                ]
+            },
+            "properties": {
+                "name": "Harku",
+                "nod": "eehar",
+                "country": "ee",
+                "coverage_radius_m": 249900
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    25.51866,
+                    58.48231
+                ]
+            },
+            "properties": {
+                "name": "Sürgavere",
+                "nod": "eesur",
+                "country": "ee",
+                "coverage_radius_m": 249900
             }
         }
     ]

--- a/src/radar.js
+++ b/src/radar.js
@@ -610,11 +610,50 @@ const observationLayer = new ImageLayer({
 });
 observationLayer.set('defaultFormat', 'image/png8');
 
+// Radar-site markers track the live radar network rather than a hand-edited
+// file: two meteocore OGC API Features collections are fetched and merged —
+// Finland (fi-radar-pvol) and Estonia (ee-radar-volume). Each feature's
+// `name` is the official station name used for the label. If both live
+// fetches fail (offline PWA, meteocore unreachable), fall back to the bundled
+// snapshot so markers still render. Default 'all' loading strategy → the
+// loader runs once for the world extent.
+const RADAR_SITE_COLLECTIONS = [
+  'https://meteocore.app.meteo.fi/features/collections/fi-radar-pvol/items?f=application/geo%2Bjson&limit=1000',
+  'https://meteocore.app.meteo.fi/features/collections/ee-radar-volume/items?f=application/geo%2Bjson&limit=1000',
+];
+const RADAR_SITE_FALLBACK_URL = 'radars-finland.json';
+
+const radarSiteSource = new Vector({
+  format: new GeoJSON(),
+  attributions: 'FMI / Estonian Environment Agency (CC BY 4.0)',
+  loader: (extent, resolution, projection, success, failure) => {
+    const readInto = (geojson) => {
+      const features = radarSiteSource.getFormat()
+        .readFeatures(geojson, { featureProjection: projection });
+      radarSiteSource.addFeatures(features);
+      return features;
+    };
+    const fetchJson = (url) => fetch(url).then((res) => {
+      if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`);
+      return res.json();
+    });
+
+    Promise.all(RADAR_SITE_COLLECTIONS.map(fetchJson))
+      .then((collections) => success(collections.flatMap(readInto)))
+      .catch((err) => {
+        debug(`Live radar sites unavailable (${err}); using bundled fallback.`);
+        fetchJson(RADAR_SITE_FALLBACK_URL)
+          .then((geojson) => success(readInto(geojson)))
+          .catch(() => {
+            radarSiteSource.removeLoadedExtent(extent);
+            failure();
+          });
+      });
+  },
+});
+
 const radarSiteLayer = new VectorLayer({
-  source: new Vector({
-    format: new GeoJSON(),
-    url: 'radars-finland.json',
-  }),
+  source: radarSiteSource,
   style(feature) {
     radarStyle.getText().setText(feature.get('name'));
     return radarStyle;


### PR DESCRIPTION
## Summary

Radar-site markers now track the **live** radar network instead of a hand-maintained file. A custom OpenLayers `Vector` loader fetches and merges two meteocore OGC API Features collections:

- **Finland** — `fi-radar-pvol` (12 stations)
- **Estonia** — `ee-radar-volume` (2 stations: Harku, Sürgavere)

Reprojects EPSG:4326 → map projection (as the old `url` loader did) and uses the default `all` strategy, so the loader runs once for the world extent.

### Offline fallback
If **both** live fetches fail (offline PWA, meteocore unreachable), it falls back to the bundled `radars-finland.json`. That snapshot is regenerated from the same two collections, so it now also carries the Estonian sites, the official station names, and each radar's `nod` + `coverage_radius_m`.

## Notable behavior change
Live names are the **official station names**, so a few markers relabel — e.g. ANJ → "Anjalankoski" (was "Kouvola"), KOR → "Korpo" (was "Parainen").

## Out of scope (deliberate)
The live data exposes `coverage_radius_m`, but it is **not** wired into the range rings: FI 250000 m vs EE 249900 m is a 100 m difference (imperceptible). Easy follow-up if a radar with materially different coverage is ever added.

## Verification
- `eslint src/radar.js` clean; `npm run build` succeeds (only pre-existing bundle-size warnings).
- Items endpoint CORS is `access-control-allow-origin: *` → browser `fetch` works.
- Merged feature IDs are unique (14/14; FI `fi*` vs EE `ee*`, no collision).
- Only `name` is read from these features anywhere in the code, so the data swap is safe.
- Not browser-verified locally (Chrome automation unavailable on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)