### PR TITLE
feat: center-crosshair reflectivity reticle ("Tähtäin")

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -458,7 +458,6 @@ html, body {
   .crosshair-overlay {
     position: absolute;
     inset: 0;
-    z-index: 50;
     pointer-events: none;
   }
 

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -451,6 +451,91 @@ html, body {
   #toolFlyoutBackdrop.open { display: block; }
 
   /* ========================================================================
+     Center-crosshair reticle ("Tähtäin") — pinned to the map viewport centre.
+     Appended inside .ol-viewport (position:relative); pointer-events:none so
+     it never blocks map interaction. The user pans the map under it.
+     ======================================================================== */
+  .crosshair-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    pointer-events: none;
+  }
+
+  /* Full-viewport crosshair lines. A faint dark edge keeps them legible over
+     both light basemaps and dark radar echoes. */
+  .crosshair-line {
+    position: absolute;
+    background: rgba(255, 255, 255, 0.5);
+    box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.45);
+  }
+  .crosshair-line-h {
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: 1px;
+    transform: translateY(-0.5px);
+  }
+  .crosshair-line-v {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    transform: translateX(-0.5px);
+  }
+
+  /* Bounded reticle (rings + radar-direction line), centred on the viewport.
+     drop-shadow gives every stroke a dark halo for contrast. */
+  .crosshair-svg {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    overflow: visible;
+    filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.6));
+  }
+
+  .crosshair-ring {
+    fill: none;
+    stroke: rgba(255, 255, 255, 0.6);
+    stroke-width: 1.5;
+  }
+
+  /* Centre ring: the colour swatch. `fill` is set live from the sampled radar
+     pixel; the `.empty` variant (no echo / layer hidden) shows a hollow dashed
+     ring instead. */
+  .crosshair-center {
+    stroke: #ffffff;
+    stroke-width: 2;
+  }
+  .crosshair-center.empty {
+    stroke: rgba(255, 255, 255, 0.75);
+    stroke-dasharray: 3 3;
+  }
+
+  .crosshair-dir-line {
+    stroke: var(--dark-primary-color);
+    stroke-width: 2;
+  }
+  .crosshair-dir-arrow {
+    fill: var(--dark-primary-color);
+  }
+
+  .crosshair-readout {
+    position: absolute;
+    top: calc(50% + 104px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 2px 10px;
+    border-radius: 12px;
+    background: rgba(22, 22, 24, 0.82);
+    color: #ffffff;
+    font: 600 14px/1.4 Roboto, sans-serif;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  }
+
+  /* ========================================================================
      Overflow menu (three-dots) — drops below top bar, anchored to menu button
      ======================================================================== */
   #overflowMenuBackdrop {

--- a/src/crosshair.js
+++ b/src/crosshair.js
@@ -102,7 +102,13 @@ export default function initCrosshair({
   readout.hidden = true;
   overlay.appendChild(readout);
 
-  map.getViewport().appendChild(overlay);
+  // Insert below OL's overlay containers (the radar-site / marker cards) so
+  // those still render on top of the reticle, but above the map canvas — DOM
+  // order handles the stacking. Fall back to append if the container is absent.
+  const viewport = map.getViewport();
+  const olOverlays = viewport.querySelector('.ol-overlaycontainer-stopevent');
+  if (olOverlays) viewport.insertBefore(overlay, olOverlays);
+  else viewport.appendChild(overlay);
 
   // --- state ---------------------------------------------------------------
   let visible = false;
@@ -110,6 +116,7 @@ export default function initCrosshair({
   let parameter = null;
   let z = null;
   let center4326 = null; // normalized [lon, lat]
+  let nearestLonLat = null; // cached nearest radar site [lon, lat] (see recomputeNearest)
   let windowMs = null; // [startMs, endMs]
   let cursorMs = null;
   let stepMs = null;
@@ -144,6 +151,14 @@ export default function initCrosshair({
     return best;
   }
 
+  // Recompute (and cache) the nearest radar site. Run on moveend / arm — NOT
+  // per frame — since the scan over all sites is wasted work during a pan and
+  // the nearest rarely changes mid-pan. updateDirection still re-aims the arrow
+  // at this cached target every frame, so it tracks smoothly while panning.
+  function recomputeNearest() {
+    nearestLonLat = center4326 ? nearestSiteLonLat(center4326) : null;
+  }
+
   function sampleColor() {
     const view = map.getView();
     const center = view.getCenter();
@@ -167,7 +182,7 @@ export default function initCrosshair({
   // at a capped length when the radar is far off-screen — never overshooting.
   function updateDirection() {
     const target = center4326
-      ? (getActiveSiteLonLat() || nearestSiteLonLat(center4326))
+      ? (getActiveSiteLonLat() || nearestLonLat)
       : null;
     const centerPx = map.getPixelFromCoordinate(map.getView().getCenter());
     const targetPx = target
@@ -275,6 +290,10 @@ export default function initCrosshair({
     // continuous pan keeps resetting the 200 ms timer, so the network query
     // only fires once the user pauses/stops.
     const moved = refreshCenter4326();
+    // One-time catch-up: if the radar-site features only finished loading after
+    // the tool was armed, pick up the nearest now. Steady-state recompute is on
+    // moveend, so this is a cheap no-op once a target exists.
+    if (nearestLonLat == null && !getActiveSiteLonLat()) recomputeNearest();
     render();
     if (moved) scheduleRefetch();
   });
@@ -286,6 +305,7 @@ export default function initCrosshair({
     // during the pan, so by moveend the delta is gone and a gate would never
     // trip. fetchSeries is cached, so a no-op move is cheap.
     refreshCenter4326();
+    recomputeNearest();
     scheduleRefetch();
   });
 
@@ -295,6 +315,7 @@ export default function initCrosshair({
       visible = true;
       overlay.style.display = '';
       refreshCenter4326();
+      recomputeNearest();
       render();
       refetch();
       // Force a fresh postrender so the centre colour samples a current frame

--- a/src/crosshair.js
+++ b/src/crosshair.js
@@ -19,26 +19,31 @@
 
 import { transform } from 'ol/proj';
 import { getDistance } from 'ol/sphere';
-import LatLon from 'geodesy/latlon-spherical';
 import { resolveEdrTarget, fetchSeries, normalizeLonLat } from './probe';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
 // Reticle geometry (SVG user units == CSS px). Center ring is the colour
 // swatch; the two outer rings are fixed-size aiming circles. The radar line
-// runs from just outside the centre ring out toward the viewport edge.
+// starts just outside the centre ring.
 const SVG_SIZE = 320;
 const C = SVG_SIZE / 2;
 const R_CENTER = 16;
 const R_MID = 46;
 const R_OUTER = 88;
 const LINE_INNER = R_CENTER + 4;
-const LINE_OUTER = 150;
+// Cap the arrow length for far radars. For nearer ones the arrow is drawn only
+// as long as the radar's on-screen distance, so the head lands on the radar
+// instead of overshooting past it (see updateDirection).
+const LINE_OUTER_MAX = 150;
+const ARROW_LEN = 10;
+const ARROW_HALF_W = 5;
 
 // The strip window holds 13 frames (0..12), mirroring probe.js.
 const WINDOW_FRAMES = 12;
-// Don't draw the radar line when the centre is essentially on the radar.
-const MIN_TARGET_M = 200;
+// Hide the radar arrow when the radar sits essentially under the reticle — too
+// close on screen to draw a sensible arrow.
+const MIN_TARGET_PX = LINE_INNER + ARROW_LEN;
 
 function el(tag, attrs) {
   const node = document.createElementNS(SVG_NS, tag);
@@ -71,17 +76,13 @@ export default function initCrosshair({
     viewBox: `0 0 ${SVG_SIZE} ${SVG_SIZE}`,
   });
 
-  // Radar-direction line + arrowhead, grouped so a single rotate() aims it.
-  // It points "north" (straight up) at rotate(0); bearing is clockwise from
-  // north, which matches SVG's clockwise-positive rotation (y grows downward).
+  // Radar-direction line + arrowhead. Endpoints are recomputed in screen space
+  // each render (updateDirection), so no rotate() transform is needed.
   const dirGroup = el('g', { class: 'crosshair-dir' });
-  dirGroup.appendChild(el('line', {
-    x1: C, y1: C - LINE_INNER, x2: C, y2: C - LINE_OUTER, class: 'crosshair-dir-line',
-  }));
-  dirGroup.appendChild(el('polygon', {
-    points: `${C - 5},${C - LINE_OUTER + 9} ${C + 5},${C - LINE_OUTER + 9} ${C},${C - LINE_OUTER}`,
-    class: 'crosshair-dir-arrow',
-  }));
+  const dirLine = el('line', { class: 'crosshair-dir-line' });
+  const dirArrow = el('polygon', { class: 'crosshair-dir-arrow' });
+  dirGroup.appendChild(dirLine);
+  dirGroup.appendChild(dirArrow);
   svg.appendChild(dirGroup);
 
   svg.appendChild(el('circle', {
@@ -161,18 +162,42 @@ export default function initCrosshair({
     }
   }
 
+  // Aim the radar-direction arrow in screen space. The head lands exactly on
+  // the radar's on-screen position when within reach, and points straight at it
+  // at a capped length when the radar is far off-screen — never overshooting.
   function updateDirection() {
-    if (!center4326) return;
-    const target = getActiveSiteLonLat() || nearestSiteLonLat(center4326);
-    const d = target ? getDistance(center4326, target) : Infinity;
-    if (target && d > MIN_TARGET_M) {
-      const brg = new LatLon(center4326[1], center4326[0])
-        .initialBearingTo(new LatLon(target[1], target[0]));
-      dirGroup.setAttribute('transform', `rotate(${brg.toFixed(1)} ${C} ${C})`);
-      dirGroup.style.display = '';
-    } else {
-      dirGroup.style.display = 'none';
-    }
+    const target = center4326
+      ? (getActiveSiteLonLat() || nearestSiteLonLat(center4326))
+      : null;
+    const centerPx = map.getPixelFromCoordinate(map.getView().getCenter());
+    const targetPx = target
+      ? map.getPixelFromCoordinate(transform(target, 'EPSG:4326', map.getView().getProjection()))
+      : null;
+    if (!centerPx || !targetPx) { dirGroup.style.display = 'none'; return; }
+
+    const dx = targetPx[0] - centerPx[0];
+    const dy = targetPx[1] - centerPx[1];
+    const dist = Math.hypot(dx, dy);
+    if (dist < MIN_TARGET_PX) { dirGroup.style.display = 'none'; return; }
+
+    const ux = dx / dist;
+    const uy = dy / dist;
+    const len = Math.min(dist, LINE_OUTER_MAX);
+    const tipX = C + ux * len;
+    const tipY = C + uy * len;
+    const backX = C + ux * (len - ARROW_LEN);
+    const backY = C + uy * (len - ARROW_LEN);
+    const perpX = -uy * ARROW_HALF_W;
+    const perpY = ux * ARROW_HALF_W;
+
+    dirLine.setAttribute('x1', (C + ux * LINE_INNER).toFixed(1));
+    dirLine.setAttribute('y1', (C + uy * LINE_INNER).toFixed(1));
+    dirLine.setAttribute('x2', tipX.toFixed(1));
+    dirLine.setAttribute('y2', tipY.toFixed(1));
+    dirArrow.setAttribute('points', `${tipX.toFixed(1)},${tipY.toFixed(1)} `
+      + `${(backX + perpX).toFixed(1)},${(backY + perpY).toFixed(1)} `
+      + `${(backX - perpX).toFixed(1)},${(backY - perpY).toFixed(1)}`);
+    dirGroup.style.display = '';
   }
 
   function refreshCenter4326() {

--- a/src/crosshair.js
+++ b/src/crosshair.js
@@ -1,0 +1,311 @@
+// Center-crosshair reflectivity reticle ("Tähtäin").
+//
+// A RadarScope-style reticle pinned to the *center* of the map viewport. Unlike
+// the Mittaa / Pistemittaus map-tap tools, this one never moves — the user pans
+// the map underneath it to change the measured point. It shows, at screen
+// center:
+//   - full-viewport vertical + horizontal crosshair lines,
+//   - a small center ring filled with the *actual rendered radar pixel colour*
+//     at that point (so the user sees exactly which value the readout samples —
+//     the ring spans several pixels, but the fill is the single centre pixel),
+//   - two outer aiming rings (fixed pixel radii, zoom-independent),
+//   - a line from the centre toward the selected (or nearest) radar site,
+//   - the dBZ value at the centre, below the crosshair.
+//
+// The dBZ value reuses the exact EDR position query Pistemittaus uses (shared
+// helpers in probe.js) so the two readouts agree at the same coordinate. The
+// pixel colour is read straight off the radar layer's canvas via getData() —
+// which requires the radar ImageWMS source to be crossOrigin-enabled.
+
+import { transform } from 'ol/proj';
+import { getDistance } from 'ol/sphere';
+import LatLon from 'geodesy/latlon-spherical';
+import { resolveEdrTarget, fetchSeries, normalizeLonLat } from './probe';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+// Reticle geometry (SVG user units == CSS px). Center ring is the colour
+// swatch; the two outer rings are fixed-size aiming circles. The radar line
+// runs from just outside the centre ring out toward the viewport edge.
+const SVG_SIZE = 320;
+const C = SVG_SIZE / 2;
+const R_CENTER = 16;
+const R_MID = 46;
+const R_OUTER = 88;
+const LINE_INNER = R_CENTER + 4;
+const LINE_OUTER = 150;
+
+// The strip window holds 13 frames (0..12), mirroring probe.js.
+const WINDOW_FRAMES = 12;
+// Don't draw the radar line when the centre is essentially on the radar.
+const MIN_TARGET_M = 200;
+
+function el(tag, attrs) {
+  const node = document.createElementNS(SVG_NS, tag);
+  Object.keys(attrs).forEach((k) => node.setAttribute(k, attrs[k]));
+  return node;
+}
+
+export default function initCrosshair({
+  map, radarLayer, radarSiteSource, getActiveSiteLonLat,
+}) {
+  // --- DOM -----------------------------------------------------------------
+  const overlay = document.createElement('div');
+  overlay.className = 'crosshair-overlay';
+  overlay.setAttribute('aria-hidden', 'true');
+  overlay.style.display = 'none';
+
+  // Full-viewport crosshair lines (kept out of the bounded SVG so they span the
+  // whole map, not just the reticle).
+  const hLine = document.createElement('div');
+  hLine.className = 'crosshair-line crosshair-line-h';
+  const vLine = document.createElement('div');
+  vLine.className = 'crosshair-line crosshair-line-v';
+  overlay.appendChild(hLine);
+  overlay.appendChild(vLine);
+
+  const svg = el('svg', {
+    class: 'crosshair-svg',
+    width: SVG_SIZE,
+    height: SVG_SIZE,
+    viewBox: `0 0 ${SVG_SIZE} ${SVG_SIZE}`,
+  });
+
+  // Radar-direction line + arrowhead, grouped so a single rotate() aims it.
+  // It points "north" (straight up) at rotate(0); bearing is clockwise from
+  // north, which matches SVG's clockwise-positive rotation (y grows downward).
+  const dirGroup = el('g', { class: 'crosshair-dir' });
+  dirGroup.appendChild(el('line', {
+    x1: C, y1: C - LINE_INNER, x2: C, y2: C - LINE_OUTER, class: 'crosshair-dir-line',
+  }));
+  dirGroup.appendChild(el('polygon', {
+    points: `${C - 5},${C - LINE_OUTER + 9} ${C + 5},${C - LINE_OUTER + 9} ${C},${C - LINE_OUTER}`,
+    class: 'crosshair-dir-arrow',
+  }));
+  svg.appendChild(dirGroup);
+
+  svg.appendChild(el('circle', {
+    cx: C, cy: C, r: R_OUTER, class: 'crosshair-ring',
+  }));
+  svg.appendChild(el('circle', {
+    cx: C, cy: C, r: R_MID, class: 'crosshair-ring',
+  }));
+  const centerCircle = el('circle', {
+    cx: C, cy: C, r: R_CENTER, class: 'crosshair-center empty',
+  });
+  svg.appendChild(centerCircle);
+  overlay.appendChild(svg);
+
+  const readout = document.createElement('div');
+  readout.className = 'crosshair-readout';
+  readout.hidden = true;
+  overlay.appendChild(readout);
+
+  map.getViewport().appendChild(overlay);
+
+  // --- state ---------------------------------------------------------------
+  let visible = false;
+  let collection = null;
+  let parameter = null;
+  let z = null;
+  let center4326 = null; // normalized [lon, lat]
+  let windowMs = null; // [startMs, endMs]
+  let cursorMs = null;
+  let stepMs = null;
+  let series = null;
+  let inFlight = null;
+  let refetchTimer = 0;
+
+  function setReadout(dbz) {
+    if (dbz == null || Number.isNaN(dbz)) {
+      readout.hidden = true;
+      readout.textContent = '';
+    } else {
+      readout.textContent = `${Math.round(dbz)} dBZ`;
+      readout.hidden = false;
+    }
+  }
+
+  // --- centre pixel colour + radar-direction line (cheap, every render) -----
+  function nearestSiteLonLat(center) {
+    const feats = radarSiteSource.getFeatures();
+    if (!feats.length) return null;
+    const proj = map.getView().getProjection();
+    let best = null;
+    let bestD = Infinity;
+    feats.forEach((f) => {
+      const g = f.getGeometry();
+      if (!g) return;
+      const ll = transform(g.getCoordinates(), proj, 'EPSG:4326');
+      const d = getDistance(center, ll);
+      if (d < bestD) { bestD = d; best = ll; }
+    });
+    return best;
+  }
+
+  function sampleColor() {
+    const view = map.getView();
+    const center = view.getCenter();
+    if (!center) return;
+    const pixel = map.getPixelFromCoordinate(center);
+    let data = null;
+    if (pixel && radarLayer.getVisible()) {
+      try { data = radarLayer.getData(pixel); } catch (_) { data = null; }
+    }
+    if (data && data.length >= 4 && data[3] > 0) {
+      centerCircle.setAttribute('fill', `rgba(${data[0]},${data[1]},${data[2]},${(data[3] / 255).toFixed(3)})`);
+      centerCircle.classList.remove('empty');
+    } else {
+      centerCircle.setAttribute('fill', 'none');
+      centerCircle.classList.add('empty');
+    }
+  }
+
+  function updateDirection() {
+    if (!center4326) return;
+    const target = getActiveSiteLonLat() || nearestSiteLonLat(center4326);
+    const d = target ? getDistance(center4326, target) : Infinity;
+    if (target && d > MIN_TARGET_M) {
+      const brg = new LatLon(center4326[1], center4326[0])
+        .initialBearingTo(new LatLon(target[1], target[0]));
+      dirGroup.setAttribute('transform', `rotate(${brg.toFixed(1)} ${C} ${C})`);
+      dirGroup.style.display = '';
+    } else {
+      dirGroup.style.display = 'none';
+    }
+  }
+
+  function refreshCenter4326() {
+    const center = map.getView().getCenter();
+    if (!center) { center4326 = null; return false; }
+    const ll = transform(center, map.getView().getProjection(), 'EPSG:4326');
+    const norm = normalizeLonLat(ll[0], ll[1]);
+    const moved = !center4326 || center4326[0] !== norm[0] || center4326[1] !== norm[1];
+    center4326 = norm;
+    return moved;
+  }
+
+  function render() {
+    if (!visible) return;
+    sampleColor();
+    updateDirection();
+  }
+
+  // --- dBZ value via EDR (windowed, mirrors probe.js) -----------------------
+  // Mirror probe.js exactly: floor at 0 dBZ (anything below is "no
+  // precipitation" → no readout) and take the peak among samples landing in the
+  // cursor's frame cell, so this readout matches what Pistemittaus shows at the
+  // same point.
+  function pickFrameValue() {
+    if (!series || !windowMs || !stepMs || cursorMs == null) return null;
+    const startMs = windowMs[0];
+    const idx = Math.round((cursorMs - startMs) / stepMs);
+    let peak = null;
+    series.forEach((p) => {
+      if (p.v == null || p.v < 0) return;
+      if (Math.round((p.t - startMs) / stepMs) !== idx) return;
+      if (peak == null || p.v > peak) peak = p.v;
+    });
+    return peak;
+  }
+
+  function updateValue() {
+    setReadout(pickFrameValue());
+  }
+
+  async function refetch() {
+    if (!visible || !collection || !center4326 || !windowMs) {
+      setReadout(null);
+      return;
+    }
+    if (inFlight) inFlight.abort();
+    inFlight = new AbortController();
+    const myAbort = inFlight;
+    try {
+      const startISO = new Date(windowMs[0]).toISOString();
+      const endISO = new Date(windowMs[1]).toISOString();
+      const data = await fetchSeries(collection, parameter, center4326[0], center4326[1], startISO, endISO, z, myAbort.signal);
+      if (myAbort.signal.aborted) return;
+      series = data;
+      updateValue();
+    } catch (err) {
+      if (err && err.name === 'AbortError') return;
+      series = null;
+      setReadout(null);
+    } finally {
+      if (inFlight === myAbort) inFlight = null;
+    }
+  }
+
+  function scheduleRefetch() {
+    if (refetchTimer) clearTimeout(refetchTimer);
+    refetchTimer = window.setTimeout(() => { refetchTimer = 0; refetch(); }, 200);
+  }
+
+  // --- map wiring (attached once; cheap no-op while hidden) ------------------
+  map.on('postrender', () => {
+    if (!visible) return;
+    // Colour + direction line follow the centre live (cheap, local). When the
+    // centre actually moves, also (re)arm the debounced dBZ refetch — a fast
+    // continuous pan keeps resetting the 200 ms timer, so the network query
+    // only fires once the user pauses/stops.
+    const moved = refreshCenter4326();
+    render();
+    if (moved) scheduleRefetch();
+  });
+
+  map.on('moveend', () => {
+    if (!visible) return;
+    // Guaranteed final refetch after a move. Not gated on refreshCenter4326()'s
+    // "moved" result: the postrender handler above already advanced center4326
+    // during the pan, so by moveend the delta is gone and a gate would never
+    // trip. fetchSeries is cached, so a no-op move is cheap.
+    refreshCenter4326();
+    scheduleRefetch();
+  });
+
+  return {
+    show() {
+      if (visible) return;
+      visible = true;
+      overlay.style.display = '';
+      refreshCenter4326();
+      render();
+      refetch();
+      // Force a fresh postrender so the centre colour samples a current frame
+      // even if the map is otherwise idle at the moment of arming.
+      map.render();
+    },
+    hide() {
+      if (!visible) return;
+      visible = false;
+      overlay.style.display = 'none';
+      if (inFlight) inFlight.abort();
+      if (refetchTimer) { clearTimeout(refetchTimer); refetchTimer = 0; }
+    },
+    isVisible: () => visible,
+    // Mirror probe.setActiveLayer: track the EDR collection/parameter/elevation
+    // for whatever radar product is currently displayed.
+    setActiveLayer(wmslayer, opts = {}) {
+      const t = resolveEdrTarget(wmslayer, { z: opts.z });
+      if (t.collection === collection && t.parameter === parameter && t.z === z) return;
+      collection = t.collection;
+      parameter = t.parameter;
+      z = t.z;
+      series = null;
+      if (visible) refetch();
+    },
+    // Mirror probe.setCursor: refetch only when the window shifts; otherwise
+    // just repick the frame from the cached series.
+    setCursor(cursorTimeMs, windowStartMs, step) {
+      cursorMs = cursorTimeMs;
+      stepMs = step;
+      const w = [windowStartMs, windowStartMs + WINDOW_FRAMES * step];
+      const changed = !windowMs || windowMs[0] !== w[0] || windowMs[1] !== w[1];
+      windowMs = w;
+      if (!visible) return;
+      if (changed) refetch();
+      else updateValue();
+    },
+  };
+}

--- a/src/index.html
+++ b/src/index.html
@@ -132,6 +132,10 @@
               aria-pressed="false" aria-label="Pistemittaus: heijastavuus">
         <i class="material-icons" aria-hidden="true">colorize</i>
       </button>
+      <button class="tool-flyout-item" type="button" role="menuitem" data-tool="crosshair"
+              aria-pressed="false" aria-label="Tähtäin: keskipisteen heijastavuus">
+        <i class="material-icons" aria-hidden="true">center_focus_weak</i>
+      </button>
     </div>
   </div>
   <div id="toolFlyoutBackdrop"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -120,7 +120,7 @@
   <div id="toolGroup" class="tool-group noselect">
     <button id="measureFab" class="measure-fab tool-group-main" type="button" aria-pressed="false"
             aria-haspopup="menu" aria-expanded="false" aria-controls="toolFlyout" aria-label="Työkalut">
-      <i class="material-icons tool-group-icon" aria-hidden="true">colorize</i>
+      <i class="material-icons tool-group-icon" aria-hidden="true">center_focus_weak</i>
     </button>
     <span class="tool-group-caret" aria-hidden="true"></span>
     <div id="toolFlyout" class="tool-flyout" role="menu" aria-label="Työkalut" hidden>

--- a/src/probe.js
+++ b/src/probe.js
@@ -36,7 +36,7 @@ const Y_MAX_DBZ = 50;
 // across world copies (e.g. lon 360.0017 for a point that is really near 0°).
 // The EDR server rejects those with HTTP 400, so wrap longitude into [-180, 180)
 // and clamp latitude into [-90, 90] before any coordinate reaches a query.
-function normalizeLonLat(lon, lat) {
+export function normalizeLonLat(lon, lat) {
   const wrappedLon = ((((lon + 180) % 360) + 360) % 360) - 180;
   const clampedLat = Math.max(-90, Math.min(90, lat));
   return [wrappedLon, clampedLat];
@@ -87,7 +87,28 @@ function parseCoverage(cov, param) {
   });
 }
 
-async function fetchSeries(collection, param, lon, lat, startISO, endISO, z, signal) {
+// Resolve a radar WMS layer name to its EDR query target. Shared with the
+// center-crosshair tool so the two readouts can't drift apart.
+//   - "<collection>/<quantity>"  → single radar site (e.g. fi-radar-pvol-fianj/DBZH)
+//   - a known composite mosaic   → identity-mapped collection, `reflectivity`
+//   - anything else              → collection:null (no EDR equivalent)
+export function resolveEdrTarget(wmslayer, { z } = {}) {
+  let collection = null;
+  let parameter = PARAMETER_NAME;
+  if (wmslayer) {
+    const slash = wmslayer.indexOf('/');
+    if (slash > 0) {
+      collection = wmslayer.slice(0, slash);
+      parameter = wmslayer.slice(slash + 1);
+    } else if (EDR_COLLECTIONS.has(wmslayer)) {
+      collection = wmslayer;
+    }
+  }
+  const nz = (z === undefined || z === null || z === '') ? null : z;
+  return { collection, parameter, z: nz };
+}
+
+export async function fetchSeries(collection, param, lon, lat, startISO, endISO, z, signal) {
   const key = cacheKey(collection, param, z, lon, lat);
   const cached = cacheGet(key);
   if (cached) return cached;
@@ -357,23 +378,11 @@ export default function initProbe({ container, onValueChange }) {
       recompute();
     },
     setActiveLayer(wmslayer, opts = {}) {
-      let nextCollection = null;
-      let nextParam = PARAMETER_NAME;
-      if (wmslayer) {
-        const slash = wmslayer.indexOf('/');
-        if (slash > 0) {
-          // Single radar-site layer "<collection>/<quantity>".
-          nextCollection = wmslayer.slice(0, slash);
-          nextParam = wmslayer.slice(slash + 1);
-        } else if (EDR_COLLECTIONS.has(wmslayer)) {
-          nextCollection = wmslayer;
-        }
-      }
-      const nextZ = (opts.z === undefined || opts.z === null || opts.z === '') ? null : opts.z;
-      if (nextCollection === collection && nextParam === parameter && nextZ === z) return;
-      collection = nextCollection;
-      parameter = nextParam;
-      z = nextZ;
+      const t = resolveEdrTarget(wmslayer, { z: opts.z });
+      if (t.collection === collection && t.parameter === parameter && t.z === z) return;
+      collection = t.collection;
+      parameter = t.parameter;
+      z = t.z;
       recompute();
     },
     setCursor(cursorTimeMs, windowStartMs, stepMs) {

--- a/src/radar.js
+++ b/src/radar.js
@@ -35,6 +35,7 @@ import createLongPressHandler from './longpress';
 import initTools from './tools';
 import initProbe from './probe';
 import initRadarSite from './radarSite';
+import initCrosshair from './crosshair';
 import FramePool from './animation/framePool';
 import { canInterpolate, RadarInterpolator } from './animation/interpolation';
 import { track } from './analytics';
@@ -70,6 +71,7 @@ let geolocation;
 let tools = null;
 let probe = null;
 let radarSite = null;
+let crosshair = null;
 let startDate = new Date(Math.floor(Date.now() / 300000) * 300000 - 300000 * 12);
 // Handle of the currently-running playback loop (now a requestAnimationFrame
 // id — was a setInterval handle before the RAF refactor). Null when paused.
@@ -570,6 +572,13 @@ const radarLayer = new ImageLayer({
     ratio: options.imageRatio,
     hidpi: false,
     serverType: 'geoserver',
+    // Lets the center-crosshair tool read the rendered radar pixel colour off
+    // the canvas (getData) without tainting it. During animation the displayed
+    // frames come from StickyImageWMS slot sources, which fetch via CORS and
+    // assign blob: URLs (already canvas-safe); this only covers the original
+    // source's direct-load path before the FramePool takes over. The meteocore
+    // WMS returns Access-Control-Allow-Origin: *, so it's safe.
+    crossOrigin: 'anonymous',
   }),
 });
 // Category default wire format. updateLayer / applyWireFormat substitute
@@ -944,6 +953,7 @@ function setTime(action = 'next') {
   // updateTimeLine((startDate.getTime()-start)/resolution);
   timeline.update((startDate.getTime() - start) / resolution);
   if (probe) probe.setCursor(startDate.getTime(), start, resolution);
+  if (crosshair) crosshair.setCursor(startDate.getTime(), start, resolution);
 
   // var startDateFormat = moment(startDate.toISOString()).utc().format()
   // debug("---");
@@ -1301,6 +1311,11 @@ function updateLayer(layer, wmslayer, opts = {}) {
     probe.setActiveLayer(layer.getVisible() ? wmslayer : null, {
       z: layer.getSource().getParams().ELEVATION,
     });
+    if (crosshair) {
+      crosshair.setActiveLayer(layer.getVisible() ? wmslayer : null, {
+        z: layer.getSource().getParams().ELEVATION,
+      });
+    }
   }
 }
 
@@ -1628,6 +1643,11 @@ function onChangeVisible(event) {
     probe.setActiveLayer(isVisible ? wmslayer : null, {
       z: layer.getSource().getParams().ELEVATION,
     });
+    if (crosshair) {
+      crosshair.setActiveLayer(isVisible ? wmslayer : null, {
+        z: layer.getSource().getParams().ELEVATION,
+      });
+    }
   }
   // Visibility change may invalidate the current timeline window
   // (e.g. activating a stale satellite caps `end` to its old time.end,
@@ -1947,7 +1967,7 @@ const toolFabBtn = document.getElementById('measureFab');
 const toolFlyoutEl = document.getElementById('toolFlyout');
 const toolFlyoutBackdropEl = document.getElementById('toolFlyoutBackdrop');
 const toolGroupIconEl = toolFabBtn ? toolFabBtn.querySelector('.tool-group-icon') : null;
-const TOOL_ICONS = { measure: 'straighten', pistemittaus: 'colorize' };
+const TOOL_ICONS = { measure: 'straighten', pistemittaus: 'colorize', crosshair: 'center_focus_weak' };
 let lastTool = 'pistemittaus';
 
 function openToolFlyout() {
@@ -1978,6 +1998,12 @@ function syncToolGroup() {
     toolFlyoutEl.querySelectorAll('.tool-flyout-item').forEach((item) => {
       item.setAttribute('aria-pressed', item.dataset.tool === active ? 'true' : 'false');
     });
+  }
+  // The crosshair is a passive screen-centre overlay rather than a map-tap
+  // tool, so its visibility is driven here from the single-select tool state.
+  if (crosshair) {
+    if (active === 'crosshair') crosshair.show();
+    else crosshair.hide();
   }
 }
 
@@ -2639,6 +2665,18 @@ const main = () => {
     drawCoverage: drawRadarCoverage,
     clearCoverage: clearRadarCoverage,
   });
+
+  crosshair = initCrosshair({
+    map,
+    radarLayer,
+    radarSiteSource,
+    getActiveSiteLonLat: radarSite.getActiveSiteLonLat,
+  });
+  if (radarLayer.getVisible()) {
+    crosshair.setActiveLayer(radarLayer.getSource().getParams().LAYERS, {
+      z: radarLayer.getSource().getParams().ELEVATION,
+    });
+  }
 
   // Overflow "Mittaa" row still arms the measure tool; remember it as the
   // last-used tool so the FAB reflects it. (The FAB itself is wired above as a

--- a/src/radar.js
+++ b/src/radar.js
@@ -1968,7 +1968,9 @@ const toolFlyoutEl = document.getElementById('toolFlyout');
 const toolFlyoutBackdropEl = document.getElementById('toolFlyoutBackdrop');
 const toolGroupIconEl = toolFabBtn ? toolFabBtn.querySelector('.tool-group-icon') : null;
 const TOOL_ICONS = { measure: 'straighten', pistemittaus: 'colorize', crosshair: 'center_focus_weak' };
-let lastTool = 'pistemittaus';
+// Default tool the FAB arms on a plain tap (and shows in its icon) until the
+// user picks another from the flyout — the centre-crosshair reticle.
+let lastTool = 'crosshair';
 
 function openToolFlyout() {
   toolFlyoutEl.hidden = false;

--- a/src/radarSite.js
+++ b/src/radarSite.js
@@ -1,4 +1,5 @@
 import Overlay from 'ol/Overlay';
+import { transform } from 'ol/proj';
 
 // Radar-site drill-in: tap a radar-site marker → a small card anchored to the
 // marker lets the user swap the main radar layer to that single site's WMS
@@ -106,6 +107,16 @@ export default function initRadarSite({
 
   const isSingleSiteActive = () => singleSite !== null;
   const getActiveWmsLayer = () => (singleSite ? singleSite.wmsLayer : null);
+  // [lon, lat] (EPSG:4326) of the active single-site marker, or null in
+  // composite mode. Used by the center-crosshair tool to aim its radar line.
+  const getActiveSiteLonLat = () => {
+    if (!singleSite || !singleSite.feature) return null;
+    return transform(
+      singleSite.feature.getGeometry().getCoordinates(),
+      map.getView().getProjection(),
+      'EPSG:4326',
+    );
+  };
 
   function getRadarParams() {
     return radarLayer.getSource().getParams();
@@ -241,5 +252,6 @@ export default function initRadarSite({
     exitSingleSite,
     isSingleSiteActive,
     getActiveWmsLayer,
+    getActiveSiteLonLat,
   };
 }

--- a/src/tools.js
+++ b/src/tools.js
@@ -423,7 +423,7 @@ export default function initTools({
   // leaving (measure features, or the probe pin + card + chart) and sets up the
   // one we're entering. Passing null (or anything else) disarms.
   function setActiveTool(next) {
-    const tool = (next === 'measure' || next === 'pistemittaus') ? next : null;
+    const tool = (next === 'measure' || next === 'pistemittaus' || next === 'crosshair') ? next : null;
     if (tool === activeTool) return;
 
     // Tear down the tool we're leaving.
@@ -448,6 +448,12 @@ export default function initTools({
       markerTranslate.setActive(true);
       setChipIdentity('colorize', 'PISTEMITTAUS');
       setChipHint('napauta karttaa');
+    } else if (tool === 'crosshair') {
+      // Passive screen-centre reticle — no map-tap, no pin. The overlay itself
+      // is shown/hidden by radar.js's onToolChange (syncToolGroup).
+      markerTranslate.setActive(false);
+      setChipIdentity('center_focus_weak', 'TÄHTÄIN');
+      setChipHint('siirrä karttaa');
     } else {
       markerTranslate.setActive(false);
     }
@@ -586,6 +592,7 @@ export default function initTools({
     disarm: disarmMeasure,
     isArmed: () => activeTool === 'measure',
     isProbeArmed: () => activeTool === 'pistemittaus',
+    isCrosshairArmed: () => activeTool === 'crosshair',
     handleMeasureTap,
   };
 }


### PR DESCRIPTION
## What

A RadarScope-style **center-crosshair reticle ("TÄHTÄIN")** as a third tool in the FAB flyout (alongside Mittaa and Pistemittaus), pinned to the map centre. The user pans the map under it to change the measured point.

At screen centre it shows:
- full-viewport vertical + horizontal crosshair lines
- a small centre ring **filled live with the actual rendered radar pixel colour** (hollow dashed when no echo / radar hidden)
- two fixed-pixel outer aiming rings
- a line + arrowhead toward the **selected single-site radar** (else the **nearest**)
- the **dBZ value** below the crosshair

## How

- **New module `src/crosshair.js`** — a fixed, viewport-centred overlay appended inside the OL viewport (`pointer-events:none`). Colour + direction track the centre live on `postrender`; the dBZ refetches after a move (`moveend`) and during slow pans (debounced on centre change).
- **Shared EDR helpers** factored out of `probe.js` (`resolveEdrTarget`, `fetchSeries`, `normalizeLonLat`) so the crosshair's dBZ uses the *exact* query Pistemittaus uses — same collection/parameter/elevation, same 0 dBZ floor + per-cell peak — and the two readouts agree at the same point.
- **Pixel colour** read via `radarLayer.getData()`. The animated frames load through `StickyImageWMS` → `fetch` → `blob:` URLs, which are same-origin, so the canvas is never tainted (no `crossOrigin` needed on the per-frame slot sources; it's set on the layer's original source only as a startup-path fallback).
- **Tool wiring** — `crosshair` slots into the existing single-select `activeTool` machine in `tools.js` (mutually exclusive); `radarSite.js` exposes `getActiveSiteLonLat()`; `radar.js` adds the icon, init, show/hide via `syncToolGroup`, and the `setCursor`/`setActiveLayer` hooks.

## Decisions (confirmed with the user)
- Fixed-pixel reticle rings (zoom-independent), not geographic range rings
- Mutually exclusive with the other tools
- Direction line targets the selected site if active, else the nearest radar
- dBZ only (no range/azimuth label)

## Verification
- ESLint clean; production build green (only pre-existing bundle-size warnings)
- Edge cases traced: frame index 0/last, off-coverage (null → blank), non-radar/hidden layer, centre-on-radar (line hidden <200 m)
- Manual: armed from the flyout, reticle stays centred while panning; dBZ updates on/after move and matches a Pistemittaus pin at the same point; icon (`center_focus_weak`) is distinct from the geolocation control

🤖 Generated with [Claude Code](https://claude.com/claude-code)