### PR TITLE
Split-screen: 1/2/4 synced panes with per-pane content

### DIFF
--- a/assets/radar.css
+++ b/assets/radar.css
@@ -43,14 +43,49 @@ html, body {
     font-family: 'Roboto', sans-serif;
 }
 
-#map {
+/* Split-screen grid. The full-viewport container holds 1, 2 or 4 panes; each
+   pane is a separate OpenLayers map sharing one View (synced pan/zoom). Kept in
+   normal flow (static, like the old #map) so it does NOT form a stacking
+   context — OL's in-map overlays keep interleaving with the fixed chrome by
+   z-index exactly as before. */
+#paneGrid {
     width: 100vw;
     height: 100vh;
+    display: grid;
+    grid-template: 1fr / 1fr;
+    background-color: var(--dark-background-color);
+}
+
+.pane {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    /* Let grid cells shrink below content size so each map fills its cell. */
+    min-width: 0;
+    min-height: 0;
     background-color: var(--dark-background-color);
     cursor: default;
 }
+
+/* Default (1-up): only pane 0 is shown; display:none drops the others out of
+   the grid flow entirely, so the single pane fills the viewport. */
+#map-1, #map-2, #map-3 { display: none; }
+
+/* 2-up: side-by-side in landscape, stacked in portrait (orientation-driven). */
+body.split-2 #paneGrid { grid-template: 1fr / 1fr 1fr; }
+body.split-2 #map-1 { display: block; }
+@media (orientation: portrait) {
+    body.split-2 #paneGrid { grid-template: 1fr 1fr / 1fr; }
+}
+
+/* 4-up: always 2x2, orientation-independent. */
+body.split-4 #paneGrid { grid-template: 1fr 1fr / 1fr 1fr; }
+body.split-4 #map-1,
+body.split-4 #map-2,
+body.split-4 #map-3 { display: block; }
+
 /* Crosshair only while a map-tap tool (Mittaa / Pistemittaus) is armed. */
-#map.tool-armed {
+.pane.tool-armed {
     cursor: crosshair;
 }
 

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -89,6 +89,71 @@ body.split-4 #map-3 { display: block; }
     cursor: crosshair;
 }
 
+/* Per-pane mini category pill — shown only in split layouts, anchored to the
+   top-centre of each pane. Compact variant of the glass toolbar pill. */
+.pane-pill {
+    display: none;
+    position: absolute;
+    top: calc(env(safe-area-inset-top, 0px) + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 50;
+    align-items: center;
+    height: 40px;
+    border-radius: 20px;
+    background-color: rgba(0, 0, 0, 0.60);
+    -webkit-backdrop-filter: blur(20px) saturate(140%);
+    backdrop-filter: blur(20px) saturate(140%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+body.split-2 .pane-pill,
+body.split-4 .pane-pill { display: flex; }
+
+.pane-seg {
+    all: unset;
+    width: 44px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.82);
+    position: relative;
+    transition: color 180ms ease, background-color 180ms ease, transform 120ms ease;
+}
+.pane-seg + .pane-seg::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: rgba(255, 255, 255, 0.08);
+}
+.pane-seg:active { transform: scale(0.94); background-color: rgba(255, 255, 255, 0.06); }
+.pane-seg .material-icons { font-size: 20px; line-height: 1; }
+.pane-seg.selectedButton { color: var(--dark-primary-color); }
+.pane-seg.selectedButton::after {
+    content: '';
+    position: absolute;
+    bottom: 3px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 14px;
+    height: 2px;
+    border-radius: 1px;
+    background: var(--dark-primary-color);
+}
+.pane-seg.stale-data { color: #ffb74d; }
+
+/* In split layouts the per-pane pills replace the global category pill. Hide
+   only the .pill — the ⋯ menu button (which holds the Näkymä switcher) lives in
+   the same toolbar and must stay reachable. */
+body.split-2 #primaryToolbar .pill,
+body.split-4 #primaryToolbar .pill { display: none; }
+
 /* Common style for top and bottom toolbars. */
 .toolbar {
   position: fixed;
@@ -460,7 +525,8 @@ body.split-4 #map-3 { display: block; }
   body.app-fullscreen #overflowMenu,
   body.app-fullscreen #overflowMenuBackdrop,
   body.app-fullscreen #playList,
-  body.app-fullscreen #playListBackdrop { display: none !important; }
+  body.app-fullscreen #playListBackdrop,
+  body.app-fullscreen .pane-pill { display: none !important; }
 
   /* No timebar underneath, so the chip drops to the screen bottom. */
   body.app-fullscreen #timeChip {

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -111,6 +111,16 @@ body.split-4 #map-3 { display: block; }
 body.split-2 .pane-pill,
 body.split-4 .pane-pill { display: flex; }
 
+/* Only top-row panes touch the device's top edge, so only they need the top
+   safe-area inset (notch / dynamic island). Bottom-row panes sit mid-screen —
+   drop the inset so their pill hugs the pane top instead of floating down.
+   Bottom row = stacked 2-up's lower pane (portrait) and 4-up's bottom two. */
+@media (orientation: portrait) {
+  body.split-2 #map-1 .pane-pill { top: 8px; }
+}
+body.split-4 #map-2 .pane-pill,
+body.split-4 #map-3 .pane-pill { top: 8px; }
+
 .pane-seg {
     all: unset;
     width: 44px;

--- a/assets/radar.css
+++ b/assets/radar.css
@@ -154,6 +154,17 @@ body.split-4 .pane-pill { display: flex; }
 body.split-2 #primaryToolbar .pill,
 body.split-4 #primaryToolbar .pill { display: none; }
 
+/* With the pill hidden the ⋯ button is the only child of the centred toolbar,
+   so at narrow widths (< 600px, where it isn't yet docked) it would centre
+   itself over the panes' pills. Dock it top-right at every width in split. */
+body.split-2 #menuButton,
+body.split-4 #menuButton {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 8px);
+  right: max(16px, env(safe-area-inset-right, 0px) + 16px);
+  z-index: 100;
+}
+
 /* Common style for top and bottom toolbars. */
 .toolbar {
   position: fixed;

--- a/src/animation/stickyImageWMS.js
+++ b/src/animation/stickyImageWMS.js
@@ -3,11 +3,20 @@ import ImageState from 'ol/ImageState';
 
 // Shared frame-blob cache across ALL sources — and therefore all split panes.
 // The GetMap URL (`src`) is deterministic from the layer params plus the
-// requested extent/resolution, so two panes showing the same layer over the
-// same area (equal-size panes sharing one View) build byte-identical URLs.
-// Keying by `src` means that frame is fetched ONCE and every pane reuses the
-// blob: no duplicate network traffic, and same-layer panes' slots load in
-// lockstep (so they stay time-synced without any playback barrier).
+// requested WIDTH/HEIGHT/BBOX, so two panes showing the same layer over the
+// same area build byte-identical URLs. Keying by `src` means that frame is
+// fetched ONCE and every pane reuses the blob: no duplicate network traffic,
+// and same-layer panes' slots load in lockstep (so they stay time-synced
+// without any playback barrier).
+//
+// IMPORTANT — dedup only engages when the panes are PIXEL-IDENTICAL. Each pane
+// requests WIDTH/HEIGHT/BBOX derived from its own viewport size; a CSS grid
+// `1fr 1fr` on an odd-width screen yields e.g. 360 vs 361 px, so the two panes
+// ask for different-sized images of different extents → different `src` →
+// separate fetches. That's correct: the images genuinely differ, so we must
+// NOT normalize the key (rounding BBOX / sizes to force a hit would hand a pane
+// a wrong-sized image for its extent). Off-by-one panes simply fall back to
+// independent (correct) fetches — the optimization is best-effort.
 //
 // Entry: { blob: Blob|null, promise: Promise<Blob>|null }. Map insertion order
 // gives us a cheap LRU.

--- a/src/animation/stickyImageWMS.js
+++ b/src/animation/stickyImageWMS.js
@@ -1,55 +1,87 @@
 import ImageWMS from 'ol/source/ImageWMS';
 import ImageState from 'ol/ImageState';
 
-// fetch() + AbortController based image loader. Each source tracks the
-// in-flight request; a new call aborts the previous one. This prevents
-// superseded requests (after rapid pan/zoom) from wasting server cycles
-// and bandwidth after the user has moved on.
+// Shared frame-blob cache across ALL sources — and therefore all split panes.
+// The GetMap URL (`src`) is deterministic from the layer params plus the
+// requested extent/resolution, so two panes showing the same layer over the
+// same area (equal-size panes sharing one View) build byte-identical URLs.
+// Keying by `src` means that frame is fetched ONCE and every pane reuses the
+// blob: no duplicate network traffic, and same-layer panes' slots load in
+// lockstep (so they stay time-synced without any playback barrier).
 //
-// OL's default loader sets `img.src = url`, which the browser can't
-// reliably cancel. fetch() supports AbortSignal and has consistent
-// cancellation behavior.
-//
-// Flow: fetch response → Blob → object URL → img.src. The image element
-// fires 'load' which resolves OL's internal decode()/load() path the
-// same as a direct src assignment.
-function createAbortableImageLoader(source) {
+// Entry: { blob: Blob|null, promise: Promise<Blob>|null }. Map insertion order
+// gives us a cheap LRU.
+const frameBlobCache = new Map();
+const FRAME_BLOB_CACHE_MAX = 400;
+
+function evictFrameCache() {
+  // Drop oldest COMPLETED entries until under the cap; never evict an in-flight
+  // fetch (a consumer is still awaiting it).
+  for (const [key, entry] of frameBlobCache) {
+    if (frameBlobCache.size <= FRAME_BLOB_CACHE_MAX) break;
+    if (entry.promise) continue; // eslint-disable-line no-continue
+    frameBlobCache.delete(key);
+  }
+}
+
+// Fetch a frame blob, deduping completed AND in-flight requests by `src`. The
+// shared fetch is not tied to any one consumer's lifecycle, so a pane that pans
+// away doesn't cancel a fetch another pane still needs. (We trade the old
+// per-source abort-on-supersession for cross-pane dedup; FramePool already
+// suppresses fetches during active pan/zoom gestures, so superseded in-flight
+// requests are rare.)
+function sharedFetchBlob(src) {
+  let entry = frameBlobCache.get(src);
+  if (entry) {
+    frameBlobCache.delete(src); // LRU bump
+    frameBlobCache.set(src, entry);
+    if (entry.blob) return Promise.resolve(entry.blob);
+    if (entry.promise) return entry.promise;
+  } else {
+    entry = {};
+    frameBlobCache.set(src, entry);
+  }
+  entry.promise = fetch(src)
+    .then((res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.blob();
+    })
+    .then((blob) => {
+      entry.blob = blob;
+      entry.promise = null;
+      evictFrameCache();
+      return blob;
+    })
+    .catch((err) => {
+      frameBlobCache.delete(src);
+      throw err;
+    });
+  return entry.promise;
+}
+
+// Image loader: pull the blob from the shared cache, then point the image
+// element at a per-image object URL. `source._wantedSrc` guards against a
+// superseded request (the source moved to a new extent before the old fetch
+// resolved) so a stale completion is ignored instead of clobbering the wrapper.
+function createSharedImageLoader(source) {
   return (imageWrapper, src) => {
-    if (source._currentAbortController) {
-      source._currentAbortController.abort();
-    }
-    const controller = new AbortController();
-    source._currentAbortController = controller;
-
+    source._wantedSrc = src;
     const htmlImage = imageWrapper.getImage();
-
-    fetch(src, { signal: controller.signal })
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.blob();
-      })
-      .then((blob) => {
-        if (controller.signal.aborted) return;
-        if (source._currentAbortController === controller) {
-          source._currentAbortController = null;
-        }
-        const blobUrl = URL.createObjectURL(blob);
-        const revoke = () => URL.revokeObjectURL(blobUrl);
-        htmlImage.addEventListener('load', revoke, { once: true });
-        htmlImage.addEventListener('error', revoke, { once: true });
-        htmlImage.src = blobUrl;
-      })
+    const assign = (blob) => {
+      if (source._wantedSrc !== src) return; // superseded by a newer extent
+      const blobUrl = URL.createObjectURL(blob);
+      const revoke = () => URL.revokeObjectURL(blobUrl);
+      htmlImage.addEventListener('load', revoke, { once: true });
+      htmlImage.addEventListener('error', revoke, { once: true });
+      htmlImage.src = blobUrl;
+    };
+    sharedFetchBlob(src)
+      .then(assign)
       .catch(() => {
-        // On abort or network error, dispatch an error event on the
-        // image so OL's internal load promise rejects and the wrapper
-        // transitions to ERROR state. Superseded request events are
-        // filtered by event.image !== source.image in FramePool.
-        //
-        // Note: OL's ImageWrapper logs an `Image load error` to the
-        // console for every rejected load, including aborts. That's
-        // accepted noise; the alternative (leaving the wrapper in
-        // LOADING state forever) leaks state and is worse.
-        htmlImage.dispatchEvent(new Event('error'));
+        // Dispatch an error so OL's load promise rejects and the wrapper hits
+        // ERROR state. Superseded events are filtered in FramePool by
+        // event.image !== source.image.
+        if (source._wantedSrc === src) htmlImage.dispatchEvent(new Event('error'));
       });
   };
 }
@@ -66,8 +98,8 @@ export default class StickyImageWMS extends ImageWMS {
   constructor(options) {
     super(options);
     this._sticky = null;
-    this._currentAbortController = null;
-    this.setImageLoadFunction(createAbortableImageLoader(this));
+    this._wantedSrc = null;
+    this.setImageLoadFunction(createSharedImageLoader(this));
   }
 
   getImage(extent, resolution, pixelRatio, projection) {
@@ -116,12 +148,10 @@ export default class StickyImageWMS extends ImageWMS {
   // can't match either via the wanted hint or the cached wrapper.
   //
   // Sticky is preserved so the layer keeps drawing the old-extent
-  // image while the new wrapper loads.
+  // image while the new wrapper loads. A still-in-flight shared fetch is
+  // left running (other panes may need it); its result is ignored here
+  // because the next loader call updates `_wantedSrc`.
   resetImageCache() {
-    if (this._currentAbortController) {
-      this._currentAbortController.abort();
-      this._currentAbortController = null;
-    }
     this.image = null;
     this.wantedExtent_ = null;
     this.wantedResolution_ = null;

--- a/src/index.html
+++ b/src/index.html
@@ -110,6 +110,13 @@
       <button class="chip" role="radio" aria-checked="false" data-interp="crossfade">Häivytys</button>
       <button class="chip" role="radio" aria-checked="false" data-interp="flow">Virtaus</button>
     </div>
+    <div class="menu-divider"></div>
+    <div class="menu-header">Näkymä</div>
+    <div class="theme-chips" role="radiogroup" aria-label="Näkymä">
+      <button class="chip" role="radio" aria-checked="true" data-layout="1-up" aria-label="Yksi ruutu">1</button>
+      <button class="chip" role="radio" aria-checked="false" data-layout="2-up" aria-label="Kaksi ruutua">2</button>
+      <button class="chip" role="radio" aria-checked="false" data-layout="4-up" aria-label="Neljä ruutua">2×2</button>
+    </div>
   </div>
 
   <button id="timeChip" class="time-chip noselect" type="button" aria-label="Nykyinen aika — napauta vaihtaaksesi paikallisaika / UTC">
@@ -202,7 +209,12 @@
     </div>
   </div>
 
-  <div id="map"></div>
+  <div id="paneGrid">
+    <div id="map" class="pane"></div>
+    <div id="map-1" class="pane"></div>
+    <div id="map-2" class="pane"></div>
+    <div id="map-3" class="pane"></div>
+  </div>
 
   <div id="timecontrol" class="toolbar noselect">
     <div id="probeChart" hidden aria-hidden="true"></div>

--- a/src/longpress.js
+++ b/src/longpress.js
@@ -2,7 +2,13 @@
  * Creates a long-press handler for a button that shows a context menu.
  * Short tap (< 500ms) calls onTap. Long press (>= 500ms) shows the menu.
  *
- * @param {string} buttonId - DOM id of the trigger button
+ * Multiple handlers may share one menu (e.g. the same radar sublayer menu
+ * opened from the global toolbar AND from each split pane's mini pill). To
+ * avoid double-firing, the menu items are wired exactly once per menu; each
+ * handler installs its own `onSelect` as the menu's *current* select callback
+ * when it opens. Since only one menu is open at a time, the last opener wins.
+ *
+ * @param {string|HTMLElement} button - the trigger button (DOM id or element)
  * @param {string} menuId - DOM id of the context menu
  * @param {Function} onTap - called on short tap
  * @param {Function} onSelect - called with the selected menu item's data-layer value
@@ -11,14 +17,20 @@
  * @param {Function} [onMenuShown] - called whenever the long-press menu opens
  * @returns {{ show: Function, hide: Function }}
  */
-function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLayer, isLayerVisible, onMenuShown) {
+function createLongPressHandler(button, menuId, onTap, onSelect, getActiveLayer, isLayerVisible, onMenuShown) {
   let timer = null;
   let triggered = false;
   let startTime = 0;
-  const button = document.getElementById(buttonId);
+  const buttonEl = typeof button === 'string' ? document.getElementById(button) : button;
 
   function showMenu() {
     const menu = document.getElementById(menuId);
+    // Install this handler's select callback as the menu's current one, so a
+    // pick routes back to the button/pane that opened it. Record the opener so
+    // the outside-click closer doesn't dismiss the menu when this very button
+    // is released after the long press.
+    menu._lpOnSelect = onSelect;
+    menu._lpOpener = buttonEl;
     const menuItems = menu.querySelectorAll('.menu-item');
     const currentLayer = getActiveLayer();
     const visible = isLayerVisible();
@@ -28,7 +40,7 @@ function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLaye
 
     const vw = window.innerWidth;
     const vh = window.innerHeight;
-    const br = button.getBoundingClientRect();
+    const br = buttonEl.getBoundingClientRect();
     menu.style.display = 'block';
     menu.style.visibility = 'hidden';
     const mr = menu.getBoundingClientRect();
@@ -68,25 +80,28 @@ function createLongPressHandler(buttonId, menuId, onTap, onSelect, getActiveLaye
     triggered = false;
   }
 
-  button.addEventListener('mousedown', start);
-  button.addEventListener('mouseup', end);
-  button.addEventListener('mouseleave', cancel);
-  button.addEventListener('touchstart', (e) => { e.preventDefault(); start(e); });
-  button.addEventListener('touchend', (e) => { e.preventDefault(); end(e); });
-  button.addEventListener('touchmove', (e) => { e.preventDefault(); cancel(); });
-  button.addEventListener('touchcancel', (e) => { e.preventDefault(); cancel(); });
+  buttonEl.addEventListener('mousedown', start);
+  buttonEl.addEventListener('mouseup', end);
+  buttonEl.addEventListener('mouseleave', cancel);
+  buttonEl.addEventListener('touchstart', (e) => { e.preventDefault(); start(e); });
+  buttonEl.addEventListener('touchend', (e) => { e.preventDefault(); end(e); });
+  buttonEl.addEventListener('touchmove', (e) => { e.preventDefault(); cancel(); });
+  buttonEl.addEventListener('touchcancel', (e) => { e.preventDefault(); cancel(); });
 
-  // Menu item click/touch handlers
-  document.querySelectorAll(`#${menuId} .menu-item`).forEach((item) => {
-    item.addEventListener('click', function () {
-      onSelect(this.getAttribute('data-layer'));
+  // Wire the menu items exactly once per menu — subsequent handlers reuse the
+  // same wiring via the menu's current `_lpOnSelect`.
+  const menu = document.getElementById(menuId);
+  if (menu && !menu._lpWired) {
+    menu._lpWired = true;
+    menu.querySelectorAll('.menu-item').forEach((item) => {
+      const pick = (e) => {
+        if (e) { e.preventDefault(); e.stopPropagation(); }
+        if (menu._lpOnSelect) menu._lpOnSelect(item.getAttribute('data-layer'));
+      };
+      item.addEventListener('click', pick);
+      item.addEventListener('touchend', pick);
     });
-    item.addEventListener('touchend', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      onSelect(this.getAttribute('data-layer'));
-    });
-  });
+  }
 
   return { show: showMenu, hide: hideMenu };
 }

--- a/src/longpress.js
+++ b/src/longpress.js
@@ -17,6 +17,20 @@
  * @param {Function} [onMenuShown] - called whenever the long-press menu opens
  * @returns {{ show: Function, hide: Function }}
  */
+// Per-menu state, kept off the DOM. A shared sublayer menu may be driven by
+// several handlers (the global toolbar in 1-up, every pane pill in split); only
+// one is open at a time, so we track its current select callback + opener here.
+const menuState = new WeakMap(); // menuEl -> { onSelect, opener }
+const wiredMenus = new WeakSet(); // menus whose items are already wired
+
+// Which button currently owns a menu (set on open). The outside-click closer in
+// radar.js uses this so releasing the opener after a long press doesn't dismiss
+// the menu it just opened.
+export function longPressMenuOpener(menuEl) {
+  const state = menuEl && menuState.get(menuEl);
+  return (state && state.opener) || null;
+}
+
 function createLongPressHandler(button, menuId, onTap, onSelect, getActiveLayer, isLayerVisible, onMenuShown) {
   let timer = null;
   let triggered = false;
@@ -25,12 +39,11 @@ function createLongPressHandler(button, menuId, onTap, onSelect, getActiveLayer,
 
   function showMenu() {
     const menu = document.getElementById(menuId);
-    // Install this handler's select callback as the menu's current one, so a
-    // pick routes back to the button/pane that opened it. Record the opener so
-    // the outside-click closer doesn't dismiss the menu when this very button
-    // is released after the long press.
-    menu._lpOnSelect = onSelect;
-    menu._lpOpener = buttonEl;
+    // Install this handler's select callback + opener as the menu's current
+    // state, so a pick routes back to the button/pane that opened it and the
+    // outside-click closer doesn't dismiss the menu when this very button is
+    // released after the long press.
+    menuState.set(menu, { onSelect, opener: buttonEl });
     const menuItems = menu.querySelectorAll('.menu-item');
     const currentLayer = getActiveLayer();
     const visible = isLayerVisible();
@@ -89,14 +102,15 @@ function createLongPressHandler(button, menuId, onTap, onSelect, getActiveLayer,
   buttonEl.addEventListener('touchcancel', (e) => { e.preventDefault(); cancel(); });
 
   // Wire the menu items exactly once per menu — subsequent handlers reuse the
-  // same wiring via the menu's current `_lpOnSelect`.
+  // same wiring via the menu's current state.
   const menu = document.getElementById(menuId);
-  if (menu && !menu._lpWired) {
-    menu._lpWired = true;
+  if (menu && !wiredMenus.has(menu)) {
+    wiredMenus.add(menu);
     menu.querySelectorAll('.menu-item').forEach((item) => {
       const pick = (e) => {
         if (e) { e.preventDefault(); e.stopPropagation(); }
-        if (menu._lpOnSelect) menu._lpOnSelect(item.getAttribute('data-layer'));
+        const state = menuState.get(menu);
+        if (state && state.onSelect) state.onSelect(item.getAttribute('data-layer'));
       };
       item.addEventListener('click', pick);
       item.addEventListener('touchend', pick);

--- a/src/pane.js
+++ b/src/pane.js
@@ -1,0 +1,342 @@
+// Pane factory — encapsulates everything that is per-map: the OpenLayers Map,
+// its full layer stack (basemaps, 4 content layers, vector overlays), the
+// per-pane GPS marker features, and the per-pane mutable selection state
+// (VISIBLE / ACTIVE_LAYERS / LAYER_IN_RANGE).
+//
+// Split-screen renders N panes that all share ONE `ol/View` (passed in) so they
+// pan/zoom in lockstep — the canonical OpenLayers "shared view" pattern. The
+// global clock (in radar.js) drives every pane's FramePools off the same
+// startDate. FramePools are NOT built here: radar.js owns them (it imports
+// FramePool and wires the timeline-aggregation callbacks) and attaches them to
+// `pane.framePools` via buildPanePools().
+//
+// pane 0 is the original single map; its VISIBLE/ACTIVE_LAYERS/LAYER_IN_RANGE
+// objects are the same instances radar.js aliases as its module globals, so the
+// existing single-map code path is byte-for-byte unchanged in 1-up.
+
+import { Map } from 'ol';
+import TileLayer from 'ol/layer/Tile';
+import ImageLayer from 'ol/layer/Image';
+import VectorLayer from 'ol/layer/Vector';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import XYZ from 'ol/source/XYZ';
+import ImageWMS from 'ol/source/ImageWMS';
+import VectorTileSource from 'ol/source/VectorTile';
+import GeoJSON from 'ol/format/GeoJSON';
+import MVT from 'ol/format/MVT';
+import Vector from 'ol/source/Vector';
+import Feature from 'ol/Feature';
+import {
+  Circle as CircleStyle, Fill, Stroke, Style,
+} from 'ol/style';
+
+// The blue GPS dot + grey accuracy disc. One pair per pane so the marker can
+// render in every pane; radar.js updates each pane's geometry on GPS change.
+function makePositionFeatures() {
+  const positionFeature = new Feature();
+  positionFeature.setStyle(new Style({
+    image: new CircleStyle({
+      radius: 6,
+      fill: new Fill({ color: '#3399CC' }),
+      stroke: new Stroke({ color: '#fff', width: 2 }),
+    }),
+  }));
+
+  const accuracyFeature = new Feature();
+  accuracyFeature.setStyle(new Style({
+    fill: new Fill({ color: [128, 128, 128, 0.3] }),
+  }));
+
+  return { positionFeature, accuracyFeature };
+}
+
+// Build one pane. `deps` carries the shared singletons the layers reference:
+//   options          — wmsServerConfiguration, imageRatio, default layer names
+//   radarSiteSource  — shared VectorSource feeding every pane's radarSiteLayer
+//   radarStyle, icaoStyle, municipalityStyleLight, vesivaylatStyleFn,
+//   vesivaylaAreaStyle, rangeStyle — shared Style objects / style functions
+//   visible          — Set seed for this pane's VISIBLE (used as-is, not cloned)
+//   activeLayers     — object seed for this pane's ACTIVE_LAYERS (used as-is)
+export default function createPane(targetEl, sharedView, deps) {
+  const {
+    options,
+    radarSiteSource,
+    radarStyle,
+    icaoStyle,
+    municipalityStyleLight,
+    vesivaylatStyleFn,
+    vesivaylaAreaStyle,
+    rangeStyle,
+    visible,
+    activeLayers,
+    layerInRange = {},
+    // For pane 0 the caller passes its existing module-global framePools object
+    // so radar.js's `framePools` const and `pane0.framePools` are one and the
+    // same; new panes get a fresh holder. buildPanePools() fills it later.
+    framePools = {
+      satelliteLayer: null,
+      radarLayer: null,
+      lightningLayer: null,
+      observationLayer: null,
+    },
+    index = 0,
+  } = deps;
+
+  const VISIBLE = visible;
+  const ACTIVE_LAYERS = activeLayers;
+  const LAYER_IN_RANGE = layerInRange;
+
+  //
+  // BASEMAPS
+  //
+  const imageryBaseLayer = new TileLayer({
+    visible: false,
+    source: new XYZ({
+      attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer">ArcGIS</a>',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    }),
+  });
+
+  const lightGrayBaseLayer = new TileLayer({
+    visible: false,
+    preload: Infinity,
+    source: new XYZ({
+      attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer">ArcGIS</a>',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}',
+    }),
+  });
+
+  const lightGrayReferenceLayer = new TileLayer({
+    visible: false,
+    source: new XYZ({
+      attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer">ArcGIS</a>',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
+    }),
+  });
+
+  const darkGrayBaseLayer = new TileLayer({
+    preload: Infinity,
+    source: new XYZ({
+      attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer">ArcGIS</a>',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}',
+    }),
+  });
+
+  const darkGrayReferenceLayer = new TileLayer({
+    source: new XYZ({
+      attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer">ArcGIS</a>',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
+    }),
+  });
+
+  //
+  // CONTENT LAYERS
+  //
+  const satelliteLayer = new ImageLayer({
+    name: 'satelliteLayer',
+    visible: VISIBLE.has('satelliteLayer'),
+    opacity: 0.7,
+    source: new ImageWMS({
+      url: options.wmsServerConfiguration.eumetsat1.url,
+      params: { FORMAT: 'image/jpeg', LAYERS: 'rgb_eview' },
+      hidpi: false,
+      attributions: 'EUMETSAT',
+      ratio: options.imageRatio,
+      serverType: 'geoserver',
+    }),
+  });
+  satelliteLayer.set('defaultFormat', 'image/jpeg');
+  satelliteLayer.set('defaultTransparent', false);
+
+  const radarLayer = new ImageLayer({
+    name: 'radarLayer',
+    visible: VISIBLE.has('radarLayer'),
+    opacity: 0.7,
+    source: new ImageWMS({
+      url: options.wmsServerConfiguration.fi.url,
+      params: { LAYERS: options.defaultRadarLayer },
+      attributions: 'FMI (CC-BY-4.0)',
+      ratio: options.imageRatio,
+      hidpi: false,
+      serverType: 'geoserver',
+      // Lets the center-crosshair tool read the rendered radar pixel colour off
+      // the canvas (getData) without tainting it. The meteocore WMS returns
+      // Access-Control-Allow-Origin: *, so it's safe.
+      crossOrigin: 'anonymous',
+    }),
+  });
+  radarLayer.set('defaultFormat', 'image/png');
+  // Opt out of the webp wire format for radar specifically (see radar.js notes).
+  radarLayer.set('disableWebp', true);
+
+  const lightningLayer = new ImageLayer({
+    name: 'lightningLayer',
+    visible: VISIBLE.has('lightningLayer'),
+    source: new ImageWMS({
+      url: options.wmsServerConfiguration['meteo-obs-new'].url,
+      params: { FORMAT: 'image/png8', LAYERS: options.defaultLightningLayer },
+      ratio: options.imageRatio,
+      hidpi: false,
+      serverType: 'geoserver',
+    }),
+  });
+  lightningLayer.set('defaultFormat', 'image/png8');
+
+  const observationLayer = new ImageLayer({
+    name: 'observationLayer',
+    visible: VISIBLE.has('observationLayer'),
+    source: new ImageWMS({
+      url: options.wmsServerConfiguration['meteo-obs-new'].url,
+      params: { FORMAT: 'image/png8', LAYERS: options.defaultObservationLayer },
+      ratio: options.imageRatio,
+      hidpi: false,
+      serverType: 'geoserver',
+    }),
+  });
+  observationLayer.set('defaultFormat', 'image/png8');
+
+  // Back-reference so radar.js can resolve which pane owns a layer when a
+  // layer-level event (change:visible / propertychange) fires.
+  satelliteLayer.set('_paneIndex', index);
+  radarLayer.set('_paneIndex', index);
+  lightningLayer.set('_paneIndex', index);
+  observationLayer.set('_paneIndex', index);
+
+  //
+  // VECTOR OVERLAYS
+  //
+  const radarSiteLayer = new VectorLayer({
+    source: radarSiteSource,
+    style(feature) {
+      radarStyle.getText().setText(feature.get('name'));
+      return radarStyle;
+    },
+  });
+
+  const icaoLayer = new VectorLayer({
+    source: new Vector({
+      format: new GeoJSON(),
+      url: 'airfields-finland.json',
+    }),
+    visible: false,
+    style(feature) {
+      icaoStyle.getText().setText(feature.get('icao'));
+      return icaoStyle;
+    },
+  });
+
+  const municipalityLayer = new VectorTileLayer({
+    visible: false,
+    renderMode: 'vector',
+    source: new VectorTileSource({
+      format: new MVT(),
+      url: 'https://meteocore.app.meteo.fi/tiles/collections/fi-municipalities/tiles/WebMercatorQuad/{z}/{y}/{x}?f=mvt',
+      attributions: 'Statistics Finland / Tilastokeskus',
+      maxZoom: 14,
+    }),
+    style: municipalityStyleLight,
+  });
+
+  const vesivaylaAreaLayer = new VectorLayer({
+    visible: false,
+    source: new Vector({
+      format: new GeoJSON(),
+      url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylaalueet_uusi/items?f=application/geo%2Bjson&limit=10000',
+      attributions: 'Väylävirasto',
+    }),
+    style: vesivaylaAreaStyle,
+  });
+
+  const vesivaylatLayer = new VectorLayer({
+    visible: false,
+    declutter: true,
+    source: new Vector({
+      format: new GeoJSON(),
+      url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylat_uusi/items?f=application/geo%2Bjson&limit=10000',
+      attributions: 'Väylävirasto',
+    }),
+    style: vesivaylatStyleFn,
+  });
+
+  const guideLayer = new VectorLayer({
+    source: new Vector(),
+    style: rangeStyle,
+  });
+
+  const { positionFeature, accuracyFeature } = makePositionFeatures();
+  const ownPositionLayer = new VectorLayer({
+    visible: false,
+    source: new Vector({
+      features: [accuracyFeature, positionFeature],
+    }),
+  });
+
+  const layerss = {
+    satelliteLayer,
+    radarLayer,
+    observationLayer,
+    lightningLayer,
+  };
+
+  const layers = [
+    lightGrayBaseLayer,
+    darkGrayBaseLayer,
+    imageryBaseLayer,
+    satelliteLayer,
+    radarLayer,
+    guideLayer,
+    lightningLayer,
+    lightGrayReferenceLayer,
+    darkGrayReferenceLayer,
+    municipalityLayer,
+    vesivaylaAreaLayer,
+    vesivaylatLayer,
+    radarSiteLayer,
+    icaoLayer,
+    ownPositionLayer,
+    observationLayer,
+  ];
+
+  const map = new Map({
+    target: targetEl,
+    layers,
+    controls: [],
+    view: sharedView,
+    keyboardEventTarget: document,
+  });
+
+  return {
+    index,
+    el: targetEl,
+    map,
+    view: sharedView,
+    layers,
+    layerss,
+    // individual layer handles
+    imageryBaseLayer,
+    lightGrayBaseLayer,
+    lightGrayReferenceLayer,
+    darkGrayBaseLayer,
+    darkGrayReferenceLayer,
+    satelliteLayer,
+    radarLayer,
+    lightningLayer,
+    observationLayer,
+    radarSiteLayer,
+    icaoLayer,
+    municipalityLayer,
+    vesivaylaAreaLayer,
+    vesivaylatLayer,
+    guideLayer,
+    ownPositionLayer,
+    positionFeature,
+    accuracyFeature,
+    // per-pane mutable state
+    VISIBLE,
+    ACTIVE_LAYERS,
+    LAYER_IN_RANGE,
+    // FramePools are attached later by radar.js buildPanePools()
+    framePools,
+    updateSize() { map.updateSize(); },
+  };
+}

--- a/src/radar.js
+++ b/src/radar.js
@@ -92,6 +92,17 @@ const framePools = {
 // it. pane 0 is pushed in the bootstrap below; setLayout() adds the rest.
 const panes = [];
 
+// The four content categories + their pill icon and shared sublayer-menu id.
+// Declared up here so the per-pane init helpers (initNewPane / buildPanePill)
+// can reference them.
+const PILL_CATEGORIES = ['satelliteLayer', 'radarLayer', 'lightningLayer', 'observationLayer'];
+const CATEGORY_UI = {
+  satelliteLayer: { icon: 'satellite_alt', menu: 'satelliteLongPressMenu', aria: 'Satelliitti' },
+  radarLayer: { icon: 'radar', menu: 'radarLongPressMenu', aria: 'Säätutka' },
+  lightningLayer: { icon: 'bolt', menu: 'lightningLongPressMenu', aria: 'Salamat' },
+  observationLayer: { icon: 'thermostat', menu: 'observationLongPressMenu', aria: 'Havainto' },
+};
+
 // Three interpolation modes:
 //   - 'off'       : no warp layer; animation shows discrete frames only.
 //   - 'crossfade' : warp layer with zero-flow — smooth A→B fade.
@@ -650,6 +661,13 @@ function clonePaneDisplay(src, dst) {
 function initNewPane(pane) {
   buildPanePools(pane);
   clonePaneDisplay(pane0, pane);
+  // Attach the per-pane visibility listener AFTER mirroring (so the clone
+  // doesn't fire a burst of change events before the pane is ready). The
+  // playlist propertychange listener is pane-0 only, so it's not attached here.
+  for (const name of PILL_CATEGORIES) {
+    pane.layerss[name].on('change:visible', onChangeVisible);
+  }
+  buildPanePill(pane);
   setMapLayer(getEffectiveTheme());
   applyPoiVisibility();
   attachInterpolators();
@@ -911,9 +929,11 @@ function setTime(action = 'next') {
   const routeLayer = (pane, name, window, currentTime) => {
     const olLayer = pane.layerss[name];
     const button = pane.index === 0 ? document.getElementById(`${name}Button`) : null;
+    const pillBtn = pane.pillButtons && pane.pillButtons[name];
 
     if (!pane.VISIBLE.has(name)) {
       if (button) button.classList.remove('stale-data');
+      if (pillBtn) pillBtn.classList.remove('stale-data');
       olLayer.setOpacity(1);
       pane.LAYER_IN_RANGE[name] = true;
       return;
@@ -924,6 +944,7 @@ function setTime(action = 'next') {
 
     const isStale = !!(info && info.end && Date.now() - info.end > STALE_THRESHOLD_MS);
     if (button) button.classList.toggle('stale-data', isStale);
+    if (pillBtn) pillBtn.classList.toggle('stale-data', isStale);
 
     const inRange = !info || !info.start || !info.end
       || (tNow >= info.start && tNow <= info.end);
@@ -1219,9 +1240,13 @@ function updateLayer(layer, wmslayer, opts = {}) {
     trackCategory(layer, { action: 'pick', layer: wmslayer, source });
   }
   debug(layerInfo[wmslayer]);
+  const pane = paneOf(layer);
+  const isPane0 = pane === pane0;
   const info = layerInfo[wmslayer];
   layer.set('info', info);
-  if (document.getElementById(wmslayer)) {
+  // The #layers selection list belongs to the primary pane; don't repaint it
+  // for a background pane's sublayer change.
+  if (isPane0 && document.getElementById(wmslayer)) {
     removeSelectedParameter(`#${layer.get('name')} > div`);
     document.getElementById(wmslayer).classList.add('selected');
   }
@@ -1258,20 +1283,22 @@ function updateLayer(layer, wmslayer, opts = {}) {
   }
   if (!skipPersist) {
     const category = layer.get('name');
-    if (category && ACTIVE_LAYERS[category] !== wmslayer) {
-      ACTIVE_LAYERS[category] = wmslayer;
-      persistActiveLayers();
+    if (category && pane.ACTIVE_LAYERS[category] !== wmslayer) {
+      pane.ACTIVE_LAYERS[category] = wmslayer;
+      // Only the primary pane persists to localStorage; background panes are
+      // re-seeded by mirroring when a split is (re)entered.
+      if (isPane0) persistActiveLayers();
     }
   }
   if (!skipVisibility) {
     if (layer.getVisible()) {
-      updateCanonicalPage();
+      if (isPane0) updateCanonicalPage();
     } else {
       layer.setVisible(true);
     }
   }
-  updateLayerSelectionSelected();
-  if (probe && layer === radarLayer) {
+  if (isPane0) updateLayerSelectionSelected();
+  if (isPane0 && probe && layer === radarLayer) {
     // Pass the elevation (set in single-site mode) so the EDR probe queries the
     // displayed sweep; composites carry no ELEVATION param (z stays null).
     probe.setActiveLayer(layer.getVisible() ? wmslayer : null, {
@@ -1312,21 +1339,21 @@ function fitToLayerExtent(wmslayer) {
 // 'radarLayer') after that category's WMS GetCapabilities has populated
 // layerInfo. If the stored layer is no longer advertised by the server,
 // drop it — the layer stays at its constructor-time default.
-function restoreActiveLayer(category) {
+function restoreActiveLayer(category, pane = pane0) {
   if (!category) return;
-  // While drilled into a single radar site, the radar layer intentionally runs
-  // a transient `<collection>/DBZH` product that is NOT in ACTIVE_LAYERS. Skip
-  // the restore so the periodic (60 s) capabilities refresh doesn't revert it
-  // back to the stored composite mid-session.
-  if (category === 'radarLayer' && radarSite && radarSite.isSingleSiteActive()) return;
-  const olLayer = layerss[category];
+  // While drilled into a single radar site (primary pane only), the radar layer
+  // runs a transient `<collection>/DBZH` product that is NOT in ACTIVE_LAYERS.
+  // Skip the restore so the periodic (60 s) capabilities refresh doesn't revert
+  // it back to the stored composite mid-session.
+  if (category === 'radarLayer' && pane === pane0 && radarSite && radarSite.isSingleSiteActive()) return;
+  const olLayer = pane.layerss[category];
   if (!olLayer) return;
-  const stored = ACTIVE_LAYERS[category];
+  const stored = pane.ACTIVE_LAYERS[category];
   if (!stored) return;
 
   if (!layerInfo[stored] || layerInfo[stored].category !== category) {
-    delete ACTIVE_LAYERS[category];
-    persistActiveLayers();
+    delete pane.ACTIVE_LAYERS[category];
+    if (pane === pane0) persistActiveLayers();
     return;
   }
 
@@ -1433,6 +1460,10 @@ const _playlistSliderHandlers = {};
 
 function layerInfoPlaylist(event) {
   const layer = event.target;
+  // The playlist reflects the primary pane only; ignore background panes'
+  // property changes entirely (FIRST check — this fires on every source swap
+  // during playback, so it must stay cheap for non-pane-0 layers).
+  if (layer.get('_paneIndex')) return;
   const name = layer.get('name');
   const info = layer.get('info');
   // Prefer the user-chosen opacity when the interpolator has zeroed
@@ -1581,31 +1612,33 @@ function onChangeVisible(event) {
   const wmslayer = layer.getSource().getParams().LAYERS;
   const name = layer.get('name');
   const isVisible = layer.getVisible();
-  removeSelectedParameter(`#${name} > div`);
-  if (isVisible) {
-    debug(`Activated ${name}`);
-    VISIBLE.add(name);
-    localStorage.setItem('VISIBLE', JSON.stringify([...VISIBLE]));
-    if (document.getElementById(wmslayer)) {
+  const pane = paneOf(layer);
+  const isPane0 = pane === pane0;
+
+  if (isVisible) pane.VISIBLE.add(name); else pane.VISIBLE.delete(name);
+  debug(`${isVisible ? 'Activated' : 'Deactivated'} ${name} (pane ${pane.index})`);
+
+  // The global toolbar, the #layers selection list and the playlist card all
+  // reflect the primary pane (pane 0). Per-pane state lives on the pill.
+  if (isPane0) {
+    removeSelectedParameter(`#${name} > div`);
+    localStorage.setItem('VISIBLE', JSON.stringify([...pane.VISIBLE]));
+    setButtonState(`${name}Button`, isVisible);
+    if (isVisible && document.getElementById(wmslayer)) {
       document.getElementById(wmslayer).classList.add('selected');
     }
-    setButtonState(`${name}Button`, true);
-    document.getElementById(`${name}Info`).classList.remove('playListDisabled');
+    const info = document.getElementById(`${name}Info`);
+    if (info) info.classList.toggle('playListDisabled', !isVisible);
     const toggleIcon = document.querySelector(`#${name}Info .card-visibility-toggle .material-icons`);
-    if (toggleIcon) toggleIcon.textContent = 'visibility';
-  } else {
-    debug(`Deactivated ${name}`);
-    VISIBLE.delete(name);
-    localStorage.setItem('VISIBLE', JSON.stringify([...VISIBLE]));
-    setButtonState(`${name}Button`, false);
-    document.getElementById(`${name}Info`).classList.add('playListDisabled');
-    const toggleIcon = document.querySelector(`#${name}Info .card-visibility-toggle .material-icons`);
-    if (toggleIcon) toggleIcon.textContent = 'visibility_off';
+    if (toggleIcon) toggleIcon.textContent = isVisible ? 'visibility' : 'visibility_off';
+    updateCanonicalPage();
+    updateLayerSelectionSelected();
   }
-  updateCanonicalPage();
-  updateLayerSelectionSelected();
+
+  refreshPanePillButton(pane, name);
   recomputeAllTimelineCells();
-  if (probe && layer === radarLayer) {
+
+  if (isPane0 && probe && layer === radarLayer) {
     probe.setActiveLayer(isVisible ? wmslayer : null, {
       z: layer.getSource().getParams().ELEVATION,
     });
@@ -1621,9 +1654,9 @@ function onChangeVisible(event) {
   // in-range state immediately so the map time, stale colour and
   // layer opacity update without waiting for a tick or manual step.
   setTime('keep');
-  // Turning the radar layer off exits single-site mode, restoring the composite
-  // product (while hidden) so re-enabling the layer shows the composite again.
-  if (layer === radarLayer && !isVisible && radarSite) {
+  // Turning the primary pane's radar off exits single-site mode, restoring the
+  // composite (while hidden) so re-enabling shows the composite again.
+  if (isPane0 && layer === radarLayer && !isVisible && radarSite) {
     radarSite.exitSingleSite({ restore: true });
   }
 }
@@ -1661,6 +1694,85 @@ function toggleAndAnnounce(layer, segId, source) {
       });
     }
   }
+}
+
+//
+// PER-PANE MINI CONTROLS (split mode)
+//
+// In split layouts each pane carries its own compact category pill so the user
+// edits that pane's content directly; the global top toolbar is hidden. The
+// pill reuses the shared sublayer long-press menus, targeted at the pane.
+// (CATEGORY_UI / PILL_CATEGORIES are declared near the top of the module so the
+// layout helpers above can reference them.)
+
+// Resolve which pane owns an OL content layer (back-ref set in createPane).
+function paneOf(layer) {
+  const idx = layer.get('_paneIndex') || 0;
+  return panes[idx] || pane0;
+}
+
+// Apply a sublayer pick (from a long-press menu) to one pane's category.
+function applySublayerToPane(pane, category, id) {
+  if (category === 'radarLayer') {
+    // Single-site drill-in lives only on the primary pane (radarSite is bound
+    // to pane 0); exit it before swapping the composite there.
+    if (pane === pane0 && radarSite) radarSite.exitSingleSite({ restore: false });
+    updateLayer(pane.layerss.radarLayer, id, { source: 'longpress' });
+    // Recentre the shared view to the picked radar's footprint only for the
+    // primary pane — a background pane's pick shouldn't yank every pane around.
+    if (pane === pane0) fitToLayerExtent(id);
+  } else {
+    updateLayer(pane.layerss[category], id, { source: 'longpress' });
+  }
+  const menu = document.getElementById(CATEGORY_UI[category].menu);
+  if (menu) menu.style.display = 'none';
+}
+
+function refreshPanePillButton(pane, category) {
+  const btn = pane.pillButtons && pane.pillButtons[category];
+  if (!btn) return;
+  const on = pane.VISIBLE.has(category);
+  btn.classList.toggle('selectedButton', on);
+  btn.setAttribute('aria-pressed', String(on));
+}
+
+function refreshPanePill(pane) {
+  PILL_CATEGORIES.forEach((c) => refreshPanePillButton(pane, c));
+}
+
+// Build a pane's pill (once) and wire each button: tap toggles that pane's
+// category, long-press opens the shared sublayer menu targeted at the pane.
+function buildPanePill(pane) {
+  if (pane.pill) return;
+  const pill = document.createElement('div');
+  pill.className = 'pane-pill noselect';
+  pane.pillButtons = {};
+  PILL_CATEGORIES.forEach((category) => {
+    const cfg = CATEGORY_UI[category];
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'pane-seg';
+    btn.setAttribute('aria-label', cfg.aria);
+    const icon = document.createElement('i');
+    icon.className = 'material-icons';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = cfg.icon;
+    btn.appendChild(icon);
+    pill.appendChild(btn);
+    pane.pillButtons[category] = btn;
+    createLongPressHandler(
+      btn,
+      cfg.menu,
+      () => toggleLayerVisibility(pane.layerss[category], 'pane-pill'),
+      (id) => applySublayerToPane(pane, category, id),
+      () => pane.layerss[category].getSource().getParams().LAYERS,
+      () => pane.layerss[category].getVisible(),
+      () => { hideCoachmarkNow(); markLongPressDiscovered(); },
+    );
+  });
+  pane.el.appendChild(pill);
+  pane.pill = pill;
+  refreshPanePill(pane);
 }
 
 //
@@ -1735,6 +1847,27 @@ document.querySelectorAll('.card-visibility-toggle').forEach((toggle) => {
   });
 });
 
+// The four shared sublayer menus, opened from the global toolbar (1-up) OR any
+// pane's mini pill (split). Each menu remembers its opener (menu._lpOpener, set
+// in createLongPressHandler) so the outside-click closer below doesn't dismiss
+// it when that very button is released after a long press.
+const LP_MENU_IDS = [
+  'observationLongPressMenu',
+  'satelliteLongPressMenu',
+  'radarLongPressMenu',
+  'lightningLongPressMenu',
+];
+
+function closeLongPressMenusOutside(e) {
+  LP_MENU_IDS.forEach((menuId) => {
+    const menu = document.getElementById(menuId);
+    if (!menu || menu.style.display === 'none') return;
+    if (menu.contains(e.target)) return;
+    if (menu._lpOpener && menu._lpOpener.contains(e.target)) return;
+    menu.style.display = 'none';
+  });
+}
+
 // Close playlist if clicked outside of playlist
 window.addEventListener('mouseup', (e) => {
   // playlist
@@ -1742,36 +1875,10 @@ window.addEventListener('mouseup', (e) => {
     if (document.getElementById('playlistButton').contains(e.target)) return;
     closePlaylist();
   }
-
-  // Close long-press menus when clicking/touching outside
-  const longPressMenus = [
-    { menuId: 'observationLongPressMenu', buttonId: 'observationLayerButton' },
-    { menuId: 'satelliteLongPressMenu', buttonId: 'satelliteLayerButton' },
-    { menuId: 'radarLongPressMenu', buttonId: 'radarLayerButton' },
-    { menuId: 'lightningLongPressMenu', buttonId: 'lightningLayerButton' },
-  ];
-  longPressMenus.forEach((cfg) => {
-    if (!document.getElementById(cfg.menuId).contains(e.target)) {
-      if (document.getElementById(cfg.buttonId).contains(e.target)) return;
-      document.getElementById(cfg.menuId).style.display = 'none';
-    }
-  });
+  closeLongPressMenusOutside(e);
 });
 
-window.addEventListener('touchend', (e) => {
-  const longPressMenus = [
-    { menuId: 'observationLongPressMenu', buttonId: 'observationLayerButton' },
-    { menuId: 'satelliteLongPressMenu', buttonId: 'satelliteLayerButton' },
-    { menuId: 'radarLongPressMenu', buttonId: 'radarLayerButton' },
-    { menuId: 'lightningLongPressMenu', buttonId: 'lightningLayerButton' },
-  ];
-  longPressMenus.forEach((cfg) => {
-    if (!document.getElementById(cfg.menuId).contains(e.target)) {
-      if (document.getElementById(cfg.buttonId).contains(e.target)) return;
-      document.getElementById(cfg.menuId).style.display = 'none';
-    }
-  });
-});
+window.addEventListener('touchend', closeLongPressMenusOutside);
 
 function setButtonState(id, active) {
   const el = document.getElementById(id);
@@ -2403,7 +2510,7 @@ function getWMSCapabilities(wms, failCountArg = 0) {
         default:
           debug('No wms.category set');
       }
-      restoreActiveLayer(wms.category);
+      for (const pane of activePanes()) restoreActiveLayer(wms.category, pane);
       if (IS_FOLLOWING) {
         setTime('last');
       }
@@ -2713,6 +2820,10 @@ const main = () => {
   observationLayer.on('change:visible', onChangeVisible);
   observationLayer.on('propertychange', layerInfoPlaylist);
 
+  // Pane 0's own mini pill — hidden in 1-up (the global toolbar drives pane 0),
+  // shown when a split layout is active.
+  buildPanePill(pane0);
+
   map.on('click', (evt) => {
     const hit = map.forEachFeatureAtPixel(evt.pixel, (f) => f);
     const pin = tools && tools.getPinFeature();
@@ -2868,15 +2979,20 @@ let etaResetAt = Date.now();
 
 function pickEtaSourceLayer() {
   let best = null;
-  VISIBLE.forEach((name) => {
-    const olLayer = layerss[name];
-    if (!olLayer) return;
-    const wmslayer = olLayer.getSource().getParams().LAYERS;
-    const info = layerInfo[wmslayer] && layerInfo[wmslayer].time;
-    if (!info || !info.end || !info.resolution) return;
-    if (Date.now() - info.end > ETA_STALE_THRESHOLD_MS) return;
-    if (!best || info.resolution < best.resolution) best = info;
-  });
+  // The ETA chip is shared, so pick the freshest source across every active
+  // pane's visible layers (matches the shared timeline window).
+  for (const pane of activePanes()) {
+    for (const name of pane.VISIBLE) {
+      const olLayer = pane.layerss[name];
+      const wmslayer = olLayer && olLayer.getSource().getParams().LAYERS;
+      const info = wmslayer && layerInfo[wmslayer] && layerInfo[wmslayer].time;
+      if (info && info.end && info.resolution
+        && Date.now() - info.end <= ETA_STALE_THRESHOLD_MS
+        && (!best || info.resolution < best.resolution)) {
+        best = info;
+      }
+    }
+  }
   return best;
 }
 

--- a/src/radar.js
+++ b/src/radar.js
@@ -995,27 +995,6 @@ function anyPoolZooming() {
   return false;
 }
 
-// Is timeline position `posIndex` loaded across EVERY active pane's visible,
-// in-range pools? Drives the atomic advance barrier in renderTick. Out-of-range
-// and hidden layers never block (they show nothing at this time anyway).
-function isPositionReadyAllPanes(posIndex) {
-  for (const pane of activePanes()) {
-    for (const name of Object.keys(pane.framePools)) {
-      const pool = pane.framePools[name];
-      if (!pool || !pane.VISIBLE.has(name)) continue; // eslint-disable-line no-continue
-      if (pane.LAYER_IN_RANGE[name] === false) continue; // eslint-disable-line no-continue
-      const load = poolLoadStates[`${pane.index}:${name}`];
-      if (!load || !load[posIndex]) return false;
-    }
-  }
-  return true;
-}
-
-// Advance-barrier bookkeeping: when we start holding for a not-yet-loaded next
-// frame, and the cap on how long we'll wait before stepping anyway.
-let advanceHoldStart = 0;
-const MAX_ADVANCE_HOLD_MS = 2000;
-
 // Playback loop. Split into two cadences so interpolation can layer on
 // top cleanly in later phases:
 //   - Advance (slow): bump the discrete timestep by a full frame when
@@ -1044,20 +1023,6 @@ const renderTick = function (now) {
 
   const stepDuration = 1000 / options.frameRate;
   if (now - lastAdvance >= stepDuration) {
-    // Atomic advance barrier (split mode only): hold the step until EVERY
-    // active pane has the next frame loaded, so all panes show the exact same
-    // timestamp at the same instant instead of a heavier pane briefly lagging
-    // a frame behind on its stale-while-loading image. Give up after
-    // MAX_ADVANCE_HOLD_MS so a slow/failing pane can't freeze playback. 1-up is
-    // untouched (no other pane to stay in sync with).
-    if (activeCount > 1 && timeline) {
-      const nextPos = (Math.round(timeline.position) + 1) % 13;
-      if (!isPositionReadyAllPanes(nextPos)) {
-        if (advanceHoldStart === 0) advanceHoldStart = now;
-        if (now - advanceHoldStart < MAX_ADVANCE_HOLD_MS) return;
-      }
-      advanceHoldStart = 0;
-    }
     lastAdvance = now;
     setTime();
     return;

--- a/src/radar.js
+++ b/src/radar.js
@@ -599,9 +599,6 @@ const {
   observationLayer,
   radarSiteLayer,
   guideLayer,
-  ownPositionLayer,
-  positionFeature,
-  accuracyFeature,
 } = pane0;
 
 //
@@ -672,6 +669,13 @@ function initNewPane(pane) {
   applyPoiVisibility();
   attachInterpolators();
   wirePaneClockGating(pane);
+  // Mirror the GPS marker into the new pane if tracking is on.
+  if (IS_TRACKING) {
+    pane.ownPositionLayer.setVisible(true);
+    if (ownPosition && ownPosition.length > 1) {
+      pane.positionFeature.setGeometry(new Point(ownPosition));
+    }
+  }
 }
 
 // Create any panes up to `count` that don't exist yet (targets #map-1..#map-3),
@@ -747,7 +751,11 @@ function bearingLine(layer, coordinates, range, direction) {
 
 function onChangeAccuracyGeometry(event) {
   debug('Accuracy geometry changed.');
-  accuracyFeature.setGeometry(event.target.getAccuracyGeometry());
+  // One device position, shown in every pane (each pane owns its own feature).
+  const geom = event.target.getAccuracyGeometry();
+  for (const pane of panes) {
+    pane.accuracyFeature.setGeometry(geom ? geom.clone() : null);
+  }
 }
 
 function onChangeSpeed(event) {
@@ -766,13 +774,19 @@ function onChangePosition(event) {
   const coordinates = event.target.getPosition();
   ownPosition = coordinates;
   ownPosition4326 = transform(coordinates, map.getView().getProjection(), 'EPSG:4326');
-  positionFeature.setGeometry(coordinates
-    ? new Point(coordinates) : null);
+  for (const pane of panes) {
+    pane.positionFeature.setGeometry(coordinates ? new Point(coordinates) : null);
+  }
   document.getElementById('gpsStatus').innerHTML = 'gps_fixed';
   localStorage.setItem('metLatitude', ownPosition4326[1]);
   localStorage.setItem('metLongitude', ownPosition4326[0]);
   localStorage.setItem('metPosition', JSON.stringify(ownPosition));
   if (tools) tools.refresh();
+}
+
+// Show/hide the GPS marker layer in every pane.
+function setOwnPositionVisible(visible) {
+  for (const pane of panes) pane.ownPositionLayer.setVisible(visible);
 }
 
 // WMS
@@ -1912,13 +1926,13 @@ document.getElementById('locationLayerButton').addEventListener('mouseup', () =>
     IS_TRACKING = false;
     localStorage.setItem('IS_TRACKING', JSON.stringify(false));
     geolocation.setTracking(false);
-    ownPositionLayer.setVisible(false);
+    setOwnPositionVisible(false);
     track('tracking-off');
   } else {
     IS_TRACKING = true;
     localStorage.setItem('IS_TRACKING', JSON.stringify(true));
     geolocation.setTracking(true);
-    ownPositionLayer.setVisible(true);
+    setOwnPositionVisible(true);
     if (ownPosition.length > 1) {
       map.getView().setCenter(ownPosition);
     }
@@ -2920,7 +2934,7 @@ const main = () => {
 
   if (IS_TRACKING) {
     geolocation.setTracking(true);
-    ownPositionLayer.setVisible(true);
+    setOwnPositionVisible(true);
   }
 
   // Position map

--- a/src/radar.js
+++ b/src/radar.js
@@ -26,7 +26,7 @@ import durationPlugin from 'dayjs/plugin/duration';
 import Timeline from './timeline';
 import createPane from './pane';
 import wmsServerConfiguration from './config';
-import createLongPressHandler from './longpress';
+import createLongPressHandler, { longPressMenuOpener } from './longpress';
 import initTools from './tools';
 import initProbe from './probe';
 import initRadarSite from './radarSite';
@@ -157,18 +157,22 @@ function attachInterpolators() {
   }
 }
 
+// Tear down one pane's interpolators, releasing their GL resources. Used both
+// when interp is switched off and when a pane drops out of the active set.
+function detachPaneInterpolators(pane) {
+  for (const name of ['radarLayer', 'satelliteLayer']) {
+    const pool = pane.framePools[name];
+    if (pool && pool.interpolator) {
+      pool.setInterpActive(false);
+      pool.setInterpolator(null);
+    }
+  }
+}
+
 function detachInterpolators() {
   // Detach from ALL panes (including inactive ones) so toggling interp off
   // fully releases GPU resources regardless of the current layout.
-  for (const pane of panes) {
-    for (const name of ['radarLayer', 'satelliteLayer']) {
-      const pool = pane.framePools[name];
-      if (pool && pool.interpolator) {
-        pool.setInterpActive(false);
-        pool.setInterpolator(null);
-      }
-    }
-  }
+  for (const pane of panes) detachPaneInterpolators(pane);
 }
 
 function setInterpMode(mode) {
@@ -710,6 +714,11 @@ function setLayout(mode) {
   layoutMode = mode;
   activeCount = LAYOUT_ACTIVE_COUNT[mode];
   ensurePanes(activeCount);
+  // Release interpolator GL resources on panes that just dropped out of the
+  // active set (e.g. 4-up → 2-up). They re-attach via attachInterpolators()
+  // below when they come back. Without this, up to 8 idle GL interpolators
+  // would linger in 4-up after shrinking the layout.
+  for (let i = activeCount; i < panes.length; i++) detachPaneInterpolators(panes[i]);
   document.body.classList.toggle('split-2', mode === '2-up');
   document.body.classList.toggle('split-4', mode === '4-up');
   // Let the grid reflow before measuring; then size every map (inactive panes
@@ -1827,9 +1836,9 @@ document.querySelectorAll('.card-visibility-toggle').forEach((toggle) => {
 });
 
 // The four shared sublayer menus, opened from the global toolbar (1-up) OR any
-// pane's mini pill (split). Each menu remembers its opener (menu._lpOpener, set
-// in createLongPressHandler) so the outside-click closer below doesn't dismiss
-// it when that very button is released after a long press.
+// pane's mini pill (split). longPressMenuOpener() reports which button owns each
+// open menu, so the outside-click closer below doesn't dismiss it when that very
+// button is released after a long press.
 const LP_MENU_IDS = [
   'observationLongPressMenu',
   'satelliteLongPressMenu',
@@ -1842,7 +1851,8 @@ function closeLongPressMenusOutside(e) {
     const menu = document.getElementById(menuId);
     if (!menu || menu.style.display === 'none') return;
     if (menu.contains(e.target)) return;
-    if (menu._lpOpener && menu._lpOpener.contains(e.target)) return;
+    const opener = longPressMenuOpener(menu);
+    if (opener && opener.contains(e.target)) return;
     menu.style.display = 'none';
   });
 }

--- a/src/radar.js
+++ b/src/radar.js
@@ -1,17 +1,11 @@
 // deploy-marker: sw-update-flow-test — bump on PR #87 to force a fresh
 // radar.[contenthash].js so the deployed test build differs from the
 // previous one and the new banner flow can be exercised end-to-end.
-import { Map, View } from 'ol';
+import { View } from 'ol';
 import Geolocation from 'ol/Geolocation';
-import TileLayer from 'ol/layer/Tile';
 import ImageLayer from 'ol/layer/Image';
 import VectorLayer from 'ol/layer/Vector';
-import VectorTileLayer from 'ol/layer/VectorTile';
-import XYZ from 'ol/source/XYZ';
-import ImageWMS from 'ol/source/ImageWMS';
-import VectorTileSource from 'ol/source/VectorTile';
 import GeoJSON from 'ol/format/GeoJSON';
-import MVT from 'ol/format/MVT';
 import Vector from 'ol/source/Vector';
 import { fromLonLat, transform, transformExtent } from 'ol/proj';
 import sync from 'ol-hashed';
@@ -30,6 +24,7 @@ import utcPlugin from 'dayjs/plugin/utc';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import durationPlugin from 'dayjs/plugin/duration';
 import Timeline from './timeline';
+import createPane from './pane';
 import wmsServerConfiguration from './config';
 import createLongPressHandler from './longpress';
 import initTools from './tools';
@@ -78,6 +73,10 @@ let startDate = new Date(Math.floor(Date.now() / 300000) * 300000 - 300000 * 12)
 let animationId = null;
 let lastAdvance = 0;
 let lastWarpTick = 0;
+// True while the user is mid pan/zoom on any pane — gates clock advance and
+// warp renders. Declared up here (used by the pane clock-gating helpers and
+// renderTick) so it precedes its first reference.
+let isInteracting = false;
 const layerInfo = {};
 let timeline;
 let mapTime = '';
@@ -88,6 +87,10 @@ const framePools = {
   lightningLayer: null,
   observationLayer: null,
 };
+// All created panes (index 0..3), cached across layout switches. Declared early
+// so the interpolator/timeline helpers above the pane bootstrap can reference
+// it. pane 0 is pushed in the bootstrap below; setLayout() adds the rest.
+const panes = [];
 
 // Three interpolation modes:
 //   - 'off'       : no warp layer; animation shows discrete frames only.
@@ -131,22 +134,28 @@ function attachInterpolators() {
   if (interpMode === 'off') return;
   const playing = animationId !== null;
   const useFlow = interpMode === 'flow';
-  for (const name of ['radarLayer', 'satelliteLayer']) {
-    const pool = framePools[name];
-    if (pool && !pool.interpolator) {
-      pool.setInterpolator(new RadarInterpolator({ useFlow }));
-      pool.refreshFlows();
-      if (playing) pool.setInterpActive(true);
+  for (const pane of activePanes()) {
+    for (const name of ['radarLayer', 'satelliteLayer']) {
+      const pool = pane.framePools[name];
+      if (pool && !pool.interpolator) {
+        pool.setInterpolator(new RadarInterpolator({ useFlow }));
+        pool.refreshFlows();
+        if (playing) pool.setInterpActive(true);
+      }
     }
   }
 }
 
 function detachInterpolators() {
-  for (const name of ['radarLayer', 'satelliteLayer']) {
-    const pool = framePools[name];
-    if (pool && pool.interpolator) {
-      pool.setInterpActive(false);
-      pool.setInterpolator(null);
+  // Detach from ALL panes (including inactive ones) so toggling interp off
+  // fully releases GPU resources regardless of the current layout.
+  for (const pane of panes) {
+    for (const name of ['radarLayer', 'satelliteLayer']) {
+      const pool = pane.framePools[name];
+      if (pool && pool.interpolator) {
+        pool.setInterpActive(false);
+        pool.setInterpolator(null);
+      }
     }
   }
 }
@@ -166,11 +175,13 @@ function setInterpMode(mode) {
     // Swap between crossfade and flow on existing interpolators —
     // cheaper than rebuilding the whole pipeline.
     const useFlow = mode === 'flow';
-    for (const name of ['radarLayer', 'satelliteLayer']) {
-      const pool = framePools[name];
-      if (pool && pool.interpolator) {
-        pool.interpolator.setUseFlow(useFlow);
-        pool.refreshFlows();
+    for (const pane of activePanes()) {
+      for (const name of ['radarLayer', 'satelliteLayer']) {
+        const pool = pane.framePools[name];
+        if (pool && pool.interpolator) {
+          pool.interpolator.setUseFlow(useFlow);
+          pool.refreshFlows();
+        }
       }
     }
   }
@@ -189,24 +200,18 @@ function updateInterpChipsState() {
     }
   });
 }
-const poolLoadStates = {
-  satelliteLayer: new Array(13).fill(false),
-  radarLayer: new Array(13).fill(false),
-  lightningLayer: new Array(13).fill(false),
-  observationLayer: new Array(13).fill(false),
-};
-// Per-cell "flow ready" state. Only populated for pools that have an
-// interpolator attached (radar, satellite when interp is enabled).
-// True means both endpoints of the pair starting at this index are
-// loaded AND the interpolator has a computed flow field — playback
-// through this timestep will show a motion-compensated warp instead
-// of a jump to the next discrete frame.
-const poolFlowStates = {
-  satelliteLayer: new Array(13).fill(false),
-  radarLayer: new Array(13).fill(false),
-  lightningLayer: new Array(13).fill(false),
-  observationLayer: new Array(13).fill(false),
-};
+// Per-(pane, category) timeline state, keyed `${paneIndex}:${name}`. A timeline
+// cell is "loaded" only when every visible (pane, layer) pool has that index
+// loaded; "flow pending" if any interpolator-bearing pool isn't flow-ready.
+// buildPanePools() seeds the keys for each pane as it's created.
+//
+// poolFlowStates is only populated for pools that have an interpolator attached
+// (radar, satellite when interp is enabled). True means both endpoints of the
+// pair starting at this index are loaded AND the interpolator has a computed
+// flow field — playback through this timestep shows a motion-compensated warp
+// instead of a jump to the next discrete frame.
+const poolLoadStates = {};
+const poolFlowStates = {};
 
 const VISIBLE = new Set(safeParseJSON('VISIBLE', ['radarLayer']));
 // Per-layer "is the chosen time inside this layer's data range?" — updated
@@ -233,14 +238,21 @@ function updateTimelineCell(i) {
   if (!timeline) return;
   let allLoaded = true;
   let flowPending = false;
-  for (const name of Object.keys(framePools)) {
-    const pool = framePools[name];
-    if (!pool || !VISIBLE.has(name)) continue; // eslint-disable-line no-continue
-    if (!poolLoadStates[name][i]) allLoaded = false;
-    // A pool only marks flow-pending if it actually has an
-    // interpolator attached. Lightning/observation (no interp) and
-    // radar/satellite with mode=off never flag this cell.
-    if (pool.interpolator && !poolFlowStates[name][i]) flowPending = true;
+  // Aggregate across every active pane's visible pools — the shared timeline
+  // reflects the whole split: a cell is ready only when all panes have it.
+  for (const pane of activePanes()) {
+    for (const name of Object.keys(pane.framePools)) {
+      const pool = pane.framePools[name];
+      if (!pool || !pane.VISIBLE.has(name)) continue; // eslint-disable-line no-continue
+      const key = `${pane.index}:${name}`;
+      const load = poolLoadStates[key];
+      if (!load || !load[i]) allLoaded = false;
+      // A pool only marks flow-pending if it actually has an interpolator
+      // attached. Lightning/observation (no interp) and radar/satellite with
+      // mode=off never flag this cell.
+      const flow = poolFlowStates[key];
+      if (pool.interpolator && (!flow || !flow[i])) flowPending = true;
+    }
   }
   timeline.setLoadState(i, allLoaded);
   // Flow-pending only meaningful when the cell is loaded — a not-
@@ -474,153 +486,13 @@ const rangeStyle = new Style({
 });
 
 //
-// FEATURES
+// LAYERS + MAP
 //
-const positionFeature = new Feature();
-positionFeature.setStyle(new Style({
-  image: new CircleStyle({
-    radius: 6,
-    fill: new Fill({
-      color: '#3399CC',
-    }),
-    stroke: new Stroke({
-      color: '#fff',
-      width: 2,
-    }),
-  }),
-}));
-
-const accuracyFeature = new Feature();
-accuracyFeature.setStyle(new Style({
-  fill: new Fill({
-    color: [128, 128, 128, 0.3],
-  }),
-}));
-
-//
-// LAYERS
-//
-const imageryBaseLayer = new TileLayer({
-  visible: false,
-  source: new XYZ({
-    attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer">ArcGIS</a>',
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-  }),
-});
-
-const lightGrayBaseLayer = new TileLayer({
-  visible: false,
-  preload: Infinity,
-  source: new XYZ({
-    attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer">ArcGIS</a>',
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}',
-  }),
-});
-
-const lightGrayReferenceLayer = new TileLayer({
-  visible: false,
-  source: new XYZ({
-    attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer">ArcGIS</a>',
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
-  }),
-});
-
-const darkGrayBaseLayer = new TileLayer({
-  preload: Infinity,
-  source: new XYZ({
-    attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer">ArcGIS</a>',
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}',
-  }),
-});
-
-const darkGrayReferenceLayer = new TileLayer({
-  source: new XYZ({
-    attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer">ArcGIS</a>',
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
-  }),
-});
-
-// Satellite Layer
-const satelliteLayer = new ImageLayer({
-  name: 'satelliteLayer',
-  visible: VISIBLE.has('satelliteLayer'),
-  opacity: 0.7,
-  source: new ImageWMS({
-    url: options.wmsServerConfiguration.eumetsat1.url,
-    params: { FORMAT: 'image/jpeg', LAYERS: 'rgb_eview' },
-    hidpi: false,
-    attributions: 'EUMETSAT',
-    ratio: options.imageRatio,
-    serverType: 'geoserver',
-  }),
-});
-// Default wire format / transparency — restored by updateLayer when the
-// user picks a layer that doesn't carry per-layer overrides. Without
-// this, switching from a transparent overlay back to a full-disc RGB
-// would inherit `TRANSPARENT=TRUE` and waste bandwidth on a PNG.
-satelliteLayer.set('defaultFormat', 'image/jpeg');
-satelliteLayer.set('defaultTransparent', false);
-
-// Radar Layer
-const radarLayer = new ImageLayer({
-  name: 'radarLayer',
-  visible: VISIBLE.has('radarLayer'),
-  opacity: 0.7,
-  source: new ImageWMS({
-    url: options.wmsServerConfiguration.fi.url,
-    params: { LAYERS: options.defaultRadarLayer },
-    attributions: 'FMI (CC-BY-4.0)',
-    ratio: options.imageRatio,
-    hidpi: false,
-    serverType: 'geoserver',
-    // Lets the center-crosshair tool read the rendered radar pixel colour off
-    // the canvas (getData) without tainting it. During animation the displayed
-    // frames come from StickyImageWMS slot sources, which fetch via CORS and
-    // assign blob: URLs (already canvas-safe); this only covers the original
-    // source's direct-load path before the FramePool takes over. The meteocore
-    // WMS returns Access-Control-Allow-Origin: *, so it's safe.
-    crossOrigin: 'anonymous',
-  }),
-});
-// Category default wire format. updateLayer / applyWireFormat substitute
-// image/webp when the serving WMS advertises it in GetCapabilities (see
-// resolveFormat) — this is the fallback for servers that don't.
-radarLayer.set('defaultFormat', 'image/png');
-// Opt out of the webp wire format for radar specifically. Lossless webp
-// encoding on the meteocore server side is currently too slow to keep up
-// with retina-fullscreen request sizes; image/png is cached and served
-// more cheaply on that path. Revisit once requests are clamped to the
-// radar's native resolution (then payload size is bounded and the
-// encoding-time cost of lossless webp becomes worth the smaller bytes).
-radarLayer.set('disableWebp', true);
-
-// Lightning Layer
-const lightningLayer = new ImageLayer({
-  name: 'lightningLayer',
-  visible: VISIBLE.has('lightningLayer'),
-  source: new ImageWMS({
-    url: options.wmsServerConfiguration['meteo-obs-new'].url,
-    params: { FORMAT: 'image/png8', LAYERS: options.defaultLightningLayer },
-    ratio: options.imageRatio,
-    hidpi: false,
-    serverType: 'geoserver',
-  }),
-});
-lightningLayer.set('defaultFormat', 'image/png8');
-
-// Observation Layer
-const observationLayer = new ImageLayer({
-  name: 'observationLayer',
-  visible: VISIBLE.has('observationLayer'),
-  source: new ImageWMS({
-    url: options.wmsServerConfiguration['meteo-obs-new'].url,
-    params: { FORMAT: 'image/png8', LAYERS: options.defaultObservationLayer },
-    ratio: options.imageRatio,
-    hidpi: false,
-    serverType: 'geoserver',
-  }),
-});
-observationLayer.set('defaultFormat', 'image/png8');
+// The basemaps, content layers, vector overlays and the OpenLayers Map are now
+// built per pane by createPane() in src/pane.js — OL layers cannot be shared
+// across maps, so each split pane needs its own instances. The single shared
+// `radarSiteSource` below feeds every pane's radar-site layer. The pane
+// bootstrap (createPane + pane-0 aliases) runs just below the source.
 
 // Radar-site markers track the live radar network rather than a hand-edited
 // file: two meteocore OGC API Features collections are fetched and merged —
@@ -664,125 +536,171 @@ const radarSiteSource = new Vector({
   },
 });
 
-const radarSiteLayer = new VectorLayer({
-  source: radarSiteSource,
-  style(feature) {
-    radarStyle.getText().setText(feature.get('name'));
-    return radarStyle;
-  },
+//
+// PANES — one OpenLayers Map per split pane, all sharing ONE View so they
+// pan/zoom in lockstep (the canonical OL "shared view" pattern). Pane 0 is the
+// original single map; its layer/state objects are aliased to the module
+// globals below so the rest of this file is unchanged. setLayout() adds further
+// panes on the same shared view.
+//
+const sharedView = new View({
+  enableRotation: false,
+  center: fromLonLat([26, 65]),
+  maxZoom: 16,
+  zoom: 5,
 });
 
-const icaoLayer = new VectorLayer({
-  source: new Vector({
-    format: new GeoJSON(),
-    url: 'airfields-finland.json',
-  }),
-  visible: false,
-  style(feature) {
-    icaoStyle.getText().setText(feature.get('icao'));
-    return icaoStyle;
-  },
-});
-
-const municipalityLayer = new VectorTileLayer({
-  visible: false,
-  // Re-render features per frame instead of rasterising them once per
-  // tile. Hybrid mode (the default) makes the strokes scale like raster
-  // pixels between integer zoom levels — visible as "thick then snaps
-  // thin" while zooming. Vector mode keeps the 1.5 px stroke crisp.
-  renderMode: 'vector',
-  source: new VectorTileSource({
-    format: new MVT(),
-    url: 'https://meteocore.app.meteo.fi/tiles/collections/fi-municipalities/tiles/WebMercatorQuad/{z}/{y}/{x}?f=mvt',
-    attributions: 'Statistics Finland / Tilastokeskus',
-    maxZoom: 14,
-  }),
-  // Initial style is set below by setMapLayer once the effective theme
-  // is known. Default to the light variant so the layer is renderable
-  // even if a future code path skips the theme bootstrap.
-  style: municipalityStyleLight,
-});
-
-// Fairways (Vesiväylät) — OGC API Features from Väylävirasto. The
-// dataset is ~770 KB gzipped (1901 LineString features as of 2026-05),
-// small enough to fetch once on first toggle-on using OL's default
-// "all" loading strategy. Limit=10000 leaves headroom; if the dataset
-// ever exceeds it, switch to bbox strategy with a tilegrid snap.
-const vesivaylaAreaLayer = new VectorLayer({
-  visible: false,
-  source: new Vector({
-    format: new GeoJSON(),
-    url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylaalueet_uusi/items?f=application/geo%2Bjson&limit=10000',
-    attributions: 'Väylävirasto',
-  }),
-  style: vesivaylaAreaStyle,
-});
-
-const vesivaylatLayer = new VectorLayer({
-  visible: false,
-  // Declutter so overlapping nimifi labels along parallel fairway segments
-  // don't pile up at harbours. Stroke geometry still renders fully — only
-  // text participates in the decluttering.
-  declutter: true,
-  source: new Vector({
-    format: new GeoJSON(),
-    url: 'https://avoinapi.vaylapilvi.fi/vaylatiedot/ogc/features/v1/collections/vesivaylatiedot:vaylat_uusi/items?f=application/geo%2Bjson&limit=10000',
-    attributions: 'Väylävirasto',
-  }),
-  style: vesivaylatStyleFn,
-});
-
-const guideLayer = new VectorLayer({
-  source: new Vector(),
-  style: rangeStyle,
-});
-
-const ownPositionLayer = new VectorLayer({
-  visible: false,
-  source: new Vector({
-    features: [accuracyFeature, positionFeature],
-  }),
-});
-
-const layerss = {
-  satelliteLayer,
-  radarLayer,
-  observationLayer,
-  lightningLayer,
+// Shared dependencies every pane's layers reference — Style objects/functions
+// and the radar-site VectorSource. Passed into createPane so src/pane.js stays
+// free of app state.
+const paneDeps = {
+  options,
+  radarSiteSource,
+  radarStyle,
+  icaoStyle,
+  municipalityStyleLight,
+  vesivaylatStyleFn,
+  vesivaylaAreaStyle,
+  rangeStyle,
 };
 
-const layers = [
-  lightGrayBaseLayer,
-  darkGrayBaseLayer,
-  imageryBaseLayer,
-  // s57Layer,
+const pane0 = createPane(document.getElementById('map'), sharedView, {
+  ...paneDeps,
+  index: 0,
+  // Pane 0 reuses the existing module-global state objects so the aliases
+  // below point at the very same instances the rest of the file mutates.
+  visible: VISIBLE,
+  activeLayers: ACTIVE_LAYERS,
+  layerInRange: LAYER_IN_RANGE,
+  framePools,
+});
+panes.push(pane0);
+
+// Pane-0 aliases — keep the original single-map identifiers working unchanged.
+// Only the handles still referenced directly by radar.js are aliased; the
+// basemaps, municipality and fairway layers are now reached via `pane.*` in the
+// theme/POI fan-outs, and imageryBaseLayer lives only inside pane0.layers.
+const { map, layerss } = pane0;
+const {
   satelliteLayer,
   radarLayer,
-  guideLayer,
   lightningLayer,
-  lightGrayReferenceLayer,
-  darkGrayReferenceLayer,
-  municipalityLayer,
-  vesivaylaAreaLayer,
-  vesivaylatLayer,
-  radarSiteLayer,
-  icaoLayer,
-  ownPositionLayer,
   observationLayer,
-];
+  radarSiteLayer,
+  guideLayer,
+  ownPositionLayer,
+  positionFeature,
+  accuracyFeature,
+} = pane0;
 
-const map = new Map({
-  target: 'map',
-  layers,
-  controls: [],
-  view: new View({
-    enableRotation: false,
-    center: fromLonLat([26, 65]),
-    maxZoom: 16,
-    zoom: 5,
-  }),
-  keyboardEventTarget: document,
-});
+//
+// LAYOUT — 1-up (default) / 2-up / 4-up. Panes are created lazily and cached;
+// the active count drives which ones the clock + UI fan out to. Inactive panes'
+// divs are display:none, so their map size is 0 and their FramePools idle via
+// the FramePool getSize/getVisible guards (no special teardown needed).
+//
+const LAYOUT_ACTIVE_COUNT = { '1-up': 1, '2-up': 2, '4-up': 4 };
+let layoutMode = '1-up';
+let activeCount = 1;
+
+function activePanes() {
+  return panes.slice(0, activeCount);
+}
+
+// Clock interaction gating, wired on EVERY active pane's map. A drag fires
+// pointerdrag on the pane the user touched; the shared view means moveend then
+// fires on every pane. Both are idempotent, so binding to all panes is safe and
+// keeps `isInteracting` correct no matter which pane is dragged.
+function onPanePointerDrag() { isInteracting = true; }
+function onPaneMoveEnd() {
+  isInteracting = false;
+  // Defer the next advance by a full step after any view change (see the
+  // original moveend note: avoids racing the moveend-triggered prefetch).
+  lastAdvance = window.performance.now();
+  const zoom = Math.min(sharedView.getZoom(), 16);
+  localStorage.setItem('metZoom', zoom);
+}
+function wirePaneClockGating(pane) {
+  pane.map.on('pointerdrag', onPanePointerDrag);
+  pane.map.on('moveend', onPaneMoveEnd);
+}
+
+// Copy pane 0's current display state (sublayer params, info, opacity,
+// visibility) onto a freshly-created pane so a new split starts as a mirror of
+// what's on screen; the user then edits it independently (Stage 3).
+function clonePaneDisplay(src, dst) {
+  ['satelliteLayer', 'radarLayer', 'lightningLayer', 'observationLayer'].forEach((name) => {
+    const s = src.layerss[name];
+    const d = dst.layerss[name];
+    const ssrc = s.getSource();
+    const dsrc = d.getSource();
+    if (dsrc.getUrl() !== ssrc.getUrl()) dsrc.setUrl(ssrc.getUrl());
+    dsrc.updateParams({ ...ssrc.getParams() });
+    d.set('info', s.get('info'));
+    d.setOpacity(s.getOpacity());
+    d.setVisible(s.getVisible());
+    if (s.getVisible()) dst.VISIBLE.add(name); else dst.VISIBLE.delete(name);
+    dst.ACTIVE_LAYERS[name] = src.ACTIVE_LAYERS[name];
+  });
+}
+
+// One-time wiring for a newly-created pane: build its pools, mirror pane 0's
+// content, apply the current theme + POI visibility, attach interpolators, and
+// gate the clock off its interactions.
+function initNewPane(pane) {
+  buildPanePools(pane);
+  clonePaneDisplay(pane0, pane);
+  setMapLayer(getEffectiveTheme());
+  applyPoiVisibility();
+  attachInterpolators();
+  wirePaneClockGating(pane);
+}
+
+// Create any panes up to `count` that don't exist yet (targets #map-1..#map-3),
+// all sharing the single View.
+function ensurePanes(count) {
+  for (let i = panes.length; i < count; i++) {
+    const el = document.getElementById(`map-${i}`);
+    const pane = createPane(el, sharedView, {
+      ...paneDeps,
+      index: i,
+      visible: new Set(pane0.VISIBLE),
+      activeLayers: { ...pane0.ACTIVE_LAYERS },
+      layerInRange: {},
+    });
+    panes.push(pane);
+    initNewPane(pane);
+  }
+}
+
+function updateLayoutChipsState() {
+  document.querySelectorAll('#overflowMenu .chip[data-layout]').forEach((chip) => {
+    chip.setAttribute('aria-checked', String(chip.getAttribute('data-layout') === layoutMode));
+  });
+}
+
+function resizeAllPanes() {
+  for (const pane of panes) pane.updateSize();
+}
+
+function setLayout(mode) {
+  if (!(mode in LAYOUT_ACTIVE_COUNT)) return;
+  layoutMode = mode;
+  activeCount = LAYOUT_ACTIVE_COUNT[mode];
+  ensurePanes(activeCount);
+  document.body.classList.toggle('split-2', mode === '2-up');
+  document.body.classList.toggle('split-4', mode === '4-up');
+  // Let the grid reflow before measuring; then size every map (inactive panes
+  // collapse to 0 and idle) and re-drive the active panes for the current time.
+  window.requestAnimationFrame(() => {
+    resizeAllPanes();
+    attachInterpolators();
+    setTime('keep');
+    recomputeAllTimelineCells();
+  });
+  updateLayoutChipsState();
+  track('layout', { mode });
+}
 
 function rangeRings(layer, coordinates, range) {
   if (typeof range === 'number' && layer && coordinates) {
@@ -904,13 +822,19 @@ function setTime(action = 'next') {
   let end = Math.floor(Date.now() / resolution) * resolution - resolution;
   let start = end - resolution * 12;
 
-  for (const item of VISIBLE) {
-    const wmslayer = layerss[item].getSource().getParams().LAYERS;
-    if (wmslayer in layerInfo) {
-      if (item === 'radarLayer' || item === 'satelliteLayer' || item === 'observationLayer') {
-        end = Math.min(end, Math.floor(layerInfo[wmslayer].time.end / resolution) * resolution);
+  // Compute the shared 13-frame window from the UNION of every active pane's
+  // visible layers — time is identical across panes, so one window drives them
+  // all. The newest-frame cap (end) and the resolution come from whichever
+  // visible layer in any pane is freshest / coarsest.
+  for (const pane of activePanes()) {
+    for (const item of pane.VISIBLE) {
+      const wmslayer = pane.layerss[item].getSource().getParams().LAYERS;
+      if (wmslayer in layerInfo) {
+        if (item === 'radarLayer' || item === 'satelliteLayer' || item === 'observationLayer') {
+          end = Math.min(end, Math.floor(layerInfo[wmslayer].time.end / resolution) * resolution);
+        }
+        resolution = Math.max(resolution, layerInfo[wmslayer].time.resolution);
       }
-      resolution = Math.max(resolution, layerInfo[wmslayer].time.resolution);
     }
   }
 
@@ -981,14 +905,17 @@ function setTime(action = 'next') {
   //      its image (opacity 0) so a previously-loaded frame doesn't stay
   //      stuck on screen.
   const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
-  const routeLayer = (name, window, currentTime) => {
-    const olLayer = layerss[name];
-    const button = document.getElementById(`${name}Button`);
+  // Route one (pane, category) for the current window. Per-pane concerns —
+  // opacity, LAYER_IN_RANGE and the pool's window/time. The shared top toolbar's
+  // stale-data button reflects pane 0 only; per-pane pills own their own state.
+  const routeLayer = (pane, name, window, currentTime) => {
+    const olLayer = pane.layerss[name];
+    const button = pane.index === 0 ? document.getElementById(`${name}Button`) : null;
 
-    if (!VISIBLE.has(name)) {
+    if (!pane.VISIBLE.has(name)) {
       if (button) button.classList.remove('stale-data');
       olLayer.setOpacity(1);
-      LAYER_IN_RANGE[name] = true;
+      pane.LAYER_IN_RANGE[name] = true;
       return;
     }
 
@@ -1001,18 +928,21 @@ function setTime(action = 'next') {
     const inRange = !info || !info.start || !info.end
       || (tNow >= info.start && tNow <= info.end);
     olLayer.setOpacity(inRange ? 1 : 0);
-    LAYER_IN_RANGE[name] = inRange;
+    pane.LAYER_IN_RANGE[name] = inRange;
 
     if (!inRange) return;
 
-    const pool = framePools[name];
+    const pool = pane.framePools[name];
+    if (!pool) return;
     pool.setWindow(window);
     pool.showTime(currentTime);
   };
-  routeLayer('satelliteLayer', windowInstant, timeISO);
-  routeLayer('radarLayer', windowInstant, timeISO);
-  routeLayer('lightningLayer', windowInterval, timeInterval);
-  routeLayer('observationLayer', windowInterval, timeInterval);
+  for (const pane of activePanes()) {
+    routeLayer(pane, 'satelliteLayer', windowInstant, timeISO);
+    routeLayer(pane, 'radarLayer', windowInstant, timeISO);
+    routeLayer(pane, 'lightningLayer', windowInterval, timeInterval);
+    routeLayer(pane, 'observationLayer', windowInterval, timeInterval);
+  }
   updateMapTimeDisplay(timeISO);
 }
 
@@ -1020,12 +950,12 @@ function setTime(action = 'next') {
 // TIME CONTROLS
 //
 
-let isInteracting = false;
-
 function anyPoolZooming() {
-  for (const name of Object.keys(framePools)) {
-    const p = framePools[name];
-    if (p && p.isZoomGestureActive && p.isZoomGestureActive()) return true;
+  for (const pane of activePanes()) {
+    for (const name of Object.keys(pane.framePools)) {
+      const p = pane.framePools[name];
+      if (p && p.isZoomGestureActive && p.isZoomGestureActive()) return true;
+    }
   }
   return false;
 }
@@ -1071,18 +1001,22 @@ const renderTick = function (now) {
   lastWarpTick = now;
 
   const t = (now - lastAdvance) / stepDuration;
-  for (const name of Object.keys(framePools)) {
-    if (!VISIBLE.has(name)) continue; // eslint-disable-line no-continue
-    if (LAYER_IN_RANGE[name] === false) continue; // eslint-disable-line no-continue
-    const pool = framePools[name];
-    if (pool) pool.showInterpolated(t);
+  for (const pane of activePanes()) {
+    for (const name of Object.keys(pane.framePools)) {
+      if (!pane.VISIBLE.has(name)) continue; // eslint-disable-line no-continue
+      if (pane.LAYER_IN_RANGE[name] === false) continue; // eslint-disable-line no-continue
+      const pool = pane.framePools[name];
+      if (pool) pool.showInterpolated(t);
+    }
   }
 };
 
 function setInterpActiveAll(active) {
-  for (const name of Object.keys(framePools)) {
-    const pool = framePools[name];
-    if (pool && pool.interpolator) pool.setInterpActive(active);
+  for (const pane of activePanes()) {
+    for (const name of Object.keys(pane.framePools)) {
+      const pool = pane.framePools[name];
+      if (pool && pool.interpolator) pool.setInterpActive(active);
+    }
   }
 }
 
@@ -1138,11 +1072,13 @@ function getEffectiveTheme() {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
+// Theme is global — the shared Style singletons are mutated once, then every
+// pane's vector layers are told to re-render with the new colours.
 function applyIcaoTheme(theme) {
   const t = icaoTextColors[theme] || icaoTextColors.dark;
   icaoStyle.getText().getFill().setColor(t.fill);
   icaoStyle.getText().getStroke().setColor(t.halo);
-  icaoLayer.changed();
+  for (const pane of panes) pane.icaoLayer.changed();
 }
 
 function applyVesivaylatTheme(theme) {
@@ -1150,35 +1086,26 @@ function applyVesivaylatTheme(theme) {
   const t = vesivaylatLabelColors[theme] || vesivaylatLabelColors.dark;
   vesivaylatLabelStyle.getText().getFill().setColor(t.fill);
   vesivaylatLabelStyle.getText().getStroke().setColor(t.halo);
-  vesivaylatLayer.changed();
   vesivaylaAreaStyle.getFill().setColor(vesivaylaAreaFills[theme] || vesivaylaAreaFills.light);
-  vesivaylaAreaLayer.changed();
+  for (const pane of panes) {
+    pane.vesivaylatLayer.changed();
+    pane.vesivaylaAreaLayer.changed();
+  }
 }
 
 function setMapLayer(maplayer) {
   debug(`Set ${maplayer} map.`);
-  switch (maplayer) {
-    case 'light':
-      darkGrayBaseLayer.setVisible(false);
-      darkGrayReferenceLayer.setVisible(false);
-      lightGrayBaseLayer.setVisible(true);
-      lightGrayReferenceLayer.setVisible(true);
-      municipalityLayer.setStyle(municipalityStyleLight);
-      applyIcaoTheme('light');
-      applyVesivaylatTheme('light');
-      break;
-    case 'dark':
-      darkGrayBaseLayer.setVisible(true);
-      darkGrayReferenceLayer.setVisible(true);
-      lightGrayBaseLayer.setVisible(false);
-      lightGrayReferenceLayer.setVisible(false);
-      municipalityLayer.setStyle(municipalityStyleDark);
-      applyIcaoTheme('dark');
-      applyVesivaylatTheme('dark');
-      break;
-    default:
-      break;
+  if (maplayer !== 'light' && maplayer !== 'dark') return;
+  const light = maplayer === 'light';
+  for (const pane of panes) {
+    pane.darkGrayBaseLayer.setVisible(!light);
+    pane.darkGrayReferenceLayer.setVisible(!light);
+    pane.lightGrayBaseLayer.setVisible(light);
+    pane.lightGrayReferenceLayer.setVisible(light);
+    pane.municipalityLayer.setStyle(light ? municipalityStyleLight : municipalityStyleDark);
   }
+  applyIcaoTheme(maplayer);
+  applyVesivaylatTheme(maplayer);
 }
 
 function getThemeMode() {
@@ -1931,6 +1858,7 @@ function openOverflowMenu() {
   overflowBackdropEl.classList.add('open');
   menuButtonEl.setAttribute('aria-expanded', 'true');
   updateThemeChipsState();
+  updateLayoutChipsState();
   updatePoiMenuState();
 }
 
@@ -2093,30 +2021,40 @@ document.querySelectorAll('#overflowMenu .chip[data-interp]').forEach((chip) => 
 // silently rejects non-'off' modes, and the user sees no feedback.
 updateInterpChipsState();
 
+// Layout chips (Näkymä): 1-up / 2-up / 4-up.
+document.querySelectorAll('#overflowMenu .chip[data-layout]').forEach((chip) => {
+  chip.addEventListener('mouseup', () => {
+    setLayout(chip.getAttribute('data-layout'));
+  });
+});
+
 // POI layers — map features that users can toggle independently of data layers.
 // Adding a future POI = one entry in this registry; the overflow menu row and
 // localStorage persistence fall out automatically.
+// `layerKeys` are pane property names — a POI toggle fans its visibility out to
+// the matching layer in EVERY pane so context overlays stay consistent across
+// the split.
 const poiRegistry = [
   {
     id: 'radars',
     label: 'Tutka-asemat',
     icon: 'cell_tower',
     defaultOn: true,
-    layerRef: () => radarSiteLayer,
+    layerKeys: ['radarSiteLayer'],
   },
   {
     id: 'airfields',
     label: 'Lentokentät',
     icon: 'flight',
     defaultOn: false,
-    layerRef: () => icaoLayer,
+    layerKeys: ['icaoLayer'],
   },
   {
     id: 'municipalities',
     label: 'Kunnat',
     icon: 'location_city',
     defaultOn: false,
-    layerRef: () => municipalityLayer,
+    layerKeys: ['municipalityLayer'],
   },
   {
     id: 'vesivaylat',
@@ -2126,7 +2064,7 @@ const poiRegistry = [
     // Area fill renders behind the line geometry — both flip together
     // off the same toggle. Order here doesn't drive z-order; the layers
     // array does (vesivaylaAreaLayer sits before vesivaylatLayer there).
-    layerRef: () => [vesivaylaAreaLayer, vesivaylatLayer],
+    layerKeys: ['vesivaylaAreaLayer', 'vesivaylatLayer'],
   },
 ];
 
@@ -2149,9 +2087,12 @@ function persistPoiState() {
 
 function applyPoiVisibility() {
   poiRegistry.forEach((entry) => {
-    const ref = entry.layerRef();
     const visible = !!POI_STATE[entry.id];
-    (Array.isArray(ref) ? ref : [ref]).forEach((l) => l.setVisible(visible));
+    for (const pane of panes) {
+      entry.layerKeys.forEach((key) => {
+        if (pane[key]) pane[key].setVisible(visible);
+      });
+    }
   });
 }
 
@@ -2397,16 +2338,15 @@ function getWMSCapabilities(wms, failCountArg = 0) {
         && getMap.Format.includes('image/webp'));
       getLayers(result.Capability.Layer.Layer, wms, supportsWebp);
       debug(layerInfo);
-      satelliteLayer.set('info', layerInfo[satelliteLayer.getSource().getParams().LAYERS]);
-      radarLayer.set('info', layerInfo[radarLayer.getSource().getParams().LAYERS]);
-      lightningLayer.set('info', layerInfo[lightningLayer.getSource().getParams().LAYERS]);
-      observationLayer.set('info', layerInfo[observationLayer.getSource().getParams().LAYERS]);
-      // Adopt webp for any category already showing a layer from a
-      // webp-capable server, including the boot defaults.
-      applyWireFormat(satelliteLayer);
-      applyWireFormat(radarLayer);
-      applyWireFormat(lightningLayer);
-      applyWireFormat(observationLayer);
+      // Set each visible category's `info` and adopt webp (where advertised)
+      // for every active pane's layers, including the boot defaults.
+      for (const pane of activePanes()) {
+        for (const name of ['satelliteLayer', 'radarLayer', 'lightningLayer', 'observationLayer']) {
+          const olLayer = pane.layerss[name];
+          olLayer.set('info', layerInfo[olLayer.getSource().getParams().LAYERS]);
+          applyWireFormat(olLayer);
+        }
+      }
       switch (wms.category) {
         case 'satelliteLayer':
           updateLayerSelection(satelliteLayer, 'satellite', 'msg_');
@@ -2596,6 +2536,34 @@ function getTimeDimension(dimensions) {
   };
 }
 
+// Build the four FramePools (one per content layer) for a pane and wire each
+// pool's load/flow callbacks into the shared timeline aggregation. For pane 0
+// `pane.framePools` is the module-global `framePools`, so this is identical to
+// the old inline construction on the single-map path.
+function buildPanePools(pane) {
+  const pairs = [
+    ['satelliteLayer', pane.layerss.satelliteLayer],
+    ['radarLayer', pane.layerss.radarLayer],
+    ['lightningLayer', pane.layerss.lightningLayer],
+    ['observationLayer', pane.layerss.observationLayer],
+  ];
+  for (const [name, layer] of pairs) {
+    const key = `${pane.index}:${name}`;
+    poolLoadStates[key] = new Array(13).fill(false);
+    poolFlowStates[key] = new Array(13).fill(false);
+    const pool = new FramePool({ primaryLayer: layer, map: pane.map });
+    pool.onLoadStateChange = (idx, loaded) => {
+      poolLoadStates[key][idx] = loaded;
+      updateTimelineCell(idx);
+    };
+    pool.onFlowStateChange = (idx, ready) => {
+      poolFlowStates[key][idx] = ready;
+      updateTimelineCell(idx);
+    };
+    pane.framePools[name] = pool;
+  }
+}
+
 //
 // MAIN
 //
@@ -2614,8 +2582,7 @@ const main = () => {
   // out of dedup: the server returns a different document per `&layer=`,
   // so each filtered request must run on its own.
   //
-  // Plain object (not a Map) because `Map` is imported from 'ol' at the
-  // top of this file — `new Map()` here would build an OpenLayers Map.
+  // Plain null-prototype object used as a string-keyed set of endpoints.
   const seenEndpoints = Object.create(null);
   Object.values(options.wmsServerConfiguration).forEach((value) => {
     if (value.disabled) return;
@@ -2627,24 +2594,7 @@ const main = () => {
 
   setButtonStates();
 
-  const pairs = [
-    ['satelliteLayer', satelliteLayer],
-    ['radarLayer', radarLayer],
-    ['lightningLayer', lightningLayer],
-    ['observationLayer', observationLayer],
-  ];
-  for (const [name, layer] of pairs) {
-    const pool = new FramePool({ primaryLayer: layer, map });
-    pool.onLoadStateChange = (idx, loaded) => {
-      poolLoadStates[name][idx] = loaded;
-      updateTimelineCell(idx);
-    };
-    pool.onFlowStateChange = (idx, ready) => {
-      poolFlowStates[name][idx] = ready;
-      updateTimelineCell(idx);
-    };
-    framePools[name] = pool;
-  }
+  buildPanePools(pane0);
   // Pools are now in framePools. If the capability probe has already
   // resolved, wire interpolators up now; otherwise the probe's .then
   // will call attachInterpolators once the verdict lands.
@@ -2701,7 +2651,9 @@ const main = () => {
     });
   }
 
-  window.__tutka = { map, framePools, tools };
+  window.__tutka = {
+    panes, map, framePools, tools, sharedView,
+  };
 
   // GEOLOCATION
   geolocation = new Geolocation({
@@ -2790,20 +2742,15 @@ const main = () => {
     displayFeatureInfo(evt.pixel);
   });
 
-  map.on('pointerdrag', () => { isInteracting = true; });
-  map.on('moveend', () => {
-    isInteracting = false;
-    // Defer the next playback advance by a full stepDuration after any
-    // view change. Without this, the advance cadence fires on the very
-    // next RAF tick after a pan (since lastAdvance accumulated while
-    // isInteracting was true), which races with the moveend-triggered
-    // prefetch in FramePool — second prefetch aborts the first, noisy
-    // "Image load error" shows up in the console for every aborted
-    // request.
-    lastAdvance = window.performance.now();
-    const zoom = Math.min(map.getView().getZoom(), 16);
-    localStorage.setItem('metZoom', zoom);
-  });
+  // Clock interaction gating + metZoom persistence, wired per pane (see
+  // wirePaneClockGating / onPaneMoveEnd). pane 0 is wired here; new panes get
+  // wired in initNewPane.
+  wirePaneClockGating(pane0);
+
+  // Keep every pane's map sized on viewport resize and orientation flips (the
+  // 2-up grid swaps cols↔rows on rotation purely in CSS; JS just re-measures).
+  window.addEventListener('resize', resizeAllPanes);
+  window.matchMedia('(orientation: portrait)').addEventListener('change', resizeAllPanes);
 
   document.addEventListener('keydown', (event) => {
     if (event.key === 'Control') {

--- a/src/radar.js
+++ b/src/radar.js
@@ -960,6 +960,27 @@ function anyPoolZooming() {
   return false;
 }
 
+// Is timeline position `posIndex` loaded across EVERY active pane's visible,
+// in-range pools? Drives the atomic advance barrier in renderTick. Out-of-range
+// and hidden layers never block (they show nothing at this time anyway).
+function isPositionReadyAllPanes(posIndex) {
+  for (const pane of activePanes()) {
+    for (const name of Object.keys(pane.framePools)) {
+      const pool = pane.framePools[name];
+      if (!pool || !pane.VISIBLE.has(name)) continue; // eslint-disable-line no-continue
+      if (pane.LAYER_IN_RANGE[name] === false) continue; // eslint-disable-line no-continue
+      const load = poolLoadStates[`${pane.index}:${name}`];
+      if (!load || !load[posIndex]) return false;
+    }
+  }
+  return true;
+}
+
+// Advance-barrier bookkeeping: when we start holding for a not-yet-loaded next
+// frame, and the cap on how long we'll wait before stepping anyway.
+let advanceHoldStart = 0;
+const MAX_ADVANCE_HOLD_MS = 2000;
+
 // Playback loop. Split into two cadences so interpolation can layer on
 // top cleanly in later phases:
 //   - Advance (slow): bump the discrete timestep by a full frame when
@@ -988,6 +1009,20 @@ const renderTick = function (now) {
 
   const stepDuration = 1000 / options.frameRate;
   if (now - lastAdvance >= stepDuration) {
+    // Atomic advance barrier (split mode only): hold the step until EVERY
+    // active pane has the next frame loaded, so all panes show the exact same
+    // timestamp at the same instant instead of a heavier pane briefly lagging
+    // a frame behind on its stale-while-loading image. Give up after
+    // MAX_ADVANCE_HOLD_MS so a slow/failing pane can't freeze playback. 1-up is
+    // untouched (no other pane to stay in sync with).
+    if (activeCount > 1 && timeline) {
+      const nextPos = (Math.round(timeline.position) + 1) % 13;
+      if (!isPositionReadyAllPanes(nextPos)) {
+        if (advanceHoldStart === 0) advanceHoldStart = now;
+        if (now - advanceHoldStart < MAX_ADVANCE_HOLD_MS) return;
+      }
+      advanceHoldStart = 0;
+    }
     lastAdvance = now;
     setTime();
     return;


### PR DESCRIPTION
Splits the map into **2 panes** (side-by-side in landscape, stacked in portrait) or **4 panes** (2×2), all **synchronized in pan, zoom and time** off the single bottom time control. Each pane chooses its own data via a per-pane mini pill. Switch layout via the **Näkymä** chips in the ⋯ overflow menu (1 / 2 / 2×2).

## How it works
- **Pane factory** (`src/pane.js`): all per-map construction (basemaps, content layers, overlays, GPS features, the OL `Map`) lives here. `radar.js` builds **pane 0** through it and aliases the old single-map identifiers to it, so 1-up is behaviour-identical.
- **One shared `ol/View`** across all pane maps → pan/zoom in lockstep with zero sync code (the [OL side-by-side](https://openlayers.org/en/latest/examples/side-by-side.html) pattern).
- **Global clock fans out**: `setTime`/`routeLayer`/`renderTick`/interpolators + timeline load/flow aggregation iterate every active pane; theme / POI / GetCapabilities too.
- **Atomic time**: in split mode the clock only advances once *every* pane has the next frame loaded (2 s escape hatch), so panes never show different timestamps while a heavier pane is fetching.
- **Per-pane content**: each pane has a compact category pill — tap toggles that pane's layer, long-press opens the shared sublayer menu targeted at the pane. The global toolbar pill is hidden in split (the ⋯ menu stays). New panes mirror pane 0 on entry, then are edited.
- **GPS marker** shows in every pane; inactive panes collapse to size 0 and idle.

## Scope / limitations (v1)
- Tools (measure / point-probe / crosshair), the radar-site drill-in, and the playlist (opacity/style) act on the **primary (top-left) pane** in split view.
- Layout is not persisted across reload (always boots 1-up); per-pane content is in-memory (mirror-then-edit).
- Follow-ups: cap flow-interpolation to fewer panes in 4-up (GPU), per-pane playlist opacity, top-right pill vs ⋯ collision polish.

## Test
1. **1-up** unchanged (layers, play/step/speed, interp, tools, theme, fullscreen).
2. ⋯ → Näkymä → **2**: pan/zoom/play synced; rotate → orientation flip; on a busy view, panes stay on the same timestamp.
3. Tap a pane's pill to toggle its layers; long-press to pick a sublayer (e.g. left=Suomi radar, right=satellite) — only that pane changes.
4. Näkymä → **2×2**; back to **1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)