### PR TITLE
feat: app-level fullscreen ("Koko ruutu") mode

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -273,11 +273,12 @@ html, body {
     }
   }
 
-  /* Location FAB: larger, bottom-right, sits above the time-control pill */
+  /* Location FAB: larger, bottom-right. Sits in the middle of the right-side
+     column — above the fullscreen FAB, below the tool group. */
   .location-fab {
     position: fixed;
     right: max(16px, env(safe-area-inset-right, 0px) + 16px);
-    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 16px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 76px);
     width: 52px;
     height: 52px;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
@@ -344,7 +345,7 @@ html, body {
   .measure-fab {
     position: fixed;
     right: max(16px, env(safe-area-inset-right, 0px) + 16px);
-    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 76px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 136px);
     width: 52px;
     height: 52px;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
@@ -367,7 +368,7 @@ html, body {
   #toolGroup {
     position: fixed;
     right: max(16px, env(safe-area-inset-right, 0px) + 16px);
-    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 76px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 136px);
     width: 52px;
     height: 52px;
     z-index: 100;
@@ -377,6 +378,57 @@ html, body {
     position: relative;
     right: auto;
     bottom: auto;
+  }
+
+  /* ========================================================================
+     App fullscreen ("Koko ruutu"): a clean, distraction-free view of the
+     animation. The enter FAB takes the lowest right-side slot (the old
+     location-FAB anchor); the exit FAB only shows while fullscreen is active.
+     ======================================================================== */
+  #fullscreenEnterButton,
+  #fullscreenExitButton {
+    width: 52px;
+    height: 52px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+    z-index: 100;
+  }
+  #fullscreenEnterButton .material-icons,
+  #fullscreenExitButton .material-icons { font-size: 24px; }
+
+  /* Enter FAB: lowest right-side slot; the time chip on the left aligns with it. */
+  #fullscreenEnterButton {
+    position: fixed;
+    right: max(16px, env(safe-area-inset-right, 0px) + 16px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--timecontrol-height, 84px) + 16px);
+    transition: bottom 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
+  }
+
+  /* Exit FAB: hidden in normal mode; bottom-right corner while fullscreen. */
+  #fullscreenExitButton { display: none; }
+  body.app-fullscreen #fullscreenExitButton {
+    display: inline-flex;
+    position: fixed;
+    right: max(16px, env(safe-area-inset-right, 0px) + 16px);
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+  }
+
+  /* Fullscreen: hide all chrome except the data-time chip and the exit FAB.
+     Transient overlays/backdrops are included defensively in case one is open. */
+  body.app-fullscreen #primaryToolbar,
+  body.app-fullscreen #timecontrol,
+  body.app-fullscreen #toolGroup,
+  body.app-fullscreen #locationLayerButton,
+  body.app-fullscreen #fullscreenEnterButton,
+  body.app-fullscreen #toolChip,
+  body.app-fullscreen #coachmark,
+  body.app-fullscreen #overflowMenu,
+  body.app-fullscreen #overflowMenuBackdrop,
+  body.app-fullscreen #playList,
+  body.app-fullscreen #playListBackdrop { display: none !important; }
+
+  /* No timebar underneath, so the chip drops to the screen bottom. */
+  body.app-fullscreen #timeChip {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
   }
 
   /* Small corner triangle marking this as a multi-tool group (Photoshop cue). */

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -420,6 +420,7 @@ html, body {
   body.app-fullscreen #locationLayerButton,
   body.app-fullscreen #fullscreenEnterButton,
   body.app-fullscreen #toolChip,
+  body.app-fullscreen #measureCard,
   body.app-fullscreen #coachmark,
   body.app-fullscreen #overflowMenu,
   body.app-fullscreen #overflowMenuBackdrop,

--- a/src/index.html
+++ b/src/index.html
@@ -144,6 +144,13 @@
     <i id="gpsStatus" class="material-icons" aria-hidden="true">gps_not_fixed</i>
   </button>
 
+  <button id="fullscreenEnterButton" class="glass-fab noselect" type="button" aria-label="Koko ruutu">
+    <i class="material-icons" aria-hidden="true">open_in_full</i>
+  </button>
+  <button id="fullscreenExitButton" class="glass-fab noselect" type="button" aria-label="Poistu koko ruudusta">
+    <i class="material-icons" aria-hidden="true">close_fullscreen</i>
+  </button>
+
   <div id="coachmark" aria-live="polite" hidden>
     <span class="coach-title"></span>
     <span class="coach-hint" hidden></span>
@@ -276,6 +283,7 @@
         <tr><td>←↑↓→</td><td>kartan liikuttaminen</td></tr>
         <tr><td><kbd>+</kbd> <kbd>-</kbd></td><td>kartan zoomaus</td></tr>
         <tr><td><kbd>⎵</kbd></td><td>ajan askellus</td></tr>
+        <tr><td><kbd>f</kbd></td><td>koko ruutu</td></tr>
         <tr><td><kbd>j</kbd></td><td>edellinen aika-askel</td></tr>
         <tr><td><kbd>k</kbd></td><td>play/pause</td></tr>
         <tr><td><kbd>l</kbd></td><td>seuraava aika-askel</td></tr>

--- a/src/radar.js
+++ b/src/radar.js
@@ -2287,7 +2287,9 @@ document.addEventListener('keyup', (event) => {
     toggleAndAnnounce(lightningLayer, 'lightningLayerButton', 'key');
   } else if (key === '4' || key === 'Digit4') {
     toggleAndAnnounce(observationLayer, 'observationLayerButton', 'key');
-  } else if (key === 'f' || key === 'KeyF') {
+  } else if ((key === 'f' || key === 'KeyF')
+    && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    // Bare `f` only — don't hijack Cmd/Ctrl+F (find-in-page) etc.
     setAppFullscreen(!appFullscreen);
   } else if (event.key === 'Escape') {
     if (overflowMenuEl.classList.contains('open')) closeOverflowMenu();

--- a/src/radar.js
+++ b/src/radar.js
@@ -81,6 +81,7 @@ let lastWarpTick = 0;
 const layerInfo = {};
 let timeline;
 let mapTime = '';
+let appFullscreen = false;
 const framePools = {
   satelliteLayer: null,
   radarLayer: null,
@@ -854,6 +855,9 @@ function updateMapTimeDisplay(time) {
     const stale = ageHours >= 24;
     currentMapTimeDiv.classList.toggle('stale', stale);
     currentMapDateDiv.classList.toggle('stale', stale);
+    // In fullscreen the bottom-left chip mirrors this data time — refresh it
+    // now so it tracks each frame without waiting for the 1 s clock tick.
+    if (appFullscreen) renderTimeChip();
   }
 }
 
@@ -2283,8 +2287,11 @@ document.addEventListener('keyup', (event) => {
     toggleAndAnnounce(lightningLayer, 'lightningLayerButton', 'key');
   } else if (key === '4' || key === 'Digit4') {
     toggleAndAnnounce(observationLayer, 'observationLayerButton', 'key');
+  } else if (key === 'f' || key === 'KeyF') {
+    setAppFullscreen(!appFullscreen);
   } else if (event.key === 'Escape') {
     if (overflowMenuEl.classList.contains('open')) closeOverflowMenu();
+    else if (appFullscreen) setAppFullscreen(false);
     else handled = false;
   } else if (event.key === 'Control') {
     document.getElementById('help').style.display = 'none';
@@ -2921,22 +2928,27 @@ setInterval(updateMapEta, 1000);
 updateMapEta();
 
 // Time chip — small clock in the bottom-left corner. Click to toggle local
-// time vs UTC; the choice persists across sessions.
+// time vs UTC; the choice persists across sessions. In app-fullscreen mode the
+// same pill instead shows the displayed frame's DATA time (see renderTimeChip).
 let timeIsUtc = safeParseJSON('timeIsUtc', false);
 const timeChipEl = document.getElementById('timeChip');
+const tcTime = timeChipEl && timeChipEl.querySelector('.tc-time');
+const tcDate = timeChipEl && timeChipEl.querySelector('.tc-date');
+
+function renderTimeChip() {
+  if (!timeChipEl) return;
+  // Fullscreen shows the displayed frame's data time (mapTime); otherwise the
+  // wall-clock "now". Falls back to now if no frame has loaded yet.
+  const base = (appFullscreen && mapTime) ? dayjs(mapTime) : dayjs();
+  const d = timeIsUtc ? base.utc() : base;
+  tcTime.textContent = d.format('HH:mm');
+  tcDate.textContent = timeIsUtc
+    ? `${d.format('dd D.M.')} UTC`
+    : d.format('dd D.M.');
+  timeChipEl.classList.toggle('utc-mode', timeIsUtc);
+}
+
 if (timeChipEl) {
-  const tcTime = timeChipEl.querySelector('.tc-time');
-  const tcDate = timeChipEl.querySelector('.tc-date');
-
-  const renderTimeChip = () => {
-    const d = timeIsUtc ? dayjs().utc() : dayjs();
-    tcTime.textContent = d.format('HH:mm');
-    tcDate.textContent = timeIsUtc
-      ? `${d.format('dd D.M.')} UTC`
-      : d.format('dd D.M.');
-    timeChipEl.classList.toggle('utc-mode', timeIsUtc);
-  };
-
   timeChipEl.addEventListener('click', (e) => {
     e.stopPropagation();
     timeIsUtc = !timeIsUtc;
@@ -2947,6 +2959,30 @@ if (timeChipEl) {
 
   renderTimeChip();
   setInterval(renderTimeChip, 1000);
+}
+
+// App-level fullscreen ("Koko ruutu") — hides all chrome except the data-time
+// chip (bottom-left) and the exit FAB (bottom-right). Transient view mode, not
+// persisted across reloads.
+function setAppFullscreen(on) {
+  appFullscreen = on;
+  document.body.classList.toggle('app-fullscreen', on);
+  if (on) {
+    closeOverflowMenu();
+    closePlaylist();
+    closeToolFlyout();
+  }
+  renderTimeChip(); // swap now ⇄ data time immediately
+  track(on ? 'fullscreen-on' : 'fullscreen-off');
+}
+
+const fullscreenEnterButton = document.getElementById('fullscreenEnterButton');
+const fullscreenExitButton = document.getElementById('fullscreenExitButton');
+if (fullscreenEnterButton) {
+  fullscreenEnterButton.addEventListener('click', () => setAppFullscreen(true));
+}
+if (fullscreenExitButton) {
+  fullscreenExitButton.addEventListener('click', () => setAppFullscreen(false));
 }
 
 main();


### PR DESCRIPTION
## What

Adds an **app-level** fullscreen mode (not the browser/OS Fullscreen API) for a clean, distraction-free view of the radar animation. When active, all chrome is hidden except:

- the **data time** of the currently displayed frame, bottom-left (reusing the existing time-chip pill visualization);
- an **exit-fullscreen FAB**, bottom-right.

A new **enter-fullscreen FAB** lives in the right-side FAB column in normal mode. The animation keeps running underneath, and the bottom-left chip tracks each frame's data time as it plays.

## Details

- **Right column re-stacked** (top→bottom): tools → position → **fullscreen** (new, lowest slot). Keeps the existing `+16/76/136` anchor pattern off `--timecontrol-height`.
- **Time chip repurposed**: `renderTimeChip()` is hoisted to module scope with an `appFullscreen` flag. In fullscreen it renders `mapTime` (the frame's data time); otherwise wall-clock now. Refreshed from `updateMapTimeDisplay()` so it follows each frame without waiting for the 1 s tick. Falls back to "now" if no frame has loaded.
- **Icons**: `open_in_full` (enter / arrows outward) and `close_fullscreen` (exit / arrows inward) — both confirmed present in the `MaterialIcons-Regular` font already loaded.
- **Keyboard**: `f` toggles; `Esc` exits (after closing any open overflow menu first). Added to the help table.
- **Transient**: not persisted — every page load starts in normal mode.
- No `map.updateSize()` needed — `#map` is already `100vw×100vh` and chrome floats over it. All fixed elements keep explicit `bottom` insets (iOS Safari safe-area).

## Files

- `src/index.html` — two new glass FABs + `f` help row
- `assets/radar.css` — column re-stack, new FAB styling, `body.app-fullscreen` rules
- `src/radar.js` — module-scope `renderTimeChip()`, `appFullscreen` flag, `setAppFullscreen()` + wiring, keyboard handling

## Verification

- ESLint clean; `npm run build` succeeds (only pre-existing bundle-size warnings).
- Manual (Chrome MCP unavailable on this machine): enter FAB sits below the position button; tapping leaves only the bottom-left time + bottom-right exit FAB; chip advances through frame data times during playback; `f`/`Esc` work; reload starts in normal mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)