### PR TITLE
feat: drill into a single radar site from its marker

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -1447,17 +1447,28 @@ html, body {
 
 .radar-site-pulse-ring {
   display: block;
+  /* border-box keeps the bordered ring exactly 26px so it stays centered on
+     the marker (content-box would render 30px and sit ~2px off). */
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
   border-radius: 50%;
   border: 2px solid var(--dark-primary-color);
-  box-shadow: 0 0 6px rgba(18, 188, 250, 0.6);
-  animation: radar-site-breathe 1.8s ease-in-out infinite;
+  /* Brightness-led breathing: opacity + glow swing a lot, size barely moves. */
+  animation: radar-site-breathe 3.6s ease-in-out infinite;
 }
 
 @keyframes radar-site-breathe {
-  0%, 100% { transform: scale(0.7); opacity: 0.95; }
-  50% { transform: scale(1.25); opacity: 0.3; }
+  0%, 100% {
+    transform: scale(1.05);
+    opacity: 1;
+    box-shadow: 0 0 9px rgba(18, 188, 250, 0.85);
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.4;
+    box-shadow: 0 0 2px rgba(18, 188, 250, 0.15);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -1453,7 +1453,9 @@ html, body {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  border: 2px solid var(--dark-primary-color);
+  /* Red, not cyan: blue would vanish over the prevailing blueish (low-dBZ)
+     echoes. A thin dark outer shadow keeps it readable over light terrain too. */
+  border: 2px solid #ff2e2e;
   /* Brightness-led breathing: opacity + glow swing a lot, size barely moves. */
   animation: radar-site-breathe 3.6s ease-in-out infinite;
 }
@@ -1462,12 +1464,12 @@ html, body {
   0%, 100% {
     transform: scale(1.05);
     opacity: 1;
-    box-shadow: 0 0 9px rgba(18, 188, 250, 0.85);
+    box-shadow: 0 0 9px rgba(255, 46, 46, 0.85), 0 0 2px rgba(0, 0, 0, 0.6);
   }
   50% {
     transform: scale(1);
     opacity: 0.4;
-    box-shadow: 0 0 2px rgba(18, 188, 250, 0.15);
+    box-shadow: 0 0 2px rgba(255, 46, 46, 0.2), 0 0 1px rgba(0, 0, 0, 0.5);
   }
 }
 

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -1387,6 +1387,55 @@ html, body {
   color: rgba(255, 255, 255, 0.82);
 }
 
+/* Radar-site drill-in card — reuses the .marker-card shell + head/close. */
+.radar-site-card { width: 200px; }
+
+.radar-site-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.radar-site-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--dark-high-emphasis-text-color);
+}
+
+.radar-site-sub {
+  font-size: 12px;
+  color: var(--dark-medium-emphasis-text-color);
+  font-variant-numeric: tabular-nums;
+}
+
+.radar-site-toggle {
+  all: unset;
+  display: block;
+  box-sizing: border-box;
+  margin-top: 4px;
+  padding: 8px 10px;
+  text-align: center;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--dark-high-emphasis-text-color);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.radar-site-toggle:hover { background: rgba(18, 188, 250, 0.14); }
+
+.radar-site-toggle.active {
+  background: var(--dark-primary-color);
+  color: #00131c;
+}
+
+.radar-site-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .marker-card-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -1436,6 +1436,38 @@ html, body {
   cursor: not-allowed;
 }
 
+/* Breathing ring marking the active single-site radar. Anchored center-center
+   on the marker by an OL Overlay; the outer element only sizes/positions, the
+   inner ring runs the animation so it doesn't clash with OL's transform. */
+.radar-site-pulse {
+  width: 26px;
+  height: 26px;
+  pointer-events: none;
+}
+
+.radar-site-pulse-ring {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 2px solid var(--dark-primary-color);
+  box-shadow: 0 0 6px rgba(18, 188, 250, 0.6);
+  animation: radar-site-breathe 1.8s ease-in-out infinite;
+}
+
+@keyframes radar-site-breathe {
+  0%, 100% { transform: scale(0.7); opacity: 0.95; }
+  50% { transform: scale(1.25); opacity: 0.3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .radar-site-pulse-ring {
+    animation: none;
+    transform: scale(1);
+    opacity: 0.9;
+  }
+}
+
 .marker-card-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/assets/radars-finland.json
+++ b/assets/radars-finland.json
@@ -20,7 +20,39 @@
                 "name": "Anjalankoski",
                 "nod": "fianj",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fianj",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -36,7 +68,39 @@
                 "name": "Kankaanpää",
                 "nod": "fikan",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fikan",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -52,7 +116,40 @@
                 "name": "Kaunispää",
                 "nod": "fikau",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fikau",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -68,7 +165,39 @@
                 "name": "Kesälahti",
                 "nod": "fikes",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fikes",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -84,7 +213,37 @@
                 "name": "Korpo",
                 "nod": "fikor",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fikor",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.4,
+                    0.5,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    9.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -100,7 +259,40 @@
                 "name": "Kuopio",
                 "nod": "fikuo",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fikuo",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -116,7 +308,40 @@
                 "name": "Luosto",
                 "nod": "filuo",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-filuo",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.1,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -132,7 +357,40 @@
                 "name": "Nurmes",
                 "nod": "finur",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-finur",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -148,7 +406,40 @@
                 "name": "Petäjävesi",
                 "nod": "fipet",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fipet",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -164,7 +455,40 @@
                 "name": "Utajärvi",
                 "nod": "fiuta",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fiuta",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -180,7 +504,39 @@
                 "name": "Vihti",
                 "nod": "fivih",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fivih",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -196,7 +552,40 @@
                 "name": "Vimpeli",
                 "nod": "fivim",
                 "country": "fi",
-                "coverage_radius_m": 250000
+                "collection": "fi-radar-pvol-fivim",
+                "coverage_radius_m": 250000,
+                "elevation_angles": [
+                    0.3,
+                    0.7,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.5,
+                    8.0,
+                    11.0,
+                    16.0,
+                    25.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "LOG",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -212,7 +601,35 @@
                 "name": "Harku",
                 "nod": "eehar",
                 "country": "ee",
-                "coverage_radius_m": 249900
+                "collection": "ee-radar-volume-eehar",
+                "coverage_radius_m": 249900,
+                "elevation_angles": [
+                    0.5,
+                    1.3,
+                    2.0,
+                    3.0,
+                    4.5,
+                    5.0,
+                    6.5,
+                    9.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "DBZV",
+                    "HCLASS",
+                    "KDP",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "TV",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         },
         {
@@ -228,7 +645,33 @@
                 "name": "Sürgavere",
                 "nod": "eesur",
                 "country": "ee",
-                "coverage_radius_m": 249900
+                "collection": "ee-radar-volume-eesur",
+                "coverage_radius_m": 249900,
+                "elevation_angles": [
+                    0.5,
+                    1.3,
+                    2.0,
+                    3.0,
+                    4.5,
+                    5.0,
+                    6.5,
+                    9.0
+                ],
+                "quantities": [
+                    "CSP",
+                    "DBZH",
+                    "HCLASS",
+                    "KDP",
+                    "PHIDP",
+                    "PMI",
+                    "RHOHV",
+                    "SNR",
+                    "SQIH",
+                    "TH",
+                    "VRADH",
+                    "WRADH",
+                    "ZDR"
+                ]
             }
         }
     ]

--- a/src/probe.js
+++ b/src/probe.js
@@ -1,8 +1,14 @@
-// Single-pin time-series probe for radar mosaic layers.
+// Single-pin time-series probe for radar layers.
 // Backed by meteocore EDR (CoverageJSON).
 //
-// Activates only when a pin is dropped AND the active radar layer's WMS name
-// matches an EDR collection. Otherwise the chart row stays collapsed (height 0).
+// Activates only when a pin is dropped AND the active radar layer maps to an
+// EDR collection. Two cases:
+//   - Composite mosaics (fmi-radar-composite-dbz, …) → identity-mapped EDR
+//     collection, `reflectivity` parameter, no vertical axis.
+//   - Single radar sites, WMS layer "<collection>/<quantity>" (e.g.
+//     fi-radar-pvol-fianj/DBZH) → EDR collection is the prefix, parameter is
+//     the quantity, queried at the displayed elevation angle (z).
+// Otherwise the chart row stays collapsed (height 0).
 
 const ENDPOINT = 'https://meteocore.app.meteo.fi/edr/collections';
 const PARAMETER_NAME = 'reflectivity';
@@ -40,8 +46,8 @@ const CACHE_TTL_MS = 60000;
 const CACHE_MAX = 20;
 const cache = new Map(); // insertion-ordered: oldest entry is first
 
-function cacheKey(collection, lon, lat) {
-  return `${collection}|${lon.toFixed(4)}|${lat.toFixed(4)}`;
+function cacheKey(collection, param, z, lon, lat) {
+  return `${collection}|${param}|${z == null ? '' : z}|${lon.toFixed(4)}|${lat.toFixed(4)}`;
 }
 
 function cacheGet(key) {
@@ -64,11 +70,11 @@ function cacheSet(key, data) {
   }
 }
 
-function parseCoverage(cov) {
+function parseCoverage(cov, param) {
   const ts = cov && cov.domain && cov.domain.axes && cov.domain.axes.t
     ? cov.domain.axes.t.values : null;
-  const vs = cov && cov.ranges && cov.ranges[PARAMETER_NAME]
-    ? cov.ranges[PARAMETER_NAME].values : null;
+  const vs = cov && cov.ranges && cov.ranges[param]
+    ? cov.ranges[param].values : null;
   if (!Array.isArray(ts) || !Array.isArray(vs) || ts.length !== vs.length) {
     return [];
   }
@@ -81,17 +87,20 @@ function parseCoverage(cov) {
   });
 }
 
-async function fetchSeries(collection, lon, lat, startISO, endISO, signal) {
-  const key = cacheKey(collection, lon, lat);
+async function fetchSeries(collection, param, lon, lat, startISO, endISO, z, signal) {
+  const key = cacheKey(collection, param, z, lon, lat);
   const cached = cacheGet(key);
   if (cached) return cached;
-  const url = `${ENDPOINT}/${collection}/position`
-    + `?f=CoverageJSON&parameter-name=${PARAMETER_NAME}`
+  let url = `${ENDPOINT}/${collection}/position`
+    + `?f=CoverageJSON&parameter-name=${param}`
     + `&coords=POINT(${lon.toFixed(4)} ${lat.toFixed(4)})`
     + `&datetime=${encodeURIComponent(`${startISO}/${endISO}`)}`;
+  // Single-site polar volumes have a vertical (elevation-angle) axis; pin it
+  // to the displayed sweep so the position query collapses to one time series.
+  if (z != null) url += `&z=${encodeURIComponent(z)}`;
   const r = await fetch(url, { signal });
   if (!r.ok) throw new Error(`EDR ${r.status}`);
-  const series = parseCoverage(await r.json());
+  const series = parseCoverage(await r.json(), param);
   cacheSet(key, series);
   return series;
 }
@@ -136,6 +145,8 @@ export default function initProbe({ container, onValueChange }) {
 
   let pin = null; // [lon, lat] in EPSG:4326, or null
   let collection = null; // EDR collection name, or null when unsupported
+  let parameter = PARAMETER_NAME; // EDR parameter-name for the active collection
+  let z = null; // elevation angle (deg) for single-site volumes, or null
   let series = null; // [{t, v}] from last fetch
   let windowMs = null; // [startMs, endMs] currently displayed
   let resolutionMs = null; // animation step in ms (one strip cell)
@@ -292,7 +303,7 @@ export default function initProbe({ container, onValueChange }) {
     try {
       const startISO = new Date(windowMs[0]).toISOString();
       const endISO = new Date(windowMs[1]).toISOString();
-      const data = await fetchSeries(collection, pin[0], pin[1], startISO, endISO, myAbort.signal);
+      const data = await fetchSeries(collection, parameter, pin[0], pin[1], startISO, endISO, z, myAbort.signal);
       if (myAbort.signal.aborted) return;
       series = data;
       if (!series || series.length === 0 || series.every((p) => p.v == null)) {
@@ -345,10 +356,24 @@ export default function initProbe({ container, onValueChange }) {
         ? normalizeLonLat(lonLat[0], lonLat[1]) : null;
       recompute();
     },
-    setActiveLayer(wmslayer) {
-      const next = wmslayer && EDR_COLLECTIONS.has(wmslayer) ? wmslayer : null;
-      if (next === collection) return;
-      collection = next;
+    setActiveLayer(wmslayer, opts = {}) {
+      let nextCollection = null;
+      let nextParam = PARAMETER_NAME;
+      if (wmslayer) {
+        const slash = wmslayer.indexOf('/');
+        if (slash > 0) {
+          // Single radar-site layer "<collection>/<quantity>".
+          nextCollection = wmslayer.slice(0, slash);
+          nextParam = wmslayer.slice(slash + 1);
+        } else if (EDR_COLLECTIONS.has(wmslayer)) {
+          nextCollection = wmslayer;
+        }
+      }
+      const nextZ = (opts.z === undefined || opts.z === null || opts.z === '') ? null : opts.z;
+      if (nextCollection === collection && nextParam === parameter && nextZ === z) return;
+      collection = nextCollection;
+      parameter = nextParam;
+      z = nextZ;
       recompute();
     },
     setCursor(cursorTimeMs, windowStartMs, stepMs) {

--- a/src/probe.js
+++ b/src/probe.js
@@ -91,8 +91,8 @@ async function fetchSeries(collection, param, lon, lat, startISO, endISO, z, sig
   const key = cacheKey(collection, param, z, lon, lat);
   const cached = cacheGet(key);
   if (cached) return cached;
-  let url = `${ENDPOINT}/${collection}/position`
-    + `?f=CoverageJSON&parameter-name=${param}`
+  let url = `${ENDPOINT}/${encodeURIComponent(collection)}/position`
+    + `?f=CoverageJSON&parameter-name=${encodeURIComponent(param)}`
     + `&coords=POINT(${lon.toFixed(4)} ${lat.toFixed(4)})`
     + `&datetime=${encodeURIComponent(`${startISO}/${endISO}`)}`;
   // Single-site polar volumes have a vertical (elevation-angle) axis; pin it

--- a/src/radar.js
+++ b/src/radar.js
@@ -1296,7 +1296,11 @@ function updateLayer(layer, wmslayer, opts = {}) {
   }
   updateLayerSelectionSelected();
   if (probe && layer === radarLayer) {
-    probe.setActiveLayer(layer.getVisible() ? wmslayer : null);
+    // Pass the elevation (set in single-site mode) so the EDR probe queries the
+    // displayed sweep; composites carry no ELEVATION param (z stays null).
+    probe.setActiveLayer(layer.getVisible() ? wmslayer : null, {
+      z: layer.getSource().getParams().ELEVATION,
+    });
   }
 }
 
@@ -1611,7 +1615,9 @@ function onChangeVisible(event) {
   updateLayerSelectionSelected();
   recomputeAllTimelineCells();
   if (probe && layer === radarLayer) {
-    probe.setActiveLayer(isVisible ? wmslayer : null);
+    probe.setActiveLayer(isVisible ? wmslayer : null, {
+      z: layer.getSource().getParams().ELEVATION,
+    });
   }
   // Visibility change may invalidate the current timeline window
   // (e.g. activating a stale satellite caps `end` to its old time.end,

--- a/src/radar.js
+++ b/src/radar.js
@@ -1368,25 +1368,35 @@ const featureOverlay = new VectorLayer({
 });
 let highlight;
 
-const displayFeatureInfo = function (pixel, presetFeature) {
-  const feature = presetFeature || map.forEachFeatureAtPixel(pixel, (f) => f);
+const displayFeatureInfo = function (pixel) {
+  const feature = map.forEachFeatureAtPixel(pixel, (f) => f);
 
   if (feature !== highlight) {
     if (highlight) {
       featureOverlay.getSource().removeFeature(highlight);
-      guideLayer.getSource().clear(true);
     }
     if (feature && feature.getGeometry().getType() === 'Point') {
       featureOverlay.getSource().addFeature(feature);
-      const coords = transform(feature.getGeometry().getCoordinates(), map.getView().getProjection(), 'EPSG:4326');
-      [50000, 100000, 150000, 200000, 250000].forEach((range) => rangeRings(guideLayer, coords, range));
-      Array.from({ length: 360 / options.radialSpacing }, (_, index) => index * options.radialSpacing)
-        .forEach((bearing) => bearingLine(guideLayer, coords, 250, bearing));
-      map.getView().fit(guideLayer.getSource().getExtent(), map.getSize());
     }
     highlight = feature;
   }
 };
+
+// Radar coverage overlay (range rings + radial bearings) for the radar shown in
+// single-site mode. Owned by radarSite's enter/exit so the rings appear and
+// clear together with the single-radar display — not on a bare marker tap.
+function drawRadarCoverage(feature) {
+  guideLayer.getSource().clear(true);
+  if (!feature) return;
+  const coords = transform(feature.getGeometry().getCoordinates(), map.getView().getProjection(), 'EPSG:4326');
+  [50000, 100000, 150000, 200000, 250000].forEach((range) => rangeRings(guideLayer, coords, range));
+  Array.from({ length: 360 / options.radialSpacing }, (_, index) => index * options.radialSpacing)
+    .forEach((bearing) => bearingLine(guideLayer, coords, 250, bearing));
+}
+
+function clearRadarCoverage() {
+  guideLayer.getSource().clear(true);
+}
 
 function createLayerInfoElement(content, className, isHTML) {
   const div = document.createElement('div');
@@ -2622,7 +2632,12 @@ const main = () => {
   syncToolGroup();
 
   radarSite = initRadarSite({
-    map, radarLayer, updateLayer, setTime,
+    map,
+    radarLayer,
+    updateLayer,
+    setTime,
+    drawCoverage: drawRadarCoverage,
+    clearCoverage: clearRadarCoverage,
   });
 
   // Overflow "Mittaa" row still arms the measure tool; remember it as the
@@ -2712,9 +2727,13 @@ const main = () => {
         return false;
       }, { hitTolerance: 12 });
       if (radarSiteHit) {
-        // Pass the matched feature so the coverage rings draw for it even when
-        // the tap landed just outside the symbol (within hitTolerance).
-        displayFeatureInfo(evt.pixel, radarSiteHit);
+        // Just open the card — coverage rings are coupled to the single-site
+        // display (drawn on toggle-on, cleared on toggle-off), not to the tap.
+        // Drop any leftover station highlight from a previous plain-feature tap.
+        if (highlight) {
+          featureOverlay.getSource().removeFeature(highlight);
+          highlight = null;
+        }
         radarSite.openCardForFeature(radarSiteHit);
         return;
       }

--- a/src/radar.js
+++ b/src/radar.js
@@ -2713,11 +2713,11 @@ const main = () => {
       return;
     }
 
-    // Tap on a radar-site marker → keep the existing coverage range-ring +
-    // highlight behaviour (displayFeatureInfo draws the rings and fits the
-    // view), then also open the drill-in card (single-site WMS toggle). The
-    // layer-aware lookup distinguishes radar sites from airfield markers
-    // (icaoLayer) regardless of z-order.
+    // Tap on a radar-site marker → open its drill-in card (single-site WMS
+    // toggle). Coverage rings are coupled to the single-site display (drawn on
+    // toggle-on, cleared on toggle-off), not to the tap. The layer-aware lookup
+    // distinguishes radar sites from airfield markers (icaoLayer) regardless of
+    // z-order.
     if (radarSite && radarSiteLayer.getVisible()) {
       let radarSiteHit = null;
       // hitTolerance enlarges the tap target around the small radar symbol

--- a/src/radar.js
+++ b/src/radar.js
@@ -1368,8 +1368,8 @@ const featureOverlay = new VectorLayer({
 });
 let highlight;
 
-const displayFeatureInfo = function (pixel) {
-  const feature = map.forEachFeatureAtPixel(pixel, (f) => f);
+const displayFeatureInfo = function (pixel, presetFeature) {
+  const feature = presetFeature || map.forEachFeatureAtPixel(pixel, (f) => f);
 
   if (feature !== highlight) {
     if (highlight) {
@@ -2705,12 +2705,16 @@ const main = () => {
     // (icaoLayer) regardless of z-order.
     if (radarSite && radarSiteLayer.getVisible()) {
       let radarSiteHit = null;
+      // hitTolerance enlarges the tap target around the small radar symbol
+      // (touch-friendly) without changing how the marker is drawn.
       map.forEachFeatureAtPixel(evt.pixel, (f, layer) => {
         if (layer === radarSiteLayer) { radarSiteHit = f; return true; }
         return false;
-      });
+      }, { hitTolerance: 12 });
       if (radarSiteHit) {
-        displayFeatureInfo(evt.pixel);
+        // Pass the matched feature so the coverage rings draw for it even when
+        // the tap landed just outside the symbol (within hitTolerance).
+        displayFeatureInfo(evt.pixel, radarSiteHit);
         radarSite.openCardForFeature(radarSiteHit);
         return;
       }

--- a/src/radar.js
+++ b/src/radar.js
@@ -2692,10 +2692,11 @@ const main = () => {
       return;
     }
 
-    // Tap on a radar-site marker → open its drill-in card (single-site WMS
-    // toggle). The layer-aware lookup distinguishes radar sites from airfield
-    // markers (icaoLayer) regardless of z-order, and we intercept before
-    // displayFeatureInfo so a site tap doesn't draw range rings + zoom.
+    // Tap on a radar-site marker → keep the existing coverage range-ring +
+    // highlight behaviour (displayFeatureInfo draws the rings and fits the
+    // view), then also open the drill-in card (single-site WMS toggle). The
+    // layer-aware lookup distinguishes radar sites from airfield markers
+    // (icaoLayer) regardless of z-order.
     if (radarSite && radarSiteLayer.getVisible()) {
       let radarSiteHit = null;
       map.forEachFeatureAtPixel(evt.pixel, (f, layer) => {
@@ -2703,11 +2704,7 @@ const main = () => {
         return false;
       });
       if (radarSiteHit) {
-        if (highlight) {
-          featureOverlay.getSource().removeFeature(highlight);
-          guideLayer.getSource().clear(true);
-          highlight = null;
-        }
+        displayFeatureInfo(evt.pixel);
         radarSite.openCardForFeature(radarSiteHit);
         return;
       }

--- a/src/radar.js
+++ b/src/radar.js
@@ -34,6 +34,7 @@ import wmsServerConfiguration from './config';
 import createLongPressHandler from './longpress';
 import initTools from './tools';
 import initProbe from './probe';
+import initRadarSite from './radarSite';
 import FramePool from './animation/framePool';
 import { canInterpolate, RadarInterpolator } from './animation/interpolation';
 import { track } from './analytics';
@@ -68,6 +69,7 @@ let ownPosition4326 = [];
 let geolocation;
 let tools = null;
 let probe = null;
+let radarSite = null;
 let startDate = new Date(Math.floor(Date.now() / 300000) * 300000 - 300000 * 12);
 // Handle of the currently-running playback loop (now a requestAnimationFrame
 // id — was a setInterval handle before the RAF refactor). Null when paused.
@@ -1327,6 +1329,11 @@ function fitToLayerExtent(wmslayer) {
 // drop it — the layer stays at its constructor-time default.
 function restoreActiveLayer(category) {
   if (!category) return;
+  // While drilled into a single radar site, the radar layer intentionally runs
+  // a transient `<collection>/DBZH` product that is NOT in ACTIVE_LAYERS. Skip
+  // the restore so the periodic (60 s) capabilities refresh doesn't revert it
+  // back to the stored composite mid-session.
+  if (category === 'radarLayer' && radarSite && radarSite.isSingleSiteActive()) return;
   const olLayer = layerss[category];
   if (!olLayer) return;
   const stored = ACTIVE_LAYERS[category];
@@ -1612,6 +1619,11 @@ function onChangeVisible(event) {
   // in-range state immediately so the map time, stale colour and
   // layer opacity update without waiting for a tick or manual step.
   setTime('keep');
+  // Turning the radar layer off exits single-site mode, restoring the composite
+  // product (while hidden) so re-enabling the layer shows the composite again.
+  if (layer === radarLayer && !isVisible && radarSite) {
+    radarSite.exitSingleSite({ restore: true });
+  }
 }
 
 /**
@@ -1843,6 +1855,10 @@ const radarMenu = createLongPressHandler(
   'radarLongPressMenu',
   () => { toggleAndAnnounce(radarLayer, 'radarLayerButton', 'button'); },
   (id) => {
+    // Picking a composite from the menu exits single-site mode first (clears
+    // the ELEVATION param + card toggle) without restoring, since the line
+    // below sets the new composite itself.
+    if (radarSite) radarSite.exitSingleSite({ restore: false });
     updateLayer(radarLayer, id, { source: 'longpress' });
     fitToLayerExtent(id);
     radarMenu.hide();
@@ -2599,6 +2615,10 @@ const main = () => {
   });
   syncToolGroup();
 
+  radarSite = initRadarSite({
+    map, radarLayer, updateLayer, setTime,
+  });
+
   // Overflow "Mittaa" row still arms the measure tool; remember it as the
   // last-used tool so the FAB reflects it. (The FAB itself is wired above as a
   // tool-group flyout.)
@@ -2670,6 +2690,27 @@ const main = () => {
     if (pin && hit === pin) {
       tools.toggleCard();
       return;
+    }
+
+    // Tap on a radar-site marker → open its drill-in card (single-site WMS
+    // toggle). The layer-aware lookup distinguishes radar sites from airfield
+    // markers (icaoLayer) regardless of z-order, and we intercept before
+    // displayFeatureInfo so a site tap doesn't draw range rings + zoom.
+    if (radarSite && radarSiteLayer.getVisible()) {
+      let radarSiteHit = null;
+      map.forEachFeatureAtPixel(evt.pixel, (f, layer) => {
+        if (layer === radarSiteLayer) { radarSiteHit = f; return true; }
+        return false;
+      });
+      if (radarSiteHit) {
+        if (highlight) {
+          featureOverlay.getSource().removeFeature(highlight);
+          guideLayer.getSource().clear(true);
+          highlight = null;
+        }
+        radarSite.openCardForFeature(radarSiteHit);
+        return;
+      }
     }
     displayFeatureInfo(evt.pixel);
   });

--- a/src/radarSite.js
+++ b/src/radarSite.js
@@ -77,6 +77,23 @@ export default function initRadarSite({
   });
   map.addOverlay(overlay);
 
+  // Breathing ring over the currently-active single-site marker. The animation
+  // is pure CSS (see .radar-site-pulse); JS only positions/clears the overlay.
+  // pointer-events:none + stopEvent:false let taps pass through to the marker.
+  const pulse = document.createElement('div');
+  pulse.className = 'radar-site-pulse';
+  pulse.setAttribute('aria-hidden', 'true');
+  // Inner ring carries the CSS animation. OpenLayers writes `transform` on the
+  // overlay element itself for positioning, so animating the outer element's
+  // transform would fight OL — the inner span keeps the two independent.
+  pulse.innerHTML = '<span class="radar-site-pulse-ring"></span>';
+  const pulseOverlay = new Overlay({
+    element: pulse,
+    positioning: 'center-center',
+    stopEvent: false,
+  });
+  map.addOverlay(pulseOverlay);
+
   const nameEl = card.querySelector('.radar-site-name');
   const subEl = card.querySelector('.radar-site-sub');
   const toggleBtn = card.querySelector('.radar-site-toggle');
@@ -92,6 +109,15 @@ export default function initRadarSite({
 
   function getRadarParams() {
     return radarLayer.getSource().getParams();
+  }
+
+  // Anchor the breathing ring on the active site's marker (or hide it).
+  function updateActiveIndicator() {
+    if (singleSite && singleSite.feature) {
+      pulseOverlay.setPosition(singleSite.feature.getGeometry().getCoordinates());
+    } else {
+      pulseOverlay.setPosition(undefined);
+    }
   }
 
   function enterSingleSite(feature) {
@@ -117,6 +143,7 @@ export default function initRadarSite({
       savedComposite,
       feature,
     };
+    updateActiveIndicator();
   }
 
   // restore=true swaps back to the saved composite; restore=false only clears
@@ -141,6 +168,7 @@ export default function initRadarSite({
       }
     }
     singleSite = null;
+    updateActiveIndicator();
     renderToggle();
   }
 

--- a/src/radarSite.js
+++ b/src/radarSite.js
@@ -63,7 +63,7 @@ function buildCard() {
 }
 
 export default function initRadarSite({
-  map, radarLayer, updateLayer, setTime,
+  map, radarLayer, updateLayer, setTime, drawCoverage = () => {}, clearCoverage = () => {},
 }) {
   const card = buildCard();
   document.body.appendChild(card);
@@ -144,6 +144,9 @@ export default function initRadarSite({
       feature,
     };
     updateActiveIndicator();
+    // Coverage rings are part of "showing this radar": redraw for the active
+    // site (this also handles a site→site switch).
+    drawCoverage(feature);
   }
 
   // restore=true swaps back to the saved composite; restore=false only clears
@@ -169,6 +172,7 @@ export default function initRadarSite({
     }
     singleSite = null;
     updateActiveIndicator();
+    clearCoverage();
     renderToggle();
   }
 

--- a/src/radarSite.js
+++ b/src/radarSite.js
@@ -1,0 +1,213 @@
+import Overlay from 'ol/Overlay';
+
+// Radar-site drill-in: tap a radar-site marker → a small card anchored to the
+// marker lets the user swap the main radar layer to that single site's WMS
+// product (DBZH at its lowest elevation sweep) and back to the composite.
+//
+// The single-site layer animates exactly like a composite because the meteocore
+// per-site layers (`<collection>/<quantity>`) carry a time dimension and the
+// FramePool already syncs the ELEVATION param across its frame slots — so the
+// only work here is swapping LAYERS + setting ELEVATION via the existing
+// updateLayer path, then letting setTime drive the window as usual.
+//
+// State is kept module-local (`singleSite`); the invariant is:
+//   singleSite != null  ⟺  radarLayer LAYERS is a site layer we set.
+// Every transition sets or clears both ends, so the composite is always
+// restorable. The one external path that could break it — restoreActiveLayer
+// firing on the 60 s capabilities refresh — is neutralised by the caller via
+// isSingleSiteActive().
+
+// Choose the quantity to display: DBZH when the radar offers it (all FI + EE
+// radars do), otherwise the first advertised quantity, with a final CSP
+// fallback (present on every radar).
+function pickQuantity(quantities) {
+  if (Array.isArray(quantities) && quantities.length) {
+    return quantities.includes('DBZH') ? 'DBZH' : quantities[0];
+  }
+  return 'CSP';
+}
+
+// Resolve a feature to its WMS product. Returns null when the feature has no
+// `collection` (e.g. an older bundled fallback snapshot) — the card then shows
+// the site but disables the toggle.
+function resolveProduct(feature) {
+  const collection = feature.get('collection');
+  if (!collection) return null;
+  const quantity = pickQuantity(feature.get('quantities'));
+  const angles = feature.get('elevation_angles');
+  const elevation = Array.isArray(angles) && angles.length ? Math.min(...angles) : null;
+  return { wmsLayer: `${collection}/${quantity}`, quantity, elevation };
+}
+
+function buildCard() {
+  const card = document.createElement('div');
+  card.id = 'radarSiteCard';
+  card.className = 'marker-card radar-site-card';
+  card.setAttribute('role', 'region');
+  card.setAttribute('aria-label', 'Tutka-asema');
+  card.innerHTML = `
+    <div class="marker-card-head">
+      <i class="material-icons marker-card-icon" aria-hidden="true">cell_tower</i>
+      <span class="marker-card-title">Tutka-asema</span>
+      <button type="button" class="marker-card-close" aria-label="Sulje">
+        <i class="material-icons" aria-hidden="true">close</i>
+      </button>
+    </div>
+    <div class="radar-site-body">
+      <div class="radar-site-name"></div>
+      <div class="radar-site-sub"></div>
+      <button type="button" class="radar-site-toggle" aria-pressed="false">Näytä tämä tutka</button>
+    </div>
+  `;
+  return card;
+}
+
+export default function initRadarSite({
+  map, radarLayer, updateLayer, setTime,
+}) {
+  const card = buildCard();
+  document.body.appendChild(card);
+
+  const overlay = new Overlay({
+    element: card,
+    positioning: 'bottom-center',
+    offset: [0, -22],
+    stopEvent: true,
+    autoPan: { animation: { duration: 250 }, margin: 20 },
+  });
+  map.addOverlay(overlay);
+
+  const nameEl = card.querySelector('.radar-site-name');
+  const subEl = card.querySelector('.radar-site-sub');
+  const toggleBtn = card.querySelector('.radar-site-toggle');
+  const closeBtn = card.querySelector('.marker-card-close');
+
+  // null in composite mode; otherwise { wmsLayer, elevation, savedComposite, feature }.
+  let singleSite = null;
+  // The feature whose card is currently shown (may differ from the active site).
+  let cardFeature = null;
+
+  const isSingleSiteActive = () => singleSite !== null;
+  const getActiveWmsLayer = () => (singleSite ? singleSite.wmsLayer : null);
+
+  function getRadarParams() {
+    return radarLayer.getSource().getParams();
+  }
+
+  function enterSingleSite(feature) {
+    const product = resolveProduct(feature);
+    if (!product) return;
+    // Turning the radar on first means a drill-in from a hidden radar layer
+    // shows the site rather than silently arming an invisible layer.
+    if (!radarLayer.getVisible()) radarLayer.setVisible(true);
+    // Keep the original composite as the restore target across a site→site
+    // switch — never capture a site layer as the composite.
+    const savedComposite = singleSite ? singleSite.savedComposite : getRadarParams().LAYERS;
+    // Set ELEVATION before swapping LAYERS so the first request for the site
+    // already carries the lowest sweep (updateParams merges, so updateLayer's
+    // own LAYERS update preserves it). The composite ignores an ELEVATION param.
+    if (product.elevation != null) {
+      radarLayer.getSource().updateParams({ ELEVATION: product.elevation });
+    }
+    updateLayer(radarLayer, product.wmsLayer, { skipPersist: true, skipTracking: true });
+    setTime('keep');
+    singleSite = {
+      wmsLayer: product.wmsLayer,
+      elevation: product.elevation,
+      savedComposite,
+      feature,
+    };
+  }
+
+  // restore=true swaps back to the saved composite; restore=false only clears
+  // single-site state + the ELEVATION param (used when another path — e.g. the
+  // radar long-press menu — is itself about to set a new composite).
+  function exitSingleSite({ restore = true } = {}) {
+    if (!singleSite) return;
+    if (getRadarParams().LAYERS === singleSite.wmsLayer) {
+      // Clear ELEVATION first so the composite GetMap omits it (ol/uri drops
+      // undefined-valued params).
+      radarLayer.getSource().updateParams({ ELEVATION: undefined });
+      if (restore) {
+        // Only skip the visibility step when the layer is already hidden (the
+        // radar-off path), so restoring there doesn't re-show it. When visible
+        // (toggle-off), let updateLayer run its normal canonical-page update.
+        updateLayer(radarLayer, singleSite.savedComposite, {
+          skipVisibility: !radarLayer.getVisible(),
+          skipPersist: true,
+          skipTracking: true,
+        });
+        setTime('keep');
+      }
+    }
+    singleSite = null;
+    renderToggle();
+  }
+
+  function renderToggle() {
+    const product = cardFeature ? resolveProduct(cardFeature) : null;
+    if (!product) {
+      toggleBtn.disabled = true;
+      toggleBtn.setAttribute('aria-pressed', 'false');
+      toggleBtn.classList.remove('active');
+      toggleBtn.textContent = 'Saatavilla vain verkossa';
+      return;
+    }
+    const active = isSingleSiteActive() && getActiveWmsLayer() === product.wmsLayer;
+    toggleBtn.disabled = false;
+    toggleBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    toggleBtn.classList.toggle('active', active);
+    toggleBtn.textContent = active ? 'Piilota tämä tutka' : 'Näytä tämä tutka';
+  }
+
+  function openCardForFeature(feature) {
+    cardFeature = feature;
+    const name = feature.get('name') || 'Tutka-asema';
+    const nod = feature.get('nod');
+    nameEl.textContent = nod ? `${name} (${nod})` : name;
+
+    const product = resolveProduct(feature);
+    const country = (feature.get('country') || '').toUpperCase();
+    const parts = [];
+    if (product) {
+      parts.push(product.quantity);
+      if (product.elevation != null) parts.push(`${product.elevation}°`);
+    }
+    if (country) parts.push(country);
+    subEl.textContent = parts.join(' · ');
+
+    renderToggle();
+    overlay.setPosition(feature.getGeometry().getCoordinates());
+  }
+
+  function hideCard() {
+    overlay.setPosition(undefined);
+    cardFeature = null;
+  }
+
+  toggleBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (!cardFeature || toggleBtn.disabled) return;
+    const product = resolveProduct(cardFeature);
+    const active = isSingleSiteActive() && getActiveWmsLayer() === product.wmsLayer;
+    if (active) {
+      exitSingleSite({ restore: true });
+    } else {
+      enterSingleSite(cardFeature);
+      renderToggle();
+    }
+  });
+
+  closeBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hideCard();
+  });
+
+  return {
+    openCardForFeature,
+    hideCard,
+    exitSingleSite,
+    isSingleSiteActive,
+    getActiveWmsLayer,
+  };
+}


### PR DESCRIPTION
## Summary

Tapping a radar-site marker opens a small card anchored to it (station name + `nod`, subline `DBZH · <lowest elevation>° · <country>`) with a **toggle** that swaps the main radar layer to that site's per-site WMS product and back to the composite.

- **Layer**: `<collection>/DBZH` (e.g. `fi-radar-pvol-fianj/DBZH`, `ee-radar-volume-eehar/DBZH`) at the radar's **lowest elevation sweep** (`ELEVATION` param), served from the same `meteocore.app.meteo.fi/wms` endpoint the composites already use. Quantity falls back to the first advertised / `CSP` if a radar ever lacks DBZH (all 14 FI+EE expose it today).
- **Animates like the composite**: the per-site layers carry a `time` dimension and `FramePool` already syncs `ELEVATION` across frame slots, so it reuses the existing `updateLayer` + `setTime` path with **no animation-specific code**.

## Enter/exit semantics
- **Transient**: single-site is never persisted to `ACTIVE_LAYERS` → a reload restores the composite.
- **Restore target** = the composite showing at drill-in time (captured live, kept across a site→site switch). Restored on toggle-off, on turning the radar layer off (while hidden, so it isn't re-shown), and when a different composite is picked from the radar long-press menu.
- **60 s capabilities-refresh guard**: `restoreActiveLayer` skips the radar category while drilled in, so the periodic refresh doesn't silently revert the single-site product. *(This was the main correctness risk — see plan.)*
- The dBZ point-probe naturally collapses in single-site mode (per-site volume has no EDR identity) and re-arms on restore.

## Changes
- **`src/radarSite.js`** (new) — card builder + OL `Overlay`, `singleSite` state, enter/exit, `openCardForFeature`/`hideCard`/`exitSingleSite`/`isSingleSiteActive`/`getActiveWmsLayer`. Mirrors the `initTools`/`initProbe` module pattern.
- **`src/radar.js`** — init the module; click branch (layer-aware, intercepts before `displayFeatureInfo` so a site tap no longer draws range rings + zooms); `restoreActiveLayer` guard; `onChangeVisible` radar-off exit; `radarMenu` onSelect reconcile.
- **`assets/radar.css`** — `.radar-site-card`/`-body`/`-name`/`-sub`/`.radar-site-toggle` (reuses the `.marker-card` shell).
- **`assets/radars-finland.json`** — bundled fallback enriched with `collection`/`elevation_angles`/`quantities` so the card works from the offline snapshot too.

## Verification
- `npm run lint` clean; `npm run build` clean (pre-existing bundle-size warnings only); enriched JSON copied to `dist/`.
- Confirmed the **percent-encoded** GetMap (`layers=fi-radar-pvol-fianj%2FDBZH&elevation=0.3`, what OpenLayers actually sends) returns `200 image/png` for FI and EE.
- Not browser-verified locally (Chrome automation unavailable on this machine). Suggested manual matrix is in the plan: toggle on/off, play/scrub, switch composite, radar off, idle >70 s (refresh guard), tap a different site, reload, POI off.

## Notes
- **Stacked on #111** (`feat/dynamic-radar-sites`) — base is that branch, since this depends on the live `collection`/`elevation_angles`/`quantities` properties its loader provides. Retarget to `master` after #111 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)